### PR TITLE
feat(osv-linter): support checking stdin

### DIFF
--- a/tools/osv-linter/go.mod
+++ b/tools/osv-linter/go.mod
@@ -3,21 +3,23 @@ module github.com/ossf/osv-schema/linter
 go 1.22.6
 
 require (
+	github.com/aquasecurity/go-pep440-version v0.0.0-20210121094942-22b2f8951d46
 	github.com/google/go-cmp v0.6.0
 	github.com/package-url/packageurl-go v0.1.3
 	github.com/sethvargo/go-retry v0.2.4
 	github.com/tidwall/gjson v1.17.1
 	github.com/urfave/cli/v2 v2.27.2
+	golang.org/x/mod v0.20.0
+	golang.org/x/term v0.23.0
 )
 
 require (
-	github.com/aquasecurity/go-pep440-version v0.0.0-20210121094942-22b2f8951d46 // indirect
 	github.com/aquasecurity/go-version v0.0.0-20210121072130-637058cfe492 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.4 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/tidwall/match v1.1.1 // indirect
 	github.com/tidwall/pretty v1.2.0 // indirect
 	github.com/xrash/smetrics v0.0.0-20240312152122-5f08fbb34913 // indirect
-	golang.org/x/mod v0.20.0 // indirect
+	golang.org/x/sys v0.23.0 // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 )

--- a/tools/osv-linter/go.sum
+++ b/tools/osv-linter/go.sum
@@ -6,11 +6,13 @@ github.com/aquasecurity/go-version v0.0.0-20210121072130-637058cfe492/go.mod h1:
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.4 h1:wfIWP927BUkWJb2NmU/kNDYIBTh/ziUX91+lVfRxZq4=
 github.com/cpuguy83/go-md2man/v2 v2.0.4/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/package-url/packageurl-go v0.1.3 h1:4juMED3hHiz0set3Vq3KeQ75KD1avthoXLtmE3I0PLs=
 github.com/package-url/packageurl-go v0.1.3/go.mod h1:nKAWB8E6uk1MHqiS/lQb9pYBGH2+mdJ2PJc2s50dQY0=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
@@ -19,6 +21,7 @@ github.com/sethvargo/go-retry v0.2.4 h1:T+jHEQy/zKJf5s95UkguisicE0zuF9y7+/vgz08O
 github.com/sethvargo/go-retry v0.2.4/go.mod h1:1afjQuvh7s4gflMObvjLPaWgluLLyhA1wmVZ6KLpICw=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/tidwall/gjson v1.17.1 h1:wlYEnwqAHgzmhNUFfw7Xalt2JzQvsMx2Se4PcoFCT/U=
 github.com/tidwall/gjson v1.17.1/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
@@ -33,8 +36,14 @@ github.com/xrash/smetrics v0.0.0-20240312152122-5f08fbb34913 h1:+qGGcbkzsfDQNPPe
 github.com/xrash/smetrics v0.0.0-20240312152122-5f08fbb34913/go.mod h1:4aEEwZQutDLsQv2Deui4iYQ6DWTxR14g6m8Wv88+Xqk=
 golang.org/x/mod v0.20.0 h1:utOm6MM3R3dnawAiJgn0y+xvuYRsm1RKM/4giyfDgV0=
 golang.org/x/mod v0.20.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
+golang.org/x/sys v0.23.0 h1:YfKFowiIMvtgl1UERQoTPPToxltDeZfbj4H7dVUCwmM=
+golang.org/x/sys v0.23.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/term v0.23.0 h1:F6D4vR+EHoL9/sWAWgAR1H2DcHr4PareCbAaCo1RpuU=
+golang.org/x/term v0.23.0/go.mod h1:DgV24QBUrK6jhZXl+20l6UWznPlwAHm1Q1mGHtydmSk=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.3/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/tools/osv-linter/internal/linter.go
+++ b/tools/osv-linter/internal/linter.go
@@ -84,7 +84,11 @@ func LintCommand(cCtx *cli.Context) error {
 
 	// Run all the checks in a collection, if no specific checks requested.
 	if checksToBeRun == nil && cCtx.String("collection") != "" {
-		fmt.Printf("Running %q check collection on %q\n", cCtx.String("collection"), cCtx.Args())
+		if cCtx.Args().Present() {
+			fmt.Printf("Running %q check collection on %q\n", cCtx.String("collection"), cCtx.Args())
+		} else {
+			fmt.Printf("Running %q check collection on stdin\n", cCtx.String("collection"))
+		}
 		// Check the requested check collection exists.
 		collection := checks.CollectionFromName(cCtx.String("collection"))
 		if collection == nil {

--- a/tools/osv-linter/internal/linter.go
+++ b/tools/osv-linter/internal/linter.go
@@ -104,7 +104,7 @@ func LintCommand(cCtx *cli.Context) error {
 	for _, thingToCheck := range cCtx.Args().Slice() {
 		// Special case "-" for stdin.
 		if thingToCheck == "-" {
-			filesToCheck = append(filesToCheck, thingToCheck)
+			filesToCheck = append(filesToCheck, "<stdin>")
 			continue
 		}
 
@@ -143,17 +143,16 @@ func LintCommand(cCtx *cli.Context) error {
 
 	// Default to stdin if no files were specified.
 	if len(filesToCheck) == 0 {
-		filesToCheck = append(filesToCheck, "-")
+		filesToCheck = append(filesToCheck, "<stdin>")
 	}
 
 	// Run the check(s) on the files.
 	for _, fileToCheck := range filesToCheck {
 		var recordBytes []byte
 		var err error
-		// Special case "-" for stdin.
-		if fileToCheck == "-" {
+		// Special case for stdin.
+		if fileToCheck == "<stdin>" {
 			recordBytes, err = io.ReadAll(os.Stdin)
-			fileToCheck = "<stdin>"
 		} else {
 			recordBytes, err = os.ReadFile(fileToCheck)
 		}

--- a/tools/osv-linter/internal/linter.go
+++ b/tools/osv-linter/internal/linter.go
@@ -87,7 +87,7 @@ func LintCommand(cCtx *cli.Context) error {
 		if cCtx.Args().Present() {
 			fmt.Printf("Running %q check collection on %q\n", cCtx.String("collection"), cCtx.Args())
 		} else {
-			fmt.Printf("Running %q check collection on stdin\n", cCtx.String("collection"))
+			fmt.Printf("Running %q check collection on <stdin>\n", cCtx.String("collection"))
 		}
 		// Check the requested check collection exists.
 		collection := checks.CollectionFromName(cCtx.String("collection"))
@@ -153,6 +153,7 @@ func LintCommand(cCtx *cli.Context) error {
 		// Special case "-" for stdin.
 		if fileToCheck == "-" {
 			recordBytes, err = io.ReadAll(os.Stdin)
+			fileToCheck = "<stdin>"
 		} else {
 			recordBytes, err = os.ReadFile(fileToCheck)
 		}


### PR DESCRIPTION
Address UX expectation surfaced by @another-rex

When invoked with no filenames or with a hyphen, read from stdin.

```
$ cat test_data/CVE-2018-5407.json | go run ./cmd/osv record lint -
Running "ALL" check collection on &["-"]
Running "introduced-event-exists" check on "<stdin>"
Running "range-is-distinct" check on "<stdin>"
Running "package-exists" check on "<stdin>"
2024/09/04 02:14:15 "<stdin>": "package-exists": []checks.CheckError{checks.CheckError{Code:"P0001", Message:": package \"openssl\" not found in \"Alpine\""}}
Running "package-versions-exist" check on "<stdin>"
2024/09/04 02:14:15 "<stdin>": "package-versions-exist": []checks.CheckError{checks.CheckError{Code:"P0002", Message:": Failed to find some versions of openssl: &errors.errorString{s:\"unsupported ecosystem: Alpine\"}"}, checks.CheckError{Code:"P0002", Message:": Failed to find some versions of openssl: &errors.errorString{s:\"unsupported ecosystem: Alpine\"}"}, checks.CheckError{Code:"P0002", Message:": Failed to find some versions of openssl: &errors.errorString{s:\"unsupported ecosystem: Alpine\"}"}, checks.CheckError{Code:"P0002", Message:": Failed to find some versions of openssl: &errors.errorString{s:\"unsupported ecosystem: Alpine\"}"}, checks.CheckError{Code:"P0002", Message:": Failed to find some versions of openssl: &errors.errorString{s:\"unsupported ecosystem: Alpine\"}"}, checks.CheckError{Code:"P0002", Message:": Failed to find some versions of openssl: &errors.errorString{s:\"unsupported ecosystem: Alpine\"}"}}
Running "package-purl-valid" check on "<stdin>"
2024/09/04 02:14:15 found errors
exit status 1
```

```
$ cat test_data/CVE-2018-5407.json | go run ./cmd/osv record lint
Running "ALL" check collection on <stdin>
Running "introduced-event-exists" check on "<stdin>"
Running "range-is-distinct" check on "<stdin>"
Running "package-exists" check on "<stdin>"
2024/09/04 02:13:17 "<stdin>": "package-exists": []checks.CheckError{checks.CheckError{Code:"P0001", Message:": package \"openssl\" not found in \"Alpine\""}}
Running "package-versions-exist" check on "<stdin>"
2024/09/04 02:13:17 "<stdin>": "package-versions-exist": []checks.CheckError{checks.CheckError{Code:"P0002", Message:": Failed to find some versions of openssl: &errors.errorString{s:\"unsupported ecosystem: Alpine\"}"}, checks.CheckError{Code:"P0002", Message:": Failed to find some versions of openssl: &errors.errorString{s:\"unsupported ecosystem: Alpine\"}"}, checks.CheckError{Code:"P0002", Message:": Failed to find some versions of openssl: &errors.errorString{s:\"unsupported ecosystem: Alpine\"}"}, checks.CheckError{Code:"P0002", Message:": Failed to find some versions of openssl: &errors.errorString{s:\"unsupported ecosystem: Alpine\"}"}, checks.CheckError{Code:"P0002", Message:": Failed to find some versions of openssl: &errors.errorString{s:\"unsupported ecosystem: Alpine\"}"}, checks.CheckError{Code:"P0002", Message:": Failed to find some versions of openssl: &errors.errorString{s:\"unsupported ecosystem: Alpine\"}"}}
Running "package-purl-valid" check on "<stdin>"
2024/09/04 02:13:17 found errors
exit status 1
```