### PR TITLE
Add optional top-level severity field

### DIFF
--- a/docs/schema.md
+++ b/docs/schema.md
@@ -252,8 +252,8 @@ display sites to unnecessary vulnerabilities.)
 	"severity": [ {
 		"type": string,
 		"score": string
-	}
-} ]
+	} ]
+}
 ```
 
 The `severity` field is a JSON array that allows generating systems to describe

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -65,6 +65,10 @@ A JSON Schema for validation is also available
 	"related": [ string ],
 	"summary": string,
 	"details": string,
+	"cvss": {
+		"score": string,
+		"version": string
+	},
 	"affected": [ {
 		"package": {
 			"ecosystem": string,
@@ -240,6 +244,25 @@ as stripping raw HTML and links that do not start with http:// or https://.
 Databases are encouraged not to include those in the first place. (The goal is
 to balance flexibility of presentation with not exposing vulnerability database
 display sites to unnecessary vulnerabilities.)
+
+## cvss field
+
+```json
+{
+	"cvss": {
+		"score": string,
+		"version": string
+	}
+}
+```
+
+The `cvss` field represents the unique characteristics and severity of the
+vulnerability using the [Common Vulnerability Scoring System notation](https://www.first.org/cvss/).
+The field is specified as an object with a string property `score`, and an
+optional string property `version` denoting the version of CVSS that was used to
+calculate the score, which can be helpful for determining how the score was
+derived. The `cvss` field itself is optional, but if present it must contain
+at least a `score` property.
 
 ## affected fields
 

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -65,10 +65,10 @@ A JSON Schema for validation is also available
 	"related": [ string ],
 	"summary": string,
 	"details": string,
-	"cvss": {
-		"score": string,
-		"version": string
-	},
+	"severity": [ {
+		"type": string,
+		"score": string
+	} ],
 	"affected": [ {
 		"package": {
 			"ecosystem": string,
@@ -245,24 +245,38 @@ Databases are encouraged not to include those in the first place. (The goal is
 to balance flexibility of presentation with not exposing vulnerability database
 display sites to unnecessary vulnerabilities.)
 
-## cvss field
+## severity field
 
 ```json
 {
-	"cvss": {
-		"score": string,
-		"version": string
+	"severity": [ {
+		"type": string,
+		"score": string
 	}
-}
+} ]
 ```
 
-The `cvss` field represents the unique characteristics and severity of the
-vulnerability using the [Common Vulnerability Scoring System notation](https://www.first.org/cvss/).
-The field is specified as an object with a string property `score`, and an
-optional string property `version` denoting the version of CVSS that was used to
-calculate the score, which can be helpful for determining how the score was
-derived. The `cvss` field itself is optional, but if present it must contain
-at least a `score` property.
+The `severity` field is a JSON array that allows generating systems to
+describe the severity of a vulnerability using one or more scoring
+methods. Each `severity` item is a JSON object specifying a `type` and
+`score` property, described below.
+
+### severity[].type field
+
+The `severity[].type` property must be one of the types defined below,
+which describe how the `associated` score was derived. This allows
+processing systems to decide how to handle each severity.
+
+| Severity Type | Score Description |
+| --------- | ----------- |
+| `CVSS_V3` | A computed score representing the unique characteristics and severity of the vulnerability using a version of the [Common Vulnerability Scoring System notation](https://www.first.org/cvss/) that is >= 3.0 and < 4.0. |
+| `PLAIN_TEXT` | A human-derived and human-readable rating of the severity, based on interpretation of available vulnerability information. |
+| Your severity type here. | [Send us a PR](https://github.com/ossf/osv-schema/compare). |
+
+### severity[].score field
+
+The `severity[].score` property is a string ranking the severity based on the
+selected `severity[].type`, as described above.
 
 ## affected fields
 

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -256,27 +256,25 @@ display sites to unnecessary vulnerabilities.)
 } ]
 ```
 
-The `severity` field is a JSON array that allows generating systems to
-describe the severity of a vulnerability using one or more scoring
-methods. Each `severity` item is a JSON object specifying a `type` and
-`score` property, described below.
+The `severity` field is a JSON array that allows generating systems to describe
+the severity of a vulnerability using one or more quantitative scoring methods.
+Each `severity` item is a JSON object specifying a `type` and `score` property,
+described below.
 
 ### severity[].type field
 
-The `severity[].type` property must be one of the types defined below,
-which describe how the `associated` score was derived. This allows
-processing systems to decide how to handle each severity.
+The `severity[].type` property must be one of the types defined below, which
+describes the quantitative method used to calculate the associated `score`.
 
 | Severity Type | Score Description |
 | --------- | ----------- |
 | `CVSS_V3` | A computed score representing the unique characteristics and severity of the vulnerability using a version of the [Common Vulnerability Scoring System notation](https://www.first.org/cvss/) that is >= 3.0 and < 4.0. |
-| `PLAIN_TEXT` | A human-derived and human-readable rating of the severity, based on interpretation of available vulnerability information. |
-| Your severity type here. | [Send us a PR](https://github.com/ossf/osv-schema/compare). |
+| Your quantitative severity type here. | [Send us a PR](https://github.com/ossf/osv-schema/compare). |
 
 ### severity[].score field
 
-The `severity[].score` property is a string ranking the severity based on the
-selected `severity[].type`, as described above.
+The `severity[].score` property is a string representing the severity score based
+on the selected `severity[].type`, as described above.
 
 ## affected fields
 

--- a/validation/schema.json
+++ b/validation/schema.json
@@ -40,6 +40,20 @@
     "details": {
       "type": "string"
     },
+    "cvss": {
+      "type": "object",
+      "properties": {
+        "score": {
+          "type": "string"
+        },
+        "version": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "score"
+      ]
+    },
     "affected": {
       "type": "array",
       "items": {

--- a/validation/schema.json
+++ b/validation/schema.json
@@ -40,19 +40,28 @@
     "details": {
       "type": "string"
     },
-    "cvss": {
-      "type": "object",
-      "properties": {
-        "score": {
-          "type": "string"
+    "severity": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "CVSS_V3",
+              "PLAIN_TEXT",
+              "OTHER"
+            ]
+          },
+          "score": {
+            "type": "string"
+          }
         },
-        "version": {
-          "type": "string"
-        }
-      },
-      "required": [
-        "score"
-      ]
+        "required": [
+          "type",
+          "score"
+        ]
+      }
     },
     "affected": {
       "type": "array",

--- a/validation/schema.json
+++ b/validation/schema.json
@@ -48,9 +48,7 @@
           "type": {
             "type": "string",
             "enum": [
-              "CVSS_V3",
-              "PLAIN_TEXT",
-              "OTHER"
+              "CVSS_V3"
             ]
           },
           "score": {


### PR DESCRIPTION
This adds a top-level `severity` array field field to capture vulnerability severity rankings such as [CVSS](https://www.first.org/cvss/). Each severity is an object with a `type` enum and a `score`.

Initially supported types are `CVSS_V3` and `PLAIN_TEXT`, described in the schema documentation.