### PR TITLE
Add database_specific to `affected[].ranges[]`.

### DIFF
--- a/docs/schema.md
+++ b/docs/schema.md
@@ -491,7 +491,7 @@ additional information about the range from which the record was obtained. The
 meaning of the values within the object is entirely defined by the database and
 beyond the scope of this document.
 
-Databases should only use this field to enable lossless conversion from the OSV
+Databases should only use this field to store additional context that may be useful in converting from the OSV
 format back into the original database representation. Values in this field
 have no effect on the [evaluation algorithm](#evaluation).
 

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -82,7 +82,8 @@ A JSON Schema for validation is also available
 				"introduced": string,
 				"fixed": string,
 				"limit": string
-			} ]
+			} ],
+			"database_specific": { see description }
 		} ],
 		"versions": [ string ],
 		"ecosystem_specific": { see description },
@@ -482,6 +483,17 @@ describing a single range.  The range object defines the fields `type`,
 `events`, `repo`.  `introduced`, `fixed`, and additional type-specific fields as needed.
 
 This field is required if `affected[].ranges[].type` is `GIT`.
+
+### affected[].ranges[].database_specific field
+
+The `ranges` object's `database_specific` field is a JSON object holding
+additional information about the range from which the record was obtained. The
+meaning of the values within the object is entirely defined by the database and
+beyond the scope of this document.
+
+Databases should only use this field to enable lossless conversion from the OSV
+format back into the original database representation. Values in this field
+have no effect on the [evaluation algorithm](#evaluation).
 
 ### affected[].ecosystem_specific field
 

--- a/validation/schema.json
+++ b/validation/schema.json
@@ -146,6 +146,9 @@
                     ]
                   },
                   "minItems": 1
+                },
+                "database_specific": {
+                  "type": "object"
                 }
               },
               "allOf": [


### PR DESCRIPTION
This is intended only for metadata that enables databases to 
better convert OSV entries back into their original representation.

Part of #35.