### PR TITLE
Clarify why aliases should not be used in vulnerability bundles

### DIFF
--- a/docs/schema.md
+++ b/docs/schema.md
@@ -413,7 +413,10 @@ Aliases should be considered symmetric (if A is an alias of B, then B is an
 alias of A) and transitive (If A aliases B and B aliases C, then A aliases C).
 
 Aliases should **not** be used in records that bundle many different
-vulnerabilities in one patch of a distribution of a package.
+vulnerabilities in one patch of a distribution of a package. Listing multiple
+vulnerabilities as `aliases` would mean that they are all identical (due to the
+symmetry/transitivity of `aliases`), not that one release fixes multiple
+(distinct) vulnerabilities.
 
 ## related field
 


### PR DESCRIPTION
@Roo4L from AlmaLinux suggested we explain why aliases shouldn't be used for bundling.
I've added a sentence based on their suggestion.