### PR TITLE
Add validation for CVSS

### DIFF
--- a/validation/schema.json
+++ b/validation/schema.json
@@ -294,7 +294,39 @@
             ]
           },
           "score": {
-            "type": "string"
+            "type": "string",
+            "oneOf": [
+              {
+                "if": {
+                  "properties": {
+                    "type": { "const": "CVSS_V2" }
+                  }
+                },
+                "then": {
+                  "pattern": "^((AV:[NAL]|AC:[LMH]|Au:[MSN]|[CIA]:[NPC]|E:(U|POC|F|H|ND)|RL:(OF|TF|W|U|ND)|RC:(UC|UR|C|ND)|CDP:(N|L|LM|MH|H|ND)|TD:(N|L|M|H|ND)|[CIA]R:(L|M|H|ND))\/)*(AV:[NAL]|AC:[LMH]|Au:[MSN]|[CIA]:[NPC]|E:(U|POC|F|H|ND)|RL:(OF|TF|W|U|ND)|RC:(UC|UR|C|ND)|CDP:(N|L|LM|MH|H|ND)|TD:(N|L|M|H|ND)|[CIA]R:(L|M|H|ND))$"
+                }
+              },
+              {
+                "if": {
+                  "properties": {
+                    "type": { "const": "CVSS_V3" }
+                  }
+                },
+                "then": {
+                  "pattern": "^CVSS:3[.][01]\/((AV:[NALP]|AC:[LH]|PR:[NLH]|UI:[NR]|S:[UC]|[CIA]:[NLH]|E:[XUPFH]|RL:[XOTWU]|RC:[XURC]|[CIA]R:[XLMH]|MAV:[XNALP]|MAC:[XLH]|MPR:[XNLH]|MUI:[XNR]|MS:[XUC]|M[CIA]:[XNLH])\/)*(AV:[NALP]|AC:[LH]|PR:[NLH]|UI:[NR]|S:[UC]|[CIA]:[NLH]|E:[XUPFH]|RL:[XOTWU]|RC:[XURC]|[CIA]R:[XLMH]|MAV:[XNALP]|MAC:[XLH]|MPR:[XNLH]|MUI:[XNR]|MS:[XUC]|M[CIA]:[XNLH])$"
+                }
+              },
+              {
+                "if": {
+                  "properties": {
+                    "type": { "const": "CVSS_V4" }
+                  }
+                },
+                "then": {
+                  "pattern": "^CVSS:4[.]0\/AV:[NALP]\/AC:[LH]\/AT:[NP]\/PR:[NLH]\/UI:[NPA]\/VC:[HLN]\/VI:[HLN]\/VA:[HLN]\/SC:[HLN]\/SI:[HLN]\/SA:[HLN](\/E:[XAPU])?(\/CR:[XHML])?(\/IR:[XHML])?(\/AR:[XHML])?(\/MAV:[XNALP])?(\/MAC:[XLH])?(\/MAT:[XNP])?(\/MPR:[XNLH])?(\/MUI:[XNPA])?(\/MVC:[XNLH])?(\/MVI:[XNLH])?(\/MVA:[XNLH])?(\/MSC:[XNLH])?(\/MSI:[XNLHS])?(\/MSA:[XNLHS])?(\/S:[XNP])?(\/AU:[XNY])?(\/R:[XAUI])?(\/V:[XDC])?(\/RE:[XLMH])?(\/U:(X|Clear|Green|Amber|Red))?$"
+                }
+              }
+            ]
           }
         },
         "required": [

--- a/validation/schema.json
+++ b/validation/schema.json
@@ -294,41 +294,53 @@
             ]
           },
           "score": {
-            "type": "string",
-            "oneOf": [
-              {
-                "if": {
-                  "properties": {
-                    "type": { "const": "CVSS_V2" }
-                  }
-                },
-                "then": {
-                  "pattern": "^((AV:[NAL]|AC:[LMH]|Au:[MSN]|[CIA]:[NPC]|E:(U|POC|F|H|ND)|RL:(OF|TF|W|U|ND)|RC:(UC|UR|C|ND)|CDP:(N|L|LM|MH|H|ND)|TD:(N|L|M|H|ND)|[CIA]R:(L|M|H|ND))\/)*(AV:[NAL]|AC:[LMH]|Au:[MSN]|[CIA]:[NPC]|E:(U|POC|F|H|ND)|RL:(OF|TF|W|U|ND)|RC:(UC|UR|C|ND)|CDP:(N|L|LM|MH|H|ND)|TD:(N|L|M|H|ND)|[CIA]R:(L|M|H|ND))$"
-                }
-              },
-              {
-                "if": {
-                  "properties": {
-                    "type": { "const": "CVSS_V3" }
-                  }
-                },
-                "then": {
-                  "pattern": "^CVSS:3[.][01]\/((AV:[NALP]|AC:[LH]|PR:[NLH]|UI:[NR]|S:[UC]|[CIA]:[NLH]|E:[XUPFH]|RL:[XOTWU]|RC:[XURC]|[CIA]R:[XLMH]|MAV:[XNALP]|MAC:[XLH]|MPR:[XNLH]|MUI:[XNR]|MS:[XUC]|M[CIA]:[XNLH])\/)*(AV:[NALP]|AC:[LH]|PR:[NLH]|UI:[NR]|S:[UC]|[CIA]:[NLH]|E:[XUPFH]|RL:[XOTWU]|RC:[XURC]|[CIA]R:[XLMH]|MAV:[XNALP]|MAC:[XLH]|MPR:[XNLH]|MUI:[XNR]|MS:[XUC]|M[CIA]:[XNLH])$"
-                }
-              },
-              {
-                "if": {
-                  "properties": {
-                    "type": { "const": "CVSS_V4" }
-                  }
-                },
-                "then": {
-                  "pattern": "^CVSS:4[.]0\/AV:[NALP]\/AC:[LH]\/AT:[NP]\/PR:[NLH]\/UI:[NPA]\/VC:[HLN]\/VI:[HLN]\/VA:[HLN]\/SC:[HLN]\/SI:[HLN]\/SA:[HLN](\/E:[XAPU])?(\/CR:[XHML])?(\/IR:[XHML])?(\/AR:[XHML])?(\/MAV:[XNALP])?(\/MAC:[XLH])?(\/MAT:[XNP])?(\/MPR:[XNLH])?(\/MUI:[XNPA])?(\/MVC:[XNLH])?(\/MVI:[XNLH])?(\/MVA:[XNLH])?(\/MSC:[XNLH])?(\/MSI:[XNLHS])?(\/MSA:[XNLHS])?(\/S:[XNP])?(\/AU:[XNY])?(\/R:[XAUI])?(\/V:[XDC])?(\/RE:[XLMH])?(\/U:(X|Clear|Green|Amber|Red))?$"
-                }
-              }
-            ]
+            "type": "string"
           }
         },
+        "allOf": [
+            {
+              "if": {
+                "properties": {
+                  "type": { "const": "CVSS_V2" }
+                }
+              },
+              "then": {
+                "properties": {
+                  "score": {
+                    "pattern": "^((AV:[NAL]|AC:[LMH]|Au:[MSN]|[CIA]:[NPC]|E:(U|POC|F|H|ND)|RL:(OF|TF|W|U|ND)|RC:(UC|UR|C|ND)|CDP:(N|L|LM|MH|H|ND)|TD:(N|L|M|H|ND)|[CIA]R:(L|M|H|ND))\/)*(AV:[NAL]|AC:[LMH]|Au:[MSN]|[CIA]:[NPC]|E:(U|POC|F|H|ND)|RL:(OF|TF|W|U|ND)|RC:(UC|UR|C|ND)|CDP:(N|L|LM|MH|H|ND)|TD:(N|L|M|H|ND)|[CIA]R:(L|M|H|ND))$"
+                  }
+                }
+              }
+            },
+            {
+              "if": {
+                "properties": {
+                  "type": { "const": "CVSS_V3" }
+                }
+              },
+              "then": {
+                "properties": {
+                  "score": {
+                    "pattern": "^CVSS:3[.][01]\/((AV:[NALP]|AC:[LH]|PR:[NLH]|UI:[NR]|S:[UC]|[CIA]:[NLH]|E:[XUPFH]|RL:[XOTWU]|RC:[XURC]|[CIA]R:[XLMH]|MAV:[XNALP]|MAC:[XLH]|MPR:[XNLH]|MUI:[XNR]|MS:[XUC]|M[CIA]:[XNLH])\/)*(AV:[NALP]|AC:[LH]|PR:[NLH]|UI:[NR]|S:[UC]|[CIA]:[NLH]|E:[XUPFH]|RL:[XOTWU]|RC:[XURC]|[CIA]R:[XLMH]|MAV:[XNALP]|MAC:[XLH]|MPR:[XNLH]|MUI:[XNR]|MS:[XUC]|M[CIA]:[XNLH])$"
+                  }
+                }
+              }
+            },
+            {
+              "if": {
+                "properties": {
+                  "type": { "const": "CVSS_V4" }
+                }
+              },
+              "then": {
+                "properties": {
+                  "score": {
+                    "pattern": "^CVSS:4[.]0\/AV:[NALP]\/AC:[LH]\/AT:[NP]\/PR:[NLH]\/UI:[NPA]\/VC:[HLN]\/VI:[HLN]\/VA:[HLN]\/SC:[HLN]\/SI:[HLN]\/SA:[HLN](\/E:[XAPU])?(\/CR:[XHML])?(\/IR:[XHML])?(\/AR:[XHML])?(\/MAV:[XNALP])?(\/MAC:[XLH])?(\/MAT:[XNP])?(\/MPR:[XNLH])?(\/MUI:[XNPA])?(\/MVC:[XNLH])?(\/MVI:[XNLH])?(\/MVA:[XNLH])?(\/MSC:[XNLH])?(\/MSI:[XNLHS])?(\/MSA:[XNLHS])?(\/S:[XNP])?(\/AU:[XNY])?(\/R:[XAUI])?(\/V:[XDC])?(\/RE:[XLMH])?(\/U:(X|Clear|Green|Amber|Red))?$"
+                  }
+                }
+              }
+            }
+        ],
         "required": [
           "type",
           "score"


### PR DESCRIPTION
Addresses undetected invalidity surfaced in
https://github.com/github/advisory-database/blob/adf108ed87cfbe666a56cd9cab986afc3854150e/advisories/github-reviewed/2023/11/GHSA-jjfh-589g-3hjx/GHSA-jjfh-589g-3hjx.json and helps address https://github.com/google/osv.dev/issues/2369

h/t @gregsdennis for assistance with the validation syntax

This uses the regexes from the [official schema definitions for CVSS](https://www.first.org/cvss/data-representations), with some additional slash-escaping that regex101.com seemed to feel was necessary to make them valid.

```
$ git -C ~/gosst/osv/advisory-database/ checkout adf108ed87cfbe666a56cd9cab986afc3854150e
HEAD is now at adf108ed87c Publish GHSA-jjfh-589g-3hjx
$ ~/go/bin/jv ./validation/schema.json ~/gosst/osv/advisory-database/advisories/github-reviewed/2023/11/GHSA-jjfh-589g-3hjx/GHSA-jjfh-589g-3hjx.json 
schema ./validation/schema.json: ok

instance /usr/local/google/home/apollock/gosst/osv/advisory-database/advisories/github-reviewed/2023/11/GHSA-jjfh-589g-3hjx/GHSA-jjfh-589g-3hjx.json: failed
jsonschema validation failed with 'file:///usr/local/google/home/apollock/gosst/osv/osv-schema/validation/schema.json#'
- at '/severity/1': allOf failed
  - at '/severity/1/score': 'CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L' does not match pattern '^CVSS:4[.]0/AV:[NALP]/AC:[LH]/AT:[NP]/PR:[NLH]/UI:[NPA]/VC:[HLN]/VI:[HLN]/VA:[HLN]/SC:[HLN]/SI:[HLN]/SA:[HLN](/'
$ git -C ~/gosst/osv/advisory-database/ checkout main
Previous HEAD position was adf108ed87c Publish GHSA-jjfh-589g-3hjx
Switched to branch 'main'
Your branch is up to date with 'origin/main'.
$ ~/go/bin/jv ./validation/schema.json ~/gosst/osv/advisory-database/advisories/github-reviewed/2023/11/GHSA-jjfh-589g-3hjx/GHSA-jjfh-589g-3hjx.json 
schema ./validation/schema.json: ok

instance /usr/local/google/home/apollock/gosst/osv/advisory-database/advisories/github-reviewed/2023/11/GHSA-jjfh-589g-3hjx/GHSA-jjfh-589g-3hjx.json: ok
```