### PR TITLE
feat(suse): allow more SUSE- prefixes

### DIFF
--- a/docs/schema.md
+++ b/docs/schema.md
@@ -410,7 +410,7 @@ The defined database prefixes and their "home" databases are:
       </td>
     </tr>
     <tr>
-      <td><code>SUSE-SU</code> and <code>openSUSE-SU</code></td>
+      <td><code>SUSE-SU</code>, <code>SUSE-RU</code>, <code>SUSE-FU</code> and <code>openSUSE-SU</code></td>
       <td><a href="https://www.suse.com/support/security/">SUSE Security Landing page</a></td>
       <td>
         <ul>

--- a/validation/schema.json
+++ b/validation/schema.json
@@ -306,7 +306,7 @@
       "type": "string",
       "title": "Currently supported home database identifier prefixes",
       "description": "These home databases are also documented at https://ossf.github.io/osv-schema/#id-modified-fields",
-      "pattern": "^(ASB-A|PUB-A|ALSA|ALBA|ALEA|BIT|CURL|CVE|DSA|DLA|ELA|DTSA|GHSA|GO|GSD|HSEC|LBSEC|MAL|OSV|openSUSE-SU|PHSA|PSF|PYSEC|RHSA|RLSA|RXSA|RSEC|RUSTSEC|SUSE-SU|UBUNTU|USN)-"
+      "pattern": "^(ASB-A|PUB-A|ALSA|ALBA|ALEA|BIT|CURL|CVE|DSA|DLA|ELA|DTSA|GHSA|GO|GSD|HSEC|LBSEC|MAL|OSV|openSUSE-SU|PHSA|PSF|PYSEC|RHSA|RLSA|RXSA|RSEC|RUSTSEC|SUSE-[SRF]U|UBUNTU|USN)-"
     },
     "severity": {
       "type": [


### PR DESCRIPTION
Our recommended (SUSE-RU) and feature (SUSE-FU) updates occasionaly includes also security fixes. We will only generate OSV entries for the ones which CVEs.