### PR TITLE
fix(workflow): use v1.2.0 of json-schema-validate-action

### DIFF
--- a/.github/workflows/validate-schema.yml
+++ b/.github/workflows/validate-schema.yml
@@ -28,7 +28,7 @@ jobs:
             validation/schema.json
       - name: Validate OSV Schema
         if: steps.check-for-changed-osv-schema.outputs.any_changed == 'true'
-        uses: dsanders11/json-schema-validate-action@v1.1.2
+        uses: dsanders11/json-schema-validate-action@v1.2.0
         with:
           # https://github.com/marketplace/actions/json-schema-validate#validating-schema
           schema: json-schema


### PR DESCRIPTION
I'm not actually sure how I came to pin at a version less than the latest...

This should fix the problem seen in https://github.com/dsanders11/json-schema-validate-action/issues/20

Signed-off-by: Andrew Pollock <apollock@google.com>