### PR TITLE
Add support of CVSS v4.0

### DIFF
--- a/docs/schema.md
+++ b/docs/schema.md
@@ -498,6 +498,7 @@ describes the quantitative method used to calculate the associated `score`.
 | --------- | ----------- |
 | `CVSS_V2` | A CVSS vector string representing the unique characteristics and severity of the vulnerability using a version of the [Common Vulnerability Scoring System notation](https://www.first.org/cvss/v2/) that is == 2.0 (e.g.`"AV:L/AC:M/Au:N/C:N/I:P/A:C"`).|
 | `CVSS_V3` | A CVSS vector string representing the unique characteristics and severity of the vulnerability using a version of the [Common Vulnerability Scoring System notation](https://www.first.org/cvss/) that is >= 3.0 and < 4.0 (e.g.`"CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:C/C:H/I:N/A:N"`).|
+| `CVSS_V4` | A CVSS vector string representing the unique characterictics and severity of the vulnerability using a version on the [Common Vulnerability Scoring System notation](https://www.first.org/cvss/) that is >= 4.0 and < 5.0 (e.g. `"CVSS:4.0/AV:N/AC:L/AT:N/PR:H/UI:N/VC:L/VI:L/VA:N/SC:N/SI:N/SA:N"`). |
 | Your quantitative severity type here. | [Send us a PR](https://github.com/ossf/osv-schema/compare). |
 
 ### severity[].score field

--- a/validation/schema.json
+++ b/validation/schema.json
@@ -289,7 +289,8 @@
             "type": "string",
             "enum": [
               "CVSS_V2",
-              "CVSS_V3"
+              "CVSS_V3",
+              "CVSS_V4"
             ]
           },
           "score": {


### PR DESCRIPTION
This PR comes to unlock #166 which seems stuck.

## What does it bring ?

Basic support of CVSS v4.0, I'll open another issue about #178 about validating the CVSS vectors soon, as the FIRST.ORG SIG CVSS provide official CVSS validation regex we could use for schema validation.

The string representation (aka vector) example comes from the CVSS v4.0 Specification Document Section 7.
