### PR TITLE
Add a credit types field

### DIFF
--- a/docs/schema.md
+++ b/docs/schema.md
@@ -756,7 +756,7 @@ at which the credited can be reached. Providing contacts is optional.
 
 ### credits[].type[] field
 
-The `credits[].type[]` field should specify the type or role of the individual or entity
+The optional `credits[].type[]` field should specify the type or role of the individual or entity
 being credited.  It must be one of the following defined credit types:
 
 - `FINDER`: identified the vulnerability.
@@ -785,7 +785,7 @@ Including a URL and an email address in `credits[].contact[]` and a credit type:
 			"https://twitter.com/JaninaKowalska01",
 			"mailto:nina@kowalska-family.net"
 		],
-    "type": "REMEDIATION DEVELOPER",
+		"type": "REMEDIATION DEVELOPER",
 	} ]
 }
 ```

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -100,7 +100,8 @@ A JSON Schema for validation is also available
 	} ],
 	"credits": [ {
 		"name": string,
-		"contact": [ string ]
+		"contact": [ string ],
+    "type": [ string ]
 	} ],
 	"database_specific": { see description }
 }
@@ -727,6 +728,7 @@ The known reference `type` values are:
 	"credits": [ {
 		"name": string,
 		"contact": [ string ],
+    "type": [ string ],
 	} ]
 }
 ```
@@ -752,9 +754,26 @@ is required for each `credits` entry.
 Each `credits[].contact[]` entry should be a valid, fully qualified, plain-text URL
 at which the credited can be reached. Providing contacts is optional.
 
+### credits[].type[] field
+
+The `credits[].type[]` field corresponds with credit types in the 
+[MITRE CVE specification](https://github.com/CVEProject/cve-schema/blob/master/schema/v5.0/CVE_JSON_5.0_schema.json#L997-L1006) 
+and must be one of the defined credit types:
+
+- "finder"
+- "reporter"
+- "analyst"
+- "coordinator"
+- "remediation developer"
+- "remediation reviewer"
+- "remediation verifier"
+- "tool"
+- "sponsor"
+- "other"
+
 #### Examples
 
-Including a URL and an email address in `credits[].contact[]`:
+Including a URL and an email address in `credits[].contact[]` and a credit type:
 
 ```json
 {
@@ -764,6 +783,7 @@ Including a URL and an email address in `credits[].contact[]`:
 			"https://twitter.com/JaninaKowalska01",
 			"mailto:nina@kowalska-family.net"
 		],
+    "type": "remediation developer",
 	} ]
 }
 ```

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -756,20 +756,22 @@ at which the credited can be reached. Providing contacts is optional.
 
 ### credits[].type[] field
 
-The `credits[].type[]` field corresponds with credit types in the 
-[MITRE CVE specification](https://github.com/CVEProject/cve-schema/blob/master/schema/v5.0/CVE_JSON_5.0_schema.json#L997-L1006) 
-and must be one of the defined credit types:
+The `credits[].type[]` field should specify type or role of the individual or entity
+being credited.  It must be one of the following defined credit types:
 
-- "finder"
-- "reporter"
-- "analyst"
-- "coordinator"
-- "remediation developer"
-- "remediation reviewer"
-- "remediation verifier"
-- "tool"
-- "sponsor"
-- "other"
+- `FINDER`
+- `REPORTER`
+- `ANALYST`
+- `COORDINATOR`
+- `REMEDIATION DEVELOPER`
+- `REMEDIATION REVIEWER`
+- `REMEDIATION VERIFIER`
+- `TOOL`
+- `SPONSOR`
+- `OTHER`
+
+These values and their definitions correspond directly to the credit types defined in the
+[MITRE CVE specification](https://github.com/CVEProject/cve-schema/blob/master/schema/v5.0/CVE_JSON_5.0_schema.json#L997-L1006).
 
 #### Examples
 
@@ -783,7 +785,7 @@ Including a URL and an email address in `credits[].contact[]` and a credit type:
 			"https://twitter.com/JaninaKowalska01",
 			"mailto:nina@kowalska-family.net"
 		],
-    "type": "remediation developer",
+    "type": "REMEDIATION DEVELOPER",
 	} ]
 }
 ```

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -759,7 +759,7 @@ at which the credited can be reached. Providing contacts is optional.
 The `credits[].type[]` field should specify type or role of the individual or entity
 being credited.  It must be one of the following defined credit types:
 
-- `FINDER`: identifies the vulnerability
+- `FINDER`: identifies the vulnerability.
 - `REPORTER`: notifies the vendor of the vulnerability to a CNA.
 - `ANALYST`: validates the vulnerability to ensure accuracy or severity.
 - `COORDINATOR`: facilitates the coordinated response process.
@@ -768,7 +768,7 @@ being credited.  It must be one of the following defined credit types:
 - `REMEDIATION VERIFIER`: tests and verifies the vulnerability or its remediation.
 - `TOOL`: names of tools used in vulnerability discovery or identification.
 - `SPONSOR`: supports the vulnerability identification or remediation activities.
-- `OTHER`
+- `OTHER`: any other type or role that does not fall under the categories described above.
 
 These values and their definitions correspond directly to the credit types defined in the
 [MITRE CVE specification](https://cveproject.github.io/cve-schema/schema/v5.0/docs/#collapseDescription_oneOf_i0_containers_cna_credits_items_type).

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -101,7 +101,7 @@ A JSON Schema for validation is also available
 	"credits": [ {
 		"name": string,
 		"contact": [ string ],
-    "type": [ string ]
+		"type": [ string ]
 	} ],
 	"database_specific": { see description }
 }
@@ -759,19 +759,19 @@ at which the credited can be reached. Providing contacts is optional.
 The `credits[].type[]` field should specify type or role of the individual or entity
 being credited.  It must be one of the following defined credit types:
 
-- `FINDER`
-- `REPORTER`
-- `ANALYST`
-- `COORDINATOR`
-- `REMEDIATION DEVELOPER`
-- `REMEDIATION REVIEWER`
-- `REMEDIATION VERIFIER`
-- `TOOL`
-- `SPONSOR`
+- `FINDER`: identifies the vulnerability
+- `REPORTER`: notifies the vendor of the vulnerability to a CNA.
+- `ANALYST`: validates the vulnerability to ensure accuracy or severity.
+- `COORDINATOR`: facilitates the coordinated response process.
+- `REMEDIATION DEVELOPER`: prepares a code change or other remediation plans.
+- `REMEDIATION REVIEWER`: reviews vulnerability remediation plans or code changes for effectiveness and completeness.
+- `REMEDIATION VERIFIER`: tests and verifies the vulnerability or its remediation.
+- `TOOL`: names of tools used in vulnerability discovery or identification.
+- `SPONSOR`: supports the vulnerability identification or remediation activities.
 - `OTHER`
 
 These values and their definitions correspond directly to the credit types defined in the
-[MITRE CVE specification](https://github.com/CVEProject/cve-schema/blob/master/schema/v5.0/CVE_JSON_5.0_schema.json#L997-L1006).
+[MITRE CVE specification](https://cveproject.github.io/cve-schema/schema/v5.0/docs/#collapseDescription_oneOf_i0_containers_cna_credits_items_type).
 
 #### Examples
 

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -756,18 +756,18 @@ at which the credited can be reached. Providing contacts is optional.
 
 ### credits[].type[] field
 
-The `credits[].type[]` field should specify type or role of the individual or entity
+The `credits[].type[]` field should specify the type or role of the individual or entity
 being credited.  It must be one of the following defined credit types:
 
-- `FINDER`: identifies the vulnerability.
-- `REPORTER`: notifies the vendor of the vulnerability to a CNA.
-- `ANALYST`: validates the vulnerability to ensure accuracy or severity.
-- `COORDINATOR`: facilitates the coordinated response process.
-- `REMEDIATION DEVELOPER`: prepares a code change or other remediation plans.
-- `REMEDIATION REVIEWER`: reviews vulnerability remediation plans or code changes for effectiveness and completeness.
-- `REMEDIATION VERIFIER`: tests and verifies the vulnerability or its remediation.
+- `FINDER`: identified the vulnerability.
+- `REPORTER`: notified the vendor of the vulnerability to a CNA.
+- `ANALYST`: validated the vulnerability to ensure accuracy or severity.
+- `COORDINATOR`: facilitated the coordinated response process.
+- `REMEDIATION_DEVELOPER`: prepared a code change or other remediation plans.
+- `REMEDIATION_REVIEWER`: reviewed vulnerability remediation plans or code changes for effectiveness and completeness.
+- `REMEDIATION_VERIFIER`: tested and verified the vulnerability or its remediation.
 - `TOOL`: names of tools used in vulnerability discovery or identification.
-- `SPONSOR`: supports the vulnerability identification or remediation activities.
+- `SPONSOR`: supported the vulnerability identification or remediation activities.
 - `OTHER`: any other type or role that does not fall under the categories described above.
 
 These values and their definitions correspond directly to the credit types defined in the

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -785,7 +785,7 @@ Including a URL and an email address in `credits[].contact[]` and a credit type:
 			"https://twitter.com/JaninaKowalska01",
 			"mailto:nina@kowalska-family.net"
 		],
-		"type": "REMEDIATION DEVELOPER",
+		"type": "REMEDIATION_DEVELOPER",
 	} ]
 }
 ```

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -728,7 +728,7 @@ The known reference `type` values are:
 	"credits": [ {
 		"name": string,
 		"contact": [ string ],
-    "type": [ string ],
+		"type": [ string ],
 	} ]
 }
 ```

--- a/validation/schema.json
+++ b/validation/schema.json
@@ -294,9 +294,9 @@
               "REPORTER",
               "ANALYST",
               "COORDINATOR",
-              "REMEDIATION DEVELOPER",
-              "REMEDIATION REVIEWER",
-              "REMEDIATION VERIFIER",
+              "REMEDIATION_DEVELOPER",
+              "REMEDIATION_REVIEWER",
+              "REMEDIATION_VERIFIER",
               "TOOL",
               "SPONSOR",
               "OTHER"

--- a/validation/schema.json
+++ b/validation/schema.json
@@ -286,6 +286,21 @@
             "items": {
               "type": "string"
             }
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "finder",
+              "reporter",
+              "analyst",
+              "coordinator",
+              "remediation developer",
+              "remediation reviewer",
+              "remediation verifier",
+              "tool",
+              "sponsor",
+              "other"
+          ]
           }
         },
         "required": [

--- a/validation/schema.json
+++ b/validation/schema.json
@@ -290,16 +290,16 @@
           "type": {
             "type": "string",
             "enum": [
-              "finder",
-              "reporter",
-              "analyst",
-              "coordinator",
-              "remediation developer",
-              "remediation reviewer",
-              "remediation verifier",
-              "tool",
-              "sponsor",
-              "other"
+              "FINDER",
+              "REPORTER",
+              "ANALYST",
+              "COORDINATOR",
+              "REMEDIATION DEVELOPER",
+              "REMEDIATION REVIEWER",
+              "REMEDIATION VERIFIER",
+              "TOOL",
+              "SPONSOR",
+              "OTHER"
           ]
           }
         },


### PR DESCRIPTION
As discussed in https://github.com/ossf/osv-schema/issues/85, we'd like to propose these changes to the OSV schema to add credit types/roles that correspond to those defined by the [MITRE CVE schema](https://github.com/CVEProject/cve-schema/blob/master/schema/v5.0/CVE_JSON_5.0_schema.json).

Would appreciate any feedback or proposed changes!