### PR TITLE
Add credits field

### DIFF
--- a/docs/schema.md
+++ b/docs/schema.md
@@ -628,9 +628,9 @@ The known reference `type` values are:
 }
 ```
 
-The `credits` field is a JSON array providing a way to give credit where credit
-is due related to the discovery, confirmation, patch, or other events in the life
-cycle of a vulnerability.
+The `credits` field is a JSON array providing a way to give credit for the
+discovery, confirmation, patch, or other events in the life cycle of a
+vulnerability.
 
 Each of the objects in the `credits` array must contain at minimum a `name` field
 specifying the name of the individual or entity being credited, using whatever
@@ -666,7 +666,6 @@ as necessary and appropriate.
 | `GITHUB` | A valid, plain-text GitHub username for the credited. |
 | `TWITTER` | A valid, plain-text Twitter username, with or without the leading `@` symbol, for the credited. |
 | `URL` | A fully-qualified plain-text URL |
-| `OTHER` | A plain-text value that is not represented by any other available type and is self-evident in its usage as a means of contacting the credited individual or entity. |
 | Your contact type here. | [Send us a PR](https://github.com/ossf/osv-schema/compare). |
 
 #### credits[].contact[].value field

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -90,10 +90,7 @@ A JSON Schema for validation is also available
 	} ],
 	"credits": [ {
 		"name": string,
-		"contact": [ {
-			"type": string,
-			"value": string
-		} ]
+		"contact": [ string ]
 	} ],
 	"database_specific": { see description }
 }
@@ -620,10 +617,7 @@ The known reference `type` values are:
 {
 	"credits": [ {
 		"name": string,
-		"contact": [ {
-			"type": string,
-			"value": string
-		} ],
+		"contact": [ string ],
 	} ]
 }
 ```
@@ -634,44 +628,36 @@ vulnerability.
 
 Each of the objects in the `credits` array must contain at minimum a `name` field
 specifying the name of the individual or entity being credited, using whatever
-notation they prefer.
-
-Each `credits` entry can optionally include a `contact` array. Each entry in the
-`contact` list is an object that indicates the `type` of contact info being
-described and a `value` based on the type. These are described in more detail below.
+notation they prefer. It can also optionally include a `contact` JSON array.
 
 ### credits[].name field
 
 `credits[].name` should specify the name, label, or other identifier of the
 individual or entity being credited, using whatever notation the creditor prefers.
-For instance, this could contain a real name like `Chris Bloom`, an Internet handle
-like `chrisbloom7`, an entity name like `GitHub`, or something else. This field is
-required for each `credits` entry.
+For instance, this could contain a real name like `Kovács János`, an Internet handle
+like `erikamustermann`, an entity name like `GitHub`, or something else. This field
+is required for each `credits` entry.
 
 ### credits[].contact[] field
 
-Each `credits[].contact[]` entry is a JSON object that defines the type of contact
-being described. Providing contact entries is optional, but when present each
-entry must provide both a `type` and `value` property.
+Each `credits[].contact[]` entry should be a valid, fully qualified, plain-text URL
+at which the credited can be reached. Providing contacts is optional.
 
-#### credits[].contact[].type field
+#### Examples
 
-The `credits[].contact[].type` property must be one of those defined below, which
-allows processing systems to interpret and display contact information dynamically
-as necessary and appropriate.
+Including a URL and an email address in `credits[].contact[]`:
 
-| Contact Type | Value Description |
-| --------- | ----------- |
-| `EMAIL` | A valid, fully qualified, plain-text email adddress at which the credited can be reached. |
-| `GITHUB` | A valid, plain-text GitHub username for the credited. |
-| `TWITTER` | A valid, plain-text Twitter username, with or without the leading `@` symbol, for the credited. |
-| `URL` | A fully-qualified plain-text URL |
-| Your contact type here. | [Send us a PR](https://github.com/ossf/osv-schema/compare). |
-
-#### credits[].contact[].value field
-
-The `credits[].contact[].value` property is a string. The format of the property
-is determined by the `type` as described above.
+```json
+{
+	"credits": [ {
+		"name": "Janina Kowalska",
+		"contact": [
+			"https://twitter.com/JaninaKowalska01",
+			"mailto:nina@kowalska-family.net"
+		],
+	} ]
+}
+```
 
 ## database_specific field
 

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -88,6 +88,13 @@ A JSON Schema for validation is also available
 		"type": string,
 		"url": string
 	} ],
+	"credits": [ {
+		"name": string,
+		"contact": [ {
+			"type": string,
+			"value": string
+		} ]
+	} ],
 	"database_specific": { see description }
 }
 ```
@@ -606,6 +613,66 @@ The known reference `type` values are:
   `GIT`-typed `affected[].ranges` entries (described above).
 - `PACKAGE`: A web page for the affected package itself.
 - `WEB`: A web page of some unspecified kind.
+
+## credits fields
+
+```json
+{
+	"credits": [ {
+		"name": string,
+		"contact": [ {
+			"type": string,
+			"value": string
+		} ],
+	} ]
+}
+```
+
+The `credits` field is a JSON array providing a way to give credit where credit
+is due related to the discovery, confirmation, patch, or other events in the life
+cycle of a vulnerability.
+
+Each of the objects in the `credits` array must contain at minimum a `name` field
+specifying the name of the individual or entity being credited, using whatever
+notation they prefer.
+
+Each `credits` entry can optionally include a `contact` array. Each entry in the
+`contact` list is an object that indicates the `type` of contact info being
+described and a `value` based on the type. These are described in more detail below.
+
+### credits[].name field
+
+`credits[].name` should specify the name, label, or other identifier of the
+individual or entity being credited, using whatever notation the creditor prefers.
+For instance, this could contain a real name like `Chris Bloom`, an Internet handle
+like `chrisbloom7`, an entity name like `GitHub`, or something else. This field is
+required for each `credits` entry.
+
+### credits[].contact[] field
+
+Each `credits[].contact[]` entry is a JSON object that defines the type of contact
+being described. Providing contact entries is optional, but when present each
+entry must provide both a `type` and `value` property.
+
+#### credits[].contact[].type field
+
+The `credits[].contact[].type` property must be one of those defined below, which
+allows processing systems to interpret and display contact information dynamically
+as necessary and appropriate.
+
+| Contact Type | Value Description |
+| --------- | ----------- |
+| `EMAIL` | A valid, fully qualified, plain-text email adddress at which the credited can be reached. |
+| `GITHUB` | A valid, plain-text GitHub username for the credited. |
+| `TWITTER` | A valid, plain-text Twitter username, with or without the leading `@` symbol, for the credited. |
+| `URL` | A fully-qualified plain-text URL |
+| `OTHER` | A plain-text value that is not represented by any other available type and is self-evident in its usage as a means of contacting the credited individual or entity. |
+| Your contact type here. | [Send us a PR](https://github.com/ossf/osv-schema/compare). |
+
+#### credits[].contact[].value field
+
+The `credits[].contact[].value` property is a string. The format of the property
+is determined by the `type` as described above.
 
 ## database_specific field
 

--- a/validation/schema.json
+++ b/validation/schema.json
@@ -229,26 +229,7 @@
           "contact": {
             "type": "array",
             "items": {
-              "type": "object",
-              "properties": {
-                "type": {
-                  "type": "string",
-                  "enum": [
-                    "EMAIL",
-                    "GITHUB",
-                    "OTHER",
-                    "TWITTER",
-                    "URL"
-                  ]
-                },
-                "value": {
-                  "type": "string"
-                }
-              },
-              "required": [
-                "type",
-                "value"
-              ]
+              "type": "string"
             }
           }
         },

--- a/validation/schema.json
+++ b/validation/schema.json
@@ -218,6 +218,45 @@
         ]
       }
     },
+    "credits": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "contact": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "EMAIL",
+                    "GITHUB",
+                    "OTHER",
+                    "TWITTER",
+                    "URL"
+                  ]
+                },
+                "value": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "value"
+              ]
+            }
+          }
+        },
+        "required": [
+          "name"
+        ]
+      }
+    },
     "database_specific": {
       "type": "object"
     }


### PR DESCRIPTION
This proposes a top-level credits field. We learned through internal research projects that credits are an important form of currency in the vulnerability community, and often a strong motivator for identifying or fixing vulnerabilities. It provides the benefit of name recognition as well as acts as a resume of sorts for vulnerability researchers. In order to proved proper credit, it's important that contributors are able to be represented with both a name as well as unique identifiers or ways to link back to other work they have done.

Because of this, we chose to implement credits as a list of objects rather than strings for a few reasons:

1. Contributors may not want their personal email addresses published, so we don't want to rely on simple lists of "First Last <email...>" values.
2. Different source databases may use different identifiers to represent contributing users
3. Contributors may wish to include multiple contact methods, or none
4. Processing systems may wish to process contact information dynamically

With those limitations in mind, we can define `credits` similar to how `references` are defined.