### PR TITLE
Force schema_version to match the schema it came from

### DIFF
--- a/validation/schema.json
+++ b/validation/schema.json
@@ -5,7 +5,8 @@
   "type": "object",
   "properties": {
     "schema_version": {
-      "type": "string"
+      "type": "string",
+      "enum": ["1.4.1"]
     },
     "id": {
       "type": "string"


### PR DESCRIPTION
Set to v1.4.1 as that's the next slated version.

This is mostly for completeness' sake when it comes to validating instances of OSV with things like [jsonschema](https://github.com/python-jsonschema/jsonschema). When combined with #130, it clearly defines instances of the data as following their particular semver of the schema.