### PR TITLE
Add Haskell ecosystem vulnerability and advisory types

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This is the repository for the Open Source Vulnerability schema, which is curren
 - [LoopBack Advisory Database](https://github.com/loopbackio/security/tree/main/advisories)
 - [Rocky Linux](https://distro-tools.rocky.page/apollo/openapi/#osv)
 - [AlmaLinux](https://github.com/AlmaLinux/osv-database)
+- [Haskell Security Advisories](https://github.com/haskell/security-advisories)
 - [OSV.dev maintained converters](https://github.com/google/osv.dev#current-data-sources)
 
 Together, these include vulnerabilities from:
@@ -20,6 +21,7 @@ Together, these include vulnerabilities from:
 -   Debian GNU/Linux
 -   GitHub Actions
 -   Go
+-   Haskell
 -   Hex
 -   Linux kernel
 -   Maven

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Open Source Vulnerability Schema 
+# Open Source Vulnerability Schema
 
 This is the repository for the Open Source Vulnerability schema, which is currently exported by:
 - [GitHub Security Advisories](https://github.com/github/advisory-database)

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -1258,6 +1258,22 @@ Ruby does not use this format currently, but here is a potential translation of 
 }
 ```
 
+## Haskell Hackage vulnerability
+TODO
+
+```json
+{
+}
+```
+
+## Haskell GHC vulnerability
+TODO
+
+```json
+{
+}
+```
+
 # Change Log
 
 - 2021-03-29 added "withdrawn" field

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -221,6 +221,17 @@ The defined database prefixes and their "home" databases are:
       </td>
     </tr>
     <tr>
+      <td><code>HSEC</code></td>
+      <td><a href="https://github.com/haskell/security-advisories">Haskell Security Advisory Database</a></td>
+      <td>
+        <ul>
+          <li>How to contribute: <a href="https://github.com/haskell/security-advisories/blob/main/CONTRIBUTING.md">https://github.com/haskell/security-advisories/blob/main/CONTRIBUTING.md</a></li>
+          <li>Source URL: <code>TBD</code></li>
+          <li>OSV Formatted URL: <code>https://raw.githubusercontent.com/haskell/security-advisories/main/advisories/&lt;ID&gt;.json</code></li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
       <td><code>GSD</code></td>
       <td><a href="https://github.com/cloudsecurityalliance/gsd-database">Global Security Database</a></td>
       <td>
@@ -514,6 +525,8 @@ The defined ecosystems are:
 | `PyPI` | the Python PyPI ecosystem; the `name` field is a [normalized](https://www.python.org/dev/peps/pep-0503/#normalized-names) PyPI package name.  |
 | `RubyGems` | The RubyGems ecosystem; the `name` field is a gem name.  |
 | `crates.io` | The crates.io ecosystem for Rust; the `name` field is a crate name.  |
+| `Hackage` | The Haskell package ecosystem. The `name` field is a Haskell package name as published on Hackage.  |
+| `GHC` | The Haskell compiler ecosystem. The `name` field is the name of a component of the GHC compiler ecosystem (e.g., compiler, GHCI, RTS).  |
 | `Packagist` | The PHP package manager ecosystem; the `name` is a package name.  |
 | `Maven` | The Maven Java package ecosystem. The `name` field is a Maven package name.  |
 | `NuGet` | The NuGet package ecosystem. The `name` field is a NuGet package name.  |

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -1300,7 +1300,7 @@ TODO
   Context: https://github.com/ossf/osv-schema/issues/35.
 - 2023-02-21 Released version 1.4.0. Added per package `severity` and
   credit types.
-- 2023-04-26 Released version 1.5.0. Added new reference types. 
+- 2023-04-26 Released version 1.5.0. Added new reference types.
 
 ## Status - 2021-04-07
 


### PR DESCRIPTION
There is a Haskell Security Response Team which is now in the process of defining a repository for security advisories, similar to how Rust handles these. As part of this, we decided to also integrate with OSV while we set things up. This should close https://github.com/haskell/security-advisories/issues/4

There are a few more TODOs left in the PR, partially waiting for https://github.com/haskell/security-advisories/pull/33#pullrequestreview-1473728366, partially waiting for a first pass over the PR. I'll try to fill in as much as possible before this can get merged.