### PR TITLE
Add a schema_version field for tracking which version of OSV Schema a vulnerability was produced against

### DIFF
--- a/docs/schema.md
+++ b/docs/schema.md
@@ -56,6 +56,7 @@ A JSON Schema for validation is also available
 
 ```json
 {
+	"schema_version": string,
 	"id": string,
 	"modified": string,
 	"published": string,
@@ -102,6 +103,22 @@ absolutely must be shared between databases, leaving customizations to the
 "ecosystem_specific" and "database_specific" blocks (see below)
 
 # Field Details
+
+## schema_version field
+
+```json
+{
+	"schema_version": string
+}
+```
+
+The `schema_version` field is used to indicate which version of the OSV schema
+a particular vulnerability was exported with. This can help consumer
+applications decide how to import the data for their own systems and offer some
+protection against future breaking changes. The value should be a string using
+the [SchemaVer](https://snowplowanalytics.com/blog/2014/05/13/introducing-schemaver-for-semantic-versioning-of-schemas/)
+format of `<MODEL>-<REVISION>-<ADDITION>`. If no value is specified, it should
+be assumed to be `1-0-0`, matching version 1.0.0 of the OSV Schema.
 
 ## id, modified fields
 

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -113,12 +113,15 @@ absolutely must be shared between databases, leaving customizations to the
 ```
 
 The `schema_version` field is used to indicate which version of the OSV schema
-a particular vulnerability was exported with. This can help consumer
-applications decide how to import the data for their own systems and offer some
-protection against future breaking changes. The value should be a string
-matching the OSV Schema version, which follows the [SemVer 2.0.0](https://semver.org)
-format, with no leading "v" prefix. If no value is specified, it should
-be assumed to be `1.0.0`, matching version 1.0 of the OSV Schema.
+a particular vulnerability was exported with. This can help consumer applications
+decide how to import the data for their own systems and offer some protection
+against future breaking changes. The value should be a string matching the OSV
+Schema version, which follows the [SemVer 2.0.0](https://semver.org) format, with
+no leading "v" prefix. If no value is specified, it should be assumed to be `1.0.0`,
+matching version 1.0 of the OSV Schema. Clients can assume that new minor and patch
+versions of the schema only add new fields, without changing the meaning of old
+fields, so that a client that knows how to read version 1.2.0 can process data
+identifying as schema version 1.3.0 by ignoring any unexpected fields.
 
 ## id, modified fields
 

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -115,10 +115,10 @@ absolutely must be shared between databases, leaving customizations to the
 The `schema_version` field is used to indicate which version of the OSV schema
 a particular vulnerability was exported with. This can help consumer
 applications decide how to import the data for their own systems and offer some
-protection against future breaking changes. The value should be a string using
-the [SchemaVer](https://snowplowanalytics.com/blog/2014/05/13/introducing-schemaver-for-semantic-versioning-of-schemas/)
-format of `<MODEL>-<REVISION>-<ADDITION>`. If no value is specified, it should
-be assumed to be `1-0-0`, matching version 1.0.0 of the OSV Schema.
+protection against future breaking changes. The value should be a string
+matching the OSV Schema version, which follows the [SemVer 2.0.0](https://semver.org)
+format, with no leading "v" prefix. If no value is specified, it should
+be assumed to be `1.0.0`, matching version 1.0 of the OSV Schema.
 
 ## id, modified fields
 

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -8,7 +8,7 @@ aside:
 show_edit_on_github: true
 ---
 
-**Version 1.0 (September 8, 2021)**
+**Version 1.1.0 (December 15, 2021)**
 
 Original authors:
 - Oliver Chang (ochang@google.com)

--- a/validation/schema.json
+++ b/validation/schema.json
@@ -4,6 +4,9 @@
   "description": "A schema for describing a vulnerability in an open source package.",
   "type": "object",
   "properties": {
+    "schema_version": {
+      "type": "string"
+    },
     "id": {
       "type": "string"
     },


### PR DESCRIPTION
It will be helpful as this schema evolves to be able to distinguish between which version a particular vulnerability was exported against. This provides downstream consumers with the ability to decide how to import a vulnerability as well as provide some protection against any future breaking schema changes.

There is currently no standard or recommended best practice for versioning JSON schemas, so I made two decisions in this PR that perhaps require further discussion:

1. Naming the field `schema_version` versus `version` - Since we're dealing with affected product versions it seemed better to be explicit about the purpose of this field so as not to introduce any ambiguity or chance for misinterpretation.
2. Using SemVer format for indicating the schema version - It seems like the OSV Schema is following this format for versioning, but please correct me if I'm wrong. An alternative format named [SchemaVer](https://snowplowanalytics.com/blog/2014/05/13/introducing-schemaver-for-semantic-versioning-of-schemas/#schemaver) has been proposed, but it's not widely adopted and since this documentation already discusses SemVer at length for affected product versions it seemed like we should avoid introducing a competing format.
