### PR TITLE
Fix truncated copy/paste in database_specific description

### DIFF
--- a/docs/schema.md
+++ b/docs/schema.md
@@ -781,7 +781,7 @@ This field is required if `affected[].ranges[].type` is `GIT`.
 ### affected[].ranges[].database_specific field
 
 The `ranges` object's `database_specific` field is a JSON object holding
-additional information about the range from which the record was obtained. The
+additional information about the range as defined by the database from which the record was obtained. The
 meaning of the values within the object is entirely defined by the database and
 beyond the scope of this document.
 


### PR DESCRIPTION
Adds back the `as defined by the database` in the description of the `range` object's `database_specific` field. This brings it into line with the descriptions of the other two `database_specific` fields. I suspect it was just a bad copy/paste operation as we were adding those fields to other objects beyond the top level. 