### PR TITLE
Debian DLAs and remove not affected

### DIFF
--- a/tools/debian/convert_debian.py
+++ b/tools/debian/convert_debian.py
@@ -55,6 +55,8 @@ WML_REPORT_DATE_PATTERN = re.compile(
 CAPTURE_DSA_WITH_NO_EXT = re.compile(r'dsa-\d+')
 CAPTURE_DLA_WITH_NO_EXT = re.compile(r'dla-\d+')
 
+NOT_AFFECTED_VERSION = '<not-affected>'
+
 
 class AffectedInfo:
   """Debian version info."""
@@ -175,9 +177,12 @@ def parse_security_tracker_file(advisories: Advisories,
 
         release_name = version_match.group(1)
         package_name = version_match.group(2)
-        advisories[current_advisory].affected.append(
-            AffectedInfo(codename_to_version[release_name], package_name,
-                         version_match.group(3)))
+        fixed_ver = version_match.group(3)
+        if fixed_ver != NOT_AFFECTED_VERSION:
+          advisories[current_advisory].affected.append(
+              AffectedInfo(codename_to_version[release_name], package_name,
+                           fixed_ver))
+
       else:
         if line.strip().startswith('NOTE:'):
           continue

--- a/tools/debian/convert_debian.py
+++ b/tools/debian/convert_debian.py
@@ -256,6 +256,9 @@ def parse_webwml_files(advisories: Advisories, webwml_repo: str, lts: bool):
 def write_output(output_dir: str, advisories: Advisories):
   """Writes the advisory dict into individual json files"""
   for dsa_id, advisory in advisories.items():
+    # Skip advisories that does not affect anything
+    if len(advisory.affected) == 0:
+      continue
 
     with open(
         os.path.join(output_dir, dsa_id + '.json'), 'w',


### PR DESCRIPTION
Support importing debian DLAs via the --lts flag, and also remove <not-affected> versions and advisories with empty affected fields.