### PR TITLE
Add 'PSF' OSV ID prefix for Python Software Foundation database

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ This is the repository for the Open Source Vulnerability schema, which is curren
 - [OSV.dev maintained converters](https://github.com/google/osv.dev#current-data-sources)
 - [VMWare Photon OS](https://github.com/vmware/photon/wiki/Security-Advisories) (unofficial)
 - [RConsortium Advisory Database](https://github.com/RConsortium/r-advisory-database)
+- [Python Software Foundation Database](https://github.com/psf/advisory-database)
 
 Together, these include vulnerabilities from:
 -   AlmaLinux
@@ -36,11 +37,12 @@ Together, these include vulnerabilities from:
 -   Photon OS
 -   Pub
 -   PyPI
+-   Python
 -   R (CRAN and Bioconductor)
 -   Rocky Linux
 -   RubyGems
 
-These vulnerabilites are aggregated by https://osv.dev.
+These vulnerabilities are aggregated by https://osv.dev.
 
 Reference tooling (e.g. converters) can be found in the [tools/](tools) directory
 

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -199,6 +199,17 @@ The defined database prefixes and their "home" databases are:
       </td>
     </tr>
     <tr>
+      <td><code>PSF</code></td>
+      <td><a href="https://github.com/psf/advisory-database">Python Software Foundation Vulnerability Database</a></td>
+      <td>
+        <ul>
+          <li>How to contribute: <a href="https://github.com/psf/advisory-database/issues">https://github.com/psf/advisory-database/issues</a></li>
+          <li>Source URL: <code>TBD</code></li>
+          <li>OSV Formatted URL: <code>TBD</code></li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
       <td><code>PYSEC</code></td>
       <td><a href="https://github.com/pypa/advisory-db">PyPI Vulnerability Database</a></td>
       <td>


### PR DESCRIPTION
Related to: https://github.com/psf/advisory-database/pull/9