### PR TITLE
Add SwiftURL ecosystem.

### DIFF
--- a/docs/schema.md
+++ b/docs/schema.md
@@ -577,7 +577,7 @@ The defined ecosystems are:
 | `Photon OS` | The Photon OS package ecosystem; the `name` is the name of the RPM package. The ecosystem string must have a `:<RELEASE-NUMBER>` suffix to scope the package to a particular Photon OS release. Eg `Photon OS:3.0`. |
 | `CRAN` | The biological R package ecosystem. The `name` is an R package name. |
 | `Bioconductor` | The R package ecosystem. The `name` is an R package name. |
-| `SwiftURL` | The Swift Package Manager ecosystem. The `name` is a Git URL to the source of the package. |
+| `SwiftURL` | The Swift Package Manager ecosystem. The `name` is a Git URL to the source of the package. Versions are Git tags that comform to [SemVer 2.0](https://docs.swift.org/package-manager/PackageDescription/PackageDescription.html#version). |
 | Your ecosystem here. | [Send us a PR](https://github.com/ossf/osv-schema/compare). |
 
 It is permitted for a database name (the DB prefix in the `id` field) and an

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -577,6 +577,7 @@ The defined ecosystems are:
 | `Photon OS` | The Photon OS package ecosystem; the `name` is the name of the RPM package. The ecosystem string must have a `:<RELEASE-NUMBER>` suffix to scope the package to a particular Photon OS release. Eg `Photon OS:3.0`. |
 | `CRAN` | The biological R package ecosystem. The `name` is an R package name. |
 | `Bioconductor` | The R package ecosystem. The `name` is an R package name. |
+| `SwiftURL` | The Swift Package Manager ecosystem. The `name` is a Git URL to the source of the package. |
 | Your ecosystem here. | [Send us a PR](https://github.com/ossf/osv-schema/compare). |
 
 It is permitted for a database name (the DB prefix in the `id` field) and an


### PR DESCRIPTION
Per

https://developer.apple.com/documentation/packagedescription/package/dependency
https://docs.swift.org/package-manager/PackageDescription/PackageDescription.html#package-dependency

Putting "URL" in the name to make this consistent with how it's actually defined using `Package.Dependency`. 

There are some changes coming as part of https://github.com/apple/swift-evolution/blob/main/proposals/0292-package-registry-service.md, and we'll likely need to define a new ecosystem for that once it's finalized, as it looks like the identifiers are moving to a `Scope.Name` format. 

Fixes #170.