### PR TITLE
Update Android IDs and links in schema table.

### DIFF
--- a/docs/schema.md
+++ b/docs/schema.md
@@ -157,12 +157,12 @@ The defined database prefixes and their "home" databases are:
   </thead>
   <tbody>
     <tr>
-      <td><code>A</code></td>
-      <td><a href="https://storage.googleapis.com/android-osv/">Android Vulnerability Database</a></td>
+      <td><code>`ASB-A`/`PUB-A`</code></td>
+      <td><a href="https://source.android.com/docs/security/bulletin">Android Security Bulletin</a></td>
       <td>
         <ul>
-          <li>How to contribute: TBD</li>
-          <li>Source URL: <code>N/A</code></li>
+          <li>How to contribute: <a href="https://bughunters.google.com/about/rules/android-friends/6171833274204160/android-and-google-devices-security-reward-program-rules">Android Vulnerability Rewards Program</a></li>
+          <li>Source URL: <a href="https://storage.googleapis.com/android-osv/index.html"><code>https://storage.googleapis.com/android-osv/&lt;ID&gt;.json</code></a></li>
           <li>OSV Formatted URL: <code>https://storage.googleapis.com/android-osv/&lt;ID&gt;.json</code></li>
         </ul>
       </td>

--- a/validation/schema.json
+++ b/validation/schema.json
@@ -306,7 +306,7 @@
       "type": "string",
       "title": "Currently supported home database identifier prefixes",
       "description": "These home databases are also documented at https://ossf.github.io/osv-schema/#id-modified-fields",
-      "pattern": "^(ASB|A|ALSA|ALBA|ALEA|BIT|CURL|CVE|DSA|DLA|DTSA|GHSA|GO|GSD|HSEC|LBSEC|MAL|OSV|PHSA|PSF|PYSEC|RLSA|RXSA|RSEC|RUSTSEC|USN)-"
+      "pattern": "^(ASB-A|PUB-A|ALSA|ALBA|ALEA|BIT|CURL|CVE|DSA|DLA|DTSA|GHSA|GO|GSD|HSEC|LBSEC|MAL|OSV|PHSA|PSF|PYSEC|RLSA|RXSA|RSEC|RUSTSEC|USN)-"
     },
     "severity": {
       "type": [


### PR DESCRIPTION
Per discussion offline, this updates Android vulnerability ID prefixes to corresponds with reality. This may need to be revisited in the future (e.g. `ASB-A` -> `A-ASB`) but that would be a separate effort.