### PR TITLE
feat: add LoopBack Advisory Database

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This is the repository for the Open Source Vulnerability schema, which is curren
 - [Rust Advisory Database](https://github.com/RustSec/advisory-db)
 - [Global Security Database](https://github.com/cloudsecurityalliance/gsd-database)
 - [OSS-Fuzz](https://github.com/google/oss-fuzz-vulns)
+- [LoopBack Advisory Database](https://github.com/loopbackio/security/tree/main/advisories)
 
 Together, these include vulnerabilities from:
 - npm

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -158,6 +158,7 @@ The defined database prefixes and their "home" databases are:
 | `RUSTSEC` | [The Rust crates vulnerability database](https://github.com/rustsec/advisory-db). Serving `<ID>` in the shared format at  `https://github.com/RustSec/advisory-db/blob/osv/crates/<ID>.json` |
 | `GSD` | The GSD database. Serving the shared format [here](https://github.com/cloudsecurityalliance/gsd-database). |
 | `GHSA` | The GitHub Security Advisory database. Serving the shared format [here](https://github.com/github/advisory-database). |
+| `LBSEC` | The LoopBack Advisory Database. Serving the shared format [here](https://github.com/loopbackio/security/tree/main/advisories). |
 | Your database here | [Send us a PR](https://github.com/ossf/osv-schema/compare). |
 
 In addition to those prefixes, other databases may serve information about


### PR DESCRIPTION
This PR adds reference to the LoopBack Advisory Database.

## Background

As part of the ongoing security-related enhancement works, LoopBack is currently setting up its own advisory database for Node.js modules under its purview.

We're working to republish existing advisories under machine-readable formats (which includes OSV) and with the `LBSEC-` prefix.

see: https://github.com/loopbackio/security/issues/14