### PR TITLE
Prepare for release again

### DIFF
--- a/docs/schema.md
+++ b/docs/schema.md
@@ -8,7 +8,7 @@ aside:
 show_edit_on_github: true
 ---
 
-**Version 1.6.5 (August 21, 2024)**
+**Version 1.6.4 (August 29, 2024)**
 
 Original authors:
 - Oliver Chang (ochang@google.com)


### PR DESCRIPTION
Fix incorrect version number (it was one patch version too high), and update the date.