### PR TITLE
Add comment about `last_affected` usage in evaluation pseudocode

### DIFF
--- a/docs/schema.md
+++ b/docs/schema.md
@@ -760,6 +760,7 @@ func IncludedInRanges(v, ranges)
         else if evt.fixed is present && v >= evt.fixed
            vulnerable = false
         else if evt.last_affected is present && v > evt.last_affected
+           # can lead to false negatives because `last_affected` is less accurate than `fixed`, see documentation
            vulnerable = false
 
       if vulnerable


### PR DESCRIPTION
Resolves partially #150

I thought this might be useful, but on the other hand I am not completely sure if this is really needed and it might just increase confusion.
So no worries if you reject this PR.