### PR TITLE
Add schema_format to aid parsers

### DIFF
--- a/docs/schema.md
+++ b/docs/schema.md
@@ -56,6 +56,7 @@ A JSON Schema for validation is also available
 
 ```json
 {
+	"schema_format": string,
 	"schema_version": string,
 	"id": string,
 	"modified": string,
@@ -114,6 +115,18 @@ absolutely must be shared between databases, leaving customizations to the
 "ecosystem_specific" and "database_specific" blocks (see below)
 
 # Field Details
+
+## schema_format field
+
+```json
+{
+	"schema_format": string
+}
+```
+
+The `schema_format` field is used to indicate to parsers that the following json
+object is explicitly OSV formatted. This string should always contain "OSV" when
+following the OSV schema.
 
 ## schema_version field
 

--- a/validation/schema.json
+++ b/validation/schema.json
@@ -4,6 +4,12 @@
   "description": "A schema for describing a vulnerability in an open source package.",
   "type": "object",
   "properties": {
+    "schema_format": {
+      "type": "string",
+      "enum": [
+        "OSV"
+      ]
+    },
     "schema_version": {
       "type": "string"
     },


### PR DESCRIPTION
Adds a schema_format field so that parsers can positively identify if an object is trying to represent an OSV object.

I think having this somewhere in the data itself will be critical in conjunction with the schema_version field, but I don't really have any opinions on how best to format that. I went with what I felt was a simple implementation that follows the naming convention of the version field. @oliverchang what are your thoughts on how to incorporate that into the schema?