### PR TITLE
[photon-os] Adds ecosystem and prefix for Photon

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ This is the repository for the Open Source Vulnerability schema, which is curren
 - [Haskell Security Advisories](https://github.com/haskell/security-advisories)
 - [Bitnami Vulnerability Database](https://github.com/bitnami/vulndb)
 - [OSV.dev maintained converters](https://github.com/google/osv.dev#current-data-sources)
+- [VMWare Photon OS](https://github.com/vmware/photon/wiki/Security-Advisories) (unofficial)
 
 Together, these include vulnerabilities from:
 -   AlmaLinux
@@ -31,6 +32,7 @@ Together, these include vulnerabilities from:
 -   NuGet
 -   OSS-Fuzz
 -   Packagist
+-   Photon OS
 -   Pub
 -   PyPI
 -   Rocky Linux

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -309,6 +309,17 @@ The defined database prefixes and their "home" databases are:
       </td>
     </tr>
     <tr>
+      <td><code>PHSA</code></td>
+      <td><a href="https://github.com/vmware/photon/wiki/Security-Advisories">VMWare Photon Security Advisory Database</a></td>
+      <td>
+        <ul>
+          <li>How to contribute: <a href="https://github.com/captn3m0/photon-os-advisories#contributing">https://github.com/captn3m0/photon-os-advisories#contributing</a></li>
+          <li>Source URL: <code>https://github.com/vmware/photon/wiki/&lt;ID&gt;</code></li>
+          <li>OSV Formatted URL: <code>https://github.com/captn3m0/photon-os-advisories/blob/main/advisories/&lt;ID&gt;.json</code> (unofficial)</li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
       <td>Your database here</td>
       <td colspan="2"><a href="https://github.com/ossf/osv-schema/compare">Send us a PR</a></td>
     </tr>
@@ -552,6 +563,7 @@ The defined ecosystems are:
 | `Rocky Linux` | The Rocky Linux package ecosystem; the `name` is the name of the source package. The ecosystem string might optionally have a `:<RELEASE>` suffix to scope the package to a particular Rocky Linux release. `<RELEASE>` is a numeric version.
 | `AlmaLinux` | AlmaLinux package ecosystem; the `name` is the name of the source package. The ecosystem string might optionally have a `:<RELEASE>` suffix to scope the package to a particular AlmaLinux release. `<RELEASE>` is a numeric version.
 | `Bitnami` | Bitnami package ecosystem; the `name` is the name of the affected component. |
+| `Photon OS` | The Photon OS package ecosystem; the `name` is the name of the RPM package. The ecosystem string must have a `:<RELEASE-NUMBER>` suffix to scope the package to a particular Photon OS release. Eg `Photon OS:3.0`. |
 | Your ecosystem here. | [Send us a PR](https://github.com/ossf/osv-schema/compare). |
 
 It is permitted for a database name (the DB prefix in the `id` field) and an


### PR DESCRIPTION
As discussed in #105 earlier. I'm also using the ecosystem field in existing advisories: https://github.com/captn3m0/photon-os-advisories/blob/main/advisories/PHSA-2016-0006.json

Advisories are already published in OSV format: https://github.com/captn3m0/photon-os-advisories/tree/main/advisories (And Automated).

I'll get those enriched over time, but this could be merged in the interim.

Signed-off-by: Nemo <commits@captnemo.in>