### PR TITLE
add Hex to the ecosystems for our erlang advisories

### DIFF
--- a/docs/schema.md
+++ b/docs/schema.md
@@ -320,7 +320,7 @@ The defined ecosystems are:
 | `NuGet` | The NuGet package ecosystem. The `name` field is a NuGet package name. |
 | `Linux` | The Linux kernel. The only supported `name` is `Kernel`. |
 | `Debian` | The Debian package ecosystem; the `name` is the name of the package. |
-| `Hex` | The package manaer for the Erlang ecosystem; the `name` is a Hex package name. |
+| `Hex` | The package manager for the Erlang ecosystem; the `name` is a Hex package name. |
 | Your ecosystem here. | [Send us a PR](https://github.com/ossf/osv-schema/compare). |
 
 It is permitted for a database name (the DB prefix in the `id` field) and an

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -320,6 +320,7 @@ The defined ecosystems are:
 | `NuGet` | The NuGet package ecosystem. The `name` field is a NuGet package name. |
 | `Linux` | The Linux kernel. The only supported `name` is `Kernel`. |
 | `Debian` | The Debian package ecosystem; the `name` is the name of the package. |
+| `Hex` | The package manaer for the Erlang ecosystem; the `name` is a Hex package name. |
 | Your ecosystem here. | [Send us a PR](https://github.com/ossf/osv-schema/compare). |
 
 It is permitted for a database name (the DB prefix in the `id` field) and an


### PR DESCRIPTION
This adds [Hex](https://hex.pm/) to the documented list of defined ecosystems. The description is the wording taken directly from their website, but open to feedback if you'd like it to follow a specific pattern.

There are no validations on the ecosystems defined in the schema docs, so the validation JSON has not been updated.