### PR TITLE
Add symlink for `schema.json` to `docs`

### DIFF
--- a/docs/schema.json
+++ b/docs/schema.json
@@ -1,0 +1,1 @@
+../validation/schema.json


### PR DESCRIPTION
This allows the JSON schema to be published alongside the rest of the documentation to GitHub pages. The schema will be available at https://ossf.github.io/osv-schema/schema.json.

Also created a symlink to the previous repository location of `validation/schema.json` in case anyone is already using that in a `$schema` property

Closes #226