### PR TITLE
Invalid OSV json example

### DIFF
--- a/docs/schema.md
+++ b/docs/schema.md
@@ -763,8 +763,8 @@ OSV uses this format already for its vulnerabilities. Here is the encoding of on
 ```json
 {
     "id": "OSV-2020-584",
-    "published": "TODO 2021-01-21T19:15:00Z",
-    "modified": "TODO 2021-03-10T23:20:53Z",
+    "published": "2020-07-01T00:00:18.401815Z",
+    "modified": "2021-03-09T04:49:05.965964Z",
     "summary": "Heap-buffer-overflow in collator_compare_fuzzer.cpp",
     "details": "OSS-Fuzz report: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=15499\nCrash type: Heap-buffer-overflow WRITE 3\nCrash state:\ncollator_compare_fuzzer.cpp\n",
     "references": [

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -762,6 +762,7 @@ OSV uses this format already for its vulnerabilities. Here is the encoding of on
 
 ```json
 {
+    "schema_version": "1.1.0",
     "id": "OSV-2020-584",
     "published": "2020-07-01T00:00:18.401815Z",
     "modified": "2021-03-09T04:49:05.965964Z",


### PR DESCRIPTION
In my understanding the OSV json is an invalid specification version 1.0.0 example, since it lakes a `versions` field and does not have a range of a SemVer 2.0 type:

> In short, each object in the `affected` array must contain either a non-empty
> `versions` list or at least one range in the `ranges` list of type `SEMVER`.

Dropping the `versions` requirement in #18 makes it valid although only for parsers that support the specification as of 1.1.0. Or have I missed something?