### PR TITLE
Add schema $id

### DIFF
--- a/validation/schema.json
+++ b/validation/schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://raw.githubusercontent.com/ossf/osv-schema/v1.4.1/validation/schema.json",
+  "$id": "https://raw.githubusercontent.com/ossf/osv-schema/main/validation/schema.json",
   "title": "Open Source Vulnerability",
   "description": "A schema for describing a vulnerability in an open source package.",
   "type": "object",

--- a/validation/schema.json
+++ b/validation/schema.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/ossf/osv-schema/v1.4.1/validation/schema.json",
   "title": "Open Source Vulnerability",
   "description": "A schema for describing a vulnerability in an open source package.",
   "type": "object",


### PR DESCRIPTION
Fixes #52 

Per https://github.com/ossf/osv-schema/pull/132#issuecomment-1489414045, the OSV schema must be fully backwards interoperable, meaning using main instead of a specific version tag is the sanest option.