### PR TITLE
Loosen schema requirement for versions array

### DIFF
--- a/validation/schema.json
+++ b/validation/schema.json
@@ -230,7 +230,8 @@
                       "type": {
                         "enum": [
                           "SEMVER",
-                          "ECOSYSTEM"
+                          "ECOSYSTEM",
+                          "GIT"
                         ]
                       }
                     }

--- a/validation/schema.json
+++ b/validation/schema.json
@@ -219,34 +219,7 @@
           "database_specific": {
             "type": "object"
           }
-        },
-        "allOf": [
-          {
-            "if": {
-              "properties": {
-                "ranges": {
-                  "contains": {
-                    "properties": {
-                      "type": {
-                        "enum": [
-                          "SEMVER",
-                          "ECOSYSTEM",
-                          "GIT"
-                        ]
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "then": {},
-            "else": {
-              "required": [
-                "versions"
-              ]
-            }
-          }
-        ]
+        }
       }
     },
     "references": {


### PR DESCRIPTION
Loosen schema requirement for versions array, since it should be valid OSV to have just git commit ranges.

Fixes #79

Signed-off-by: Rex P <106129829+another-rex@users.noreply.github.com>