### PR TITLE
Mention a more performant JSON validator

### DIFF
--- a/validation/README.md
+++ b/validation/README.md
@@ -5,6 +5,10 @@ This directory contains a JSON schema to validate OSV entries.
 ## Usage
 
 ```
+$ go run github.com/neilpa/yajsv@latest -s schema.json osv_to_test.json
+```
+
+```
 $ pip install check-jsonschema
 $ check-jsonschema --schemafile schema.json osv_to_test.json
 ```

--- a/validation/README.md
+++ b/validation/README.md
@@ -2,7 +2,9 @@
 
 This directory contains a JSON schema to validate OSV entries.
 
-## Usage
+## Example Usage
+
+(Any [validator](https://json-schema.org/implementations#validators) can be used, these are a couple that are known to work)
 
 ```
 $ go run github.com/neilpa/yajsv@latest -s schema.json osv_to_test.json


### PR DESCRIPTION
It does users a disservice to direct them to `check-jsonschema` in the first instance.

`check-jsonschema` is incredibly slow (probably because of Python interpreter startup time) when run in a loop on multiple files.