### PR TITLE
add Red Hat converter

### DIFF
--- a/tools/redhat/.pylintrc
+++ b/tools/redhat/.pylintrc
@@ -1,0 +1,8 @@
+[MESSAGES CONTROL]
+disable=
+  broad-except,
+  fixme,
+  too-few-public-methods,
+  too-many-branches,
+  too-many-locals,
+  unspecified-encoding,

--- a/tools/redhat/.style.yapf
+++ b/tools/redhat/.style.yapf
@@ -1,0 +1,5 @@
+[style]
+based_on_style = pep8
+column_limit = 80
+indent_width = 4
+split_before_named_assigns = true

--- a/tools/redhat/Pipfile
+++ b/tools/redhat/Pipfile
@@ -1,0 +1,12 @@
+[[source]]
+url = "https://pypi.python.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+jsonschema = "*"
+requests = "*"
+
+[dev-packages]
+pylint = "*"
+yapf = "*"

--- a/tools/redhat/Pipfile.lock
+++ b/tools/redhat/Pipfile.lock
@@ -1,0 +1,377 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "da567803a04cab5177e6ba33ecc92bfc91c26ed20b0d6c83b80cde8156f42f33"
+        },
+        "pipfile-spec": 6,
+        "requires": {},
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.python.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "attrs": {
+            "hashes": [
+                "sha256:5cfb1b9148b5b086569baec03f20d7b6bf3bcacc9a42bebf87ffaaca362f6346",
+                "sha256:81921eb96de3191c8258c199618104dd27ac608d9366f5e35d011eae1867ede2"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==24.2.0"
+        },
+        "certifi": {
+            "hashes": [
+                "sha256:922820b53db7a7257ffbda3f597266d435245903d80737e34f8a45ff3e3230d8",
+                "sha256:bec941d2aa8195e248a60b31ff9f0558284cf01a52591ceda73ea9afffd69fd9"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==2024.8.30"
+        },
+        "charset-normalizer": {
+            "hashes": [
+                "sha256:06435b539f889b1f6f4ac1758871aae42dc3a8c0e24ac9e60c2384973ad73027",
+                "sha256:06a81e93cd441c56a9b65d8e1d043daeb97a3d0856d177d5c90ba85acb3db087",
+                "sha256:0a55554a2fa0d408816b3b5cedf0045f4b8e1a6065aec45849de2d6f3f8e9786",
+                "sha256:0b2b64d2bb6d3fb9112bafa732def486049e63de9618b5843bcdd081d8144cd8",
+                "sha256:10955842570876604d404661fbccbc9c7e684caf432c09c715ec38fbae45ae09",
+                "sha256:122c7fa62b130ed55f8f285bfd56d5f4b4a5b503609d181f9ad85e55c89f4185",
+                "sha256:1ceae2f17a9c33cb48e3263960dc5fc8005351ee19db217e9b1bb15d28c02574",
+                "sha256:1d3193f4a680c64b4b6a9115943538edb896edc190f0b222e73761716519268e",
+                "sha256:1f79682fbe303db92bc2b1136016a38a42e835d932bab5b3b1bfcfbf0640e519",
+                "sha256:2127566c664442652f024c837091890cb1942c30937add288223dc895793f898",
+                "sha256:22afcb9f253dac0696b5a4be4a1c0f8762f8239e21b99680099abd9b2b1b2269",
+                "sha256:25baf083bf6f6b341f4121c2f3c548875ee6f5339300e08be3f2b2ba1721cdd3",
+                "sha256:2e81c7b9c8979ce92ed306c249d46894776a909505d8f5a4ba55b14206e3222f",
+                "sha256:3287761bc4ee9e33561a7e058c72ac0938c4f57fe49a09eae428fd88aafe7bb6",
+                "sha256:34d1c8da1e78d2e001f363791c98a272bb734000fcef47a491c1e3b0505657a8",
+                "sha256:37e55c8e51c236f95b033f6fb391d7d7970ba5fe7ff453dad675e88cf303377a",
+                "sha256:3d47fa203a7bd9c5b6cee4736ee84ca03b8ef23193c0d1ca99b5089f72645c73",
+                "sha256:3e4d1f6587322d2788836a99c69062fbb091331ec940e02d12d179c1d53e25fc",
+                "sha256:42cb296636fcc8b0644486d15c12376cb9fa75443e00fb25de0b8602e64c1714",
+                "sha256:45485e01ff4d3630ec0d9617310448a8702f70e9c01906b0d0118bdf9d124cf2",
+                "sha256:4a78b2b446bd7c934f5dcedc588903fb2f5eec172f3d29e52a9096a43722adfc",
+                "sha256:4ab2fe47fae9e0f9dee8c04187ce5d09f48eabe611be8259444906793ab7cbce",
+                "sha256:4d0d1650369165a14e14e1e47b372cfcb31d6ab44e6e33cb2d4e57265290044d",
+                "sha256:549a3a73da901d5bc3ce8d24e0600d1fa85524c10287f6004fbab87672bf3e1e",
+                "sha256:55086ee1064215781fff39a1af09518bc9255b50d6333f2e4c74ca09fac6a8f6",
+                "sha256:572c3763a264ba47b3cf708a44ce965d98555f618ca42c926a9c1616d8f34269",
+                "sha256:573f6eac48f4769d667c4442081b1794f52919e7edada77495aaed9236d13a96",
+                "sha256:5b4c145409bef602a690e7cfad0a15a55c13320ff7a3ad7ca59c13bb8ba4d45d",
+                "sha256:6463effa3186ea09411d50efc7d85360b38d5f09b870c48e4600f63af490e56a",
+                "sha256:65f6f63034100ead094b8744b3b97965785388f308a64cf8d7c34f2f2e5be0c4",
+                "sha256:663946639d296df6a2bb2aa51b60a2454ca1cb29835324c640dafb5ff2131a77",
+                "sha256:6897af51655e3691ff853668779c7bad41579facacf5fd7253b0133308cf000d",
+                "sha256:68d1f8a9e9e37c1223b656399be5d6b448dea850bed7d0f87a8311f1ff3dabb0",
+                "sha256:6ac7ffc7ad6d040517be39eb591cac5ff87416c2537df6ba3cba3bae290c0fed",
+                "sha256:6b3251890fff30ee142c44144871185dbe13b11bab478a88887a639655be1068",
+                "sha256:6c4caeef8fa63d06bd437cd4bdcf3ffefe6738fb1b25951440d80dc7df8c03ac",
+                "sha256:6ef1d82a3af9d3eecdba2321dc1b3c238245d890843e040e41e470ffa64c3e25",
+                "sha256:753f10e867343b4511128c6ed8c82f7bec3bd026875576dfd88483c5c73b2fd8",
+                "sha256:7cd13a2e3ddeed6913a65e66e94b51d80a041145a026c27e6bb76c31a853c6ab",
+                "sha256:7ed9e526742851e8d5cc9e6cf41427dfc6068d4f5a3bb03659444b4cabf6bc26",
+                "sha256:7f04c839ed0b6b98b1a7501a002144b76c18fb1c1850c8b98d458ac269e26ed2",
+                "sha256:802fe99cca7457642125a8a88a084cef28ff0cf9407060f7b93dca5aa25480db",
+                "sha256:80402cd6ee291dcb72644d6eac93785fe2c8b9cb30893c1af5b8fdd753b9d40f",
+                "sha256:8465322196c8b4d7ab6d1e049e4c5cb460d0394da4a27d23cc242fbf0034b6b5",
+                "sha256:86216b5cee4b06df986d214f664305142d9c76df9b6512be2738aa72a2048f99",
+                "sha256:87d1351268731db79e0f8e745d92493ee2841c974128ef629dc518b937d9194c",
+                "sha256:8bdb58ff7ba23002a4c5808d608e4e6c687175724f54a5dade5fa8c67b604e4d",
+                "sha256:8c622a5fe39a48f78944a87d4fb8a53ee07344641b0562c540d840748571b811",
+                "sha256:8d756e44e94489e49571086ef83b2bb8ce311e730092d2c34ca8f7d925cb20aa",
+                "sha256:8f4a014bc36d3c57402e2977dada34f9c12300af536839dc38c0beab8878f38a",
+                "sha256:9063e24fdb1e498ab71cb7419e24622516c4a04476b17a2dab57e8baa30d6e03",
+                "sha256:90d558489962fd4918143277a773316e56c72da56ec7aa3dc3dbbe20fdfed15b",
+                "sha256:923c0c831b7cfcb071580d3f46c4baf50f174be571576556269530f4bbd79d04",
+                "sha256:95f2a5796329323b8f0512e09dbb7a1860c46a39da62ecb2324f116fa8fdc85c",
+                "sha256:96b02a3dc4381e5494fad39be677abcb5e6634bf7b4fa83a6dd3112607547001",
+                "sha256:9f96df6923e21816da7e0ad3fd47dd8f94b2a5ce594e00677c0013018b813458",
+                "sha256:a10af20b82360ab00827f916a6058451b723b4e65030c5a18577c8b2de5b3389",
+                "sha256:a50aebfa173e157099939b17f18600f72f84eed3049e743b68ad15bd69b6bf99",
+                "sha256:a981a536974bbc7a512cf44ed14938cf01030a99e9b3a06dd59578882f06f985",
+                "sha256:a9a8e9031d613fd2009c182b69c7b2c1ef8239a0efb1df3f7c8da66d5dd3d537",
+                "sha256:ae5f4161f18c61806f411a13b0310bea87f987c7d2ecdbdaad0e94eb2e404238",
+                "sha256:aed38f6e4fb3f5d6bf81bfa990a07806be9d83cf7bacef998ab1a9bd660a581f",
+                "sha256:b01b88d45a6fcb69667cd6d2f7a9aeb4bf53760d7fc536bf679ec94fe9f3ff3d",
+                "sha256:b261ccdec7821281dade748d088bb6e9b69e6d15b30652b74cbbac25e280b796",
+                "sha256:b2b0a0c0517616b6869869f8c581d4eb2dd83a4d79e0ebcb7d373ef9956aeb0a",
+                "sha256:b4a23f61ce87adf89be746c8a8974fe1c823c891d8f86eb218bb957c924bb143",
+                "sha256:bd8f7df7d12c2db9fab40bdd87a7c09b1530128315d047a086fa3ae3435cb3a8",
+                "sha256:beb58fe5cdb101e3a055192ac291b7a21e3b7ef4f67fa1d74e331a7f2124341c",
+                "sha256:c002b4ffc0be611f0d9da932eb0f704fe2602a9a949d1f738e4c34c75b0863d5",
+                "sha256:c083af607d2515612056a31f0a8d9e0fcb5876b7bfc0abad3ecd275bc4ebc2d5",
+                "sha256:c180f51afb394e165eafe4ac2936a14bee3eb10debc9d9e4db8958fe36afe711",
+                "sha256:c235ebd9baae02f1b77bcea61bce332cb4331dc3617d254df3323aa01ab47bd4",
+                "sha256:cd70574b12bb8a4d2aaa0094515df2463cb429d8536cfb6c7ce983246983e5a6",
+                "sha256:d0eccceffcb53201b5bfebb52600a5fb483a20b61da9dbc885f8b103cbe7598c",
+                "sha256:d965bba47ddeec8cd560687584e88cf699fd28f192ceb452d1d7ee807c5597b7",
+                "sha256:db364eca23f876da6f9e16c9da0df51aa4f104a972735574842618b8c6d999d4",
+                "sha256:ddbb2551d7e0102e7252db79ba445cdab71b26640817ab1e3e3648dad515003b",
+                "sha256:deb6be0ac38ece9ba87dea880e438f25ca3eddfac8b002a2ec3d9183a454e8ae",
+                "sha256:e06ed3eb3218bc64786f7db41917d4e686cc4856944f53d5bdf83a6884432e12",
+                "sha256:e27ad930a842b4c5eb8ac0016b0a54f5aebbe679340c26101df33424142c143c",
+                "sha256:e537484df0d8f426ce2afb2d0f8e1c3d0b114b83f8850e5f2fbea0e797bd82ae",
+                "sha256:eb00ed941194665c332bf8e078baf037d6c35d7c4f3102ea2d4f16ca94a26dc8",
+                "sha256:eb6904c354526e758fda7167b33005998fb68c46fbc10e013ca97f21ca5c8887",
+                "sha256:eb8821e09e916165e160797a6c17edda0679379a4be5c716c260e836e122f54b",
+                "sha256:efcb3f6676480691518c177e3b465bcddf57cea040302f9f4e6e191af91174d4",
+                "sha256:f27273b60488abe721a075bcca6d7f3964f9f6f067c8c4c605743023d7d3944f",
+                "sha256:f30c3cb33b24454a82faecaf01b19c18562b1e89558fb6c56de4d9118a032fd5",
+                "sha256:fb69256e180cb6c8a894fee62b3afebae785babc1ee98b81cdf68bbca1987f33",
+                "sha256:fd1abc0d89e30cc4e02e4064dc67fcc51bd941eb395c502aac3ec19fab46b519",
+                "sha256:ff8fa367d09b717b2a17a052544193ad76cd49979c805768879cb63d9ca50561"
+            ],
+            "markers": "python_full_version >= '3.7.0'",
+            "version": "==3.3.2"
+        },
+        "idna": {
+            "hashes": [
+                "sha256:050b4e5baadcd44d760cedbd2b8e639f2ff89bbc7a5730fcc662954303377aac",
+                "sha256:d838c2c0ed6fced7693d5e8ab8e734d5f8fda53a039c0164afb0b82e771e3603"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==3.8"
+        },
+        "jsonschema": {
+            "hashes": [
+                "sha256:d71497fef26351a33265337fa77ffeb82423f3ea21283cd9467bb03999266bc4",
+                "sha256:fbadb6f8b144a8f8cf9f0b89ba94501d143e50411a1278633f56a7acf7fd5566"
+            ],
+            "index": "pypi",
+            "version": "==4.23.0"
+        },
+        "jsonschema-specifications": {
+            "hashes": [
+                "sha256:48a76787b3e70f5ed53f1160d2b81f586e4ca6d1548c5de7085d1682674764cc",
+                "sha256:87e4fdf3a94858b8a2ba2778d9ba57d8a9cafca7c7489c46ba0d30a8bc6a9c3c"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==2023.12.1"
+        },
+        "referencing": {
+            "hashes": [
+                "sha256:25b42124a6c8b632a425174f24087783efb348a6f1e0008e63cd4466fedf703c",
+                "sha256:eda6d3234d62814d1c64e305c1331c9a3a6132da475ab6382eaa997b21ee75de"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==0.35.1"
+        },
+        "requests": {
+            "hashes": [
+                "sha256:55365417734eb18255590a9ff9eb97e9e1da868d4ccd6402399eaf68af20a760",
+                "sha256:70761cfe03c773ceb22aa2f671b4757976145175cdfca038c02654d061d6dcc6"
+            ],
+            "index": "pypi",
+            "version": "==2.32.3"
+        },
+        "rpds-py": {
+            "hashes": [
+                "sha256:06db23d43f26478303e954c34c75182356ca9aa7797d22c5345b16871ab9c45c",
+                "sha256:0e13e6952ef264c40587d510ad676a988df19adea20444c2b295e536457bc585",
+                "sha256:11ef6ce74616342888b69878d45e9f779b95d4bd48b382a229fe624a409b72c5",
+                "sha256:1259c7b3705ac0a0bd38197565a5d603218591d3f6cee6e614e380b6ba61c6f6",
+                "sha256:18d7585c463087bddcfa74c2ba267339f14f2515158ac4db30b1f9cbdb62c8ef",
+                "sha256:1e0f80b739e5a8f54837be5d5c924483996b603d5502bfff79bf33da06164ee2",
+                "sha256:1e5f3cd7397c8f86c8cc72d5a791071431c108edd79872cdd96e00abd8497d29",
+                "sha256:220002c1b846db9afd83371d08d239fdc865e8f8c5795bbaec20916a76db3318",
+                "sha256:22e6c9976e38f4d8c4a63bd8a8edac5307dffd3ee7e6026d97f3cc3a2dc02a0b",
+                "sha256:238a2d5b1cad28cdc6ed15faf93a998336eb041c4e440dd7f902528b8891b399",
+                "sha256:2580b0c34583b85efec8c5c5ec9edf2dfe817330cc882ee972ae650e7b5ef739",
+                "sha256:28527c685f237c05445efec62426d285e47a58fb05ba0090a4340b73ecda6dee",
+                "sha256:2cf126d33a91ee6eedc7f3197b53e87a2acdac63602c0f03a02dd69e4b138174",
+                "sha256:338ca4539aad4ce70a656e5187a3a31c5204f261aef9f6ab50e50bcdffaf050a",
+                "sha256:39ed0d010457a78f54090fafb5d108501b5aa5604cc22408fc1c0c77eac14344",
+                "sha256:3ad0fda1635f8439cde85c700f964b23ed5fc2d28016b32b9ee5fe30da5c84e2",
+                "sha256:3d2b1ad682a3dfda2a4e8ad8572f3100f95fad98cb99faf37ff0ddfe9cbf9d03",
+                "sha256:3d61339e9f84a3f0767b1995adfb171a0d00a1185192718a17af6e124728e0f5",
+                "sha256:3fde368e9140312b6e8b6c09fb9f8c8c2f00999d1823403ae90cc00480221b22",
+                "sha256:40ce74fc86ee4645d0a225498d091d8bc61f39b709ebef8204cb8b5a464d3c0e",
+                "sha256:49a8063ea4296b3a7e81a5dfb8f7b2d73f0b1c20c2af401fb0cdf22e14711a96",
+                "sha256:4a1f1d51eccb7e6c32ae89243cb352389228ea62f89cd80823ea7dd1b98e0b91",
+                "sha256:4b16aa0107ecb512b568244ef461f27697164d9a68d8b35090e9b0c1c8b27752",
+                "sha256:4f1ed4749a08379555cebf4650453f14452eaa9c43d0a95c49db50c18b7da075",
+                "sha256:4fe84294c7019456e56d93e8ababdad5a329cd25975be749c3f5f558abb48253",
+                "sha256:50eccbf054e62a7b2209b28dc7a22d6254860209d6753e6b78cfaeb0075d7bee",
+                "sha256:514b3293b64187172bc77c8fb0cdae26981618021053b30d8371c3a902d4d5ad",
+                "sha256:54b43a2b07db18314669092bb2de584524d1ef414588780261e31e85846c26a5",
+                "sha256:55fea87029cded5df854ca7e192ec7bdb7ecd1d9a3f63d5c4eb09148acf4a7ce",
+                "sha256:569b3ea770c2717b730b61998b6c54996adee3cef69fc28d444f3e7920313cf7",
+                "sha256:56e27147a5a4c2c21633ff8475d185734c0e4befd1c989b5b95a5d0db699b21b",
+                "sha256:57eb94a8c16ab08fef6404301c38318e2c5a32216bf5de453e2714c964c125c8",
+                "sha256:5a35df9f5548fd79cb2f52d27182108c3e6641a4feb0f39067911bf2adaa3e57",
+                "sha256:5a8c94dad2e45324fc74dce25e1645d4d14df9a4e54a30fa0ae8bad9a63928e3",
+                "sha256:5b4f105deeffa28bbcdff6c49b34e74903139afa690e35d2d9e3c2c2fba18cec",
+                "sha256:5c1dc0f53856b9cc9a0ccca0a7cc61d3d20a7088201c0937f3f4048c1718a209",
+                "sha256:614fdafe9f5f19c63ea02817fa4861c606a59a604a77c8cdef5aa01d28b97921",
+                "sha256:617c7357272c67696fd052811e352ac54ed1d9b49ab370261a80d3b6ce385045",
+                "sha256:65794e4048ee837494aea3c21a28ad5fc080994dfba5b036cf84de37f7ad5074",
+                "sha256:6632f2d04f15d1bd6fe0eedd3b86d9061b836ddca4c03d5cf5c7e9e6b7c14580",
+                "sha256:6c8ef2ebf76df43f5750b46851ed1cdf8f109d7787ca40035fe19fbdc1acc5a7",
+                "sha256:758406267907b3781beee0f0edfe4a179fbd97c0be2e9b1154d7f0a1279cf8e5",
+                "sha256:7e60cb630f674a31f0368ed32b2a6b4331b8350d67de53c0359992444b116dd3",
+                "sha256:89c19a494bf3ad08c1da49445cc5d13d8fefc265f48ee7e7556839acdacf69d0",
+                "sha256:8a86a9b96070674fc88b6f9f71a97d2c1d3e5165574615d1f9168ecba4cecb24",
+                "sha256:8bc7690f7caee50b04a79bf017a8d020c1f48c2a1077ffe172abec59870f1139",
+                "sha256:8d7919548df3f25374a1f5d01fbcd38dacab338ef5f33e044744b5c36729c8db",
+                "sha256:9426133526f69fcaba6e42146b4e12d6bc6c839b8b555097020e2b78ce908dcc",
+                "sha256:9824fb430c9cf9af743cf7aaf6707bf14323fb51ee74425c380f4c846ea70789",
+                "sha256:9bb4a0d90fdb03437c109a17eade42dfbf6190408f29b2744114d11586611d6f",
+                "sha256:9bc2d153989e3216b0559251b0c260cfd168ec78b1fac33dd485750a228db5a2",
+                "sha256:9d35cef91e59ebbeaa45214861874bc6f19eb35de96db73e467a8358d701a96c",
+                "sha256:a1862d2d7ce1674cffa6d186d53ca95c6e17ed2b06b3f4c476173565c862d232",
+                "sha256:a84ab91cbe7aab97f7446652d0ed37d35b68a465aeef8fc41932a9d7eee2c1a6",
+                "sha256:aa7f429242aae2947246587d2964fad750b79e8c233a2367f71b554e9447949c",
+                "sha256:aa9a0521aeca7d4941499a73ad7d4f8ffa3d1affc50b9ea11d992cd7eff18a29",
+                "sha256:ac2f4f7a98934c2ed6505aead07b979e6f999389f16b714448fb39bbaa86a489",
+                "sha256:ae94bd0b2f02c28e199e9bc51485d0c5601f58780636185660f86bf80c89af94",
+                "sha256:af0fc424a5842a11e28956e69395fbbeab2c97c42253169d87e90aac2886d751",
+                "sha256:b2a5db5397d82fa847e4c624b0c98fe59d2d9b7cf0ce6de09e4d2e80f8f5b3f2",
+                "sha256:b4c29cbbba378759ac5786730d1c3cb4ec6f8ababf5c42a9ce303dc4b3d08cda",
+                "sha256:b74b25f024b421d5859d156750ea9a65651793d51b76a2e9238c05c9d5f203a9",
+                "sha256:b7f19250ceef892adf27f0399b9e5afad019288e9be756d6919cb58892129f51",
+                "sha256:b80d4a7900cf6b66bb9cee5c352b2d708e29e5a37fe9bf784fa97fc11504bf6c",
+                "sha256:b8c00a3b1e70c1d3891f0db1b05292747f0dbcfb49c43f9244d04c70fbc40eb8",
+                "sha256:bb273176be34a746bdac0b0d7e4e2c467323d13640b736c4c477881a3220a989",
+                "sha256:c3c20f0ddeb6e29126d45f89206b8291352b8c5b44384e78a6499d68b52ae511",
+                "sha256:c3e130fd0ec56cb76eb49ef52faead8ff09d13f4527e9b0c400307ff72b408e1",
+                "sha256:c52d3f2f82b763a24ef52f5d24358553e8403ce05f893b5347098014f2d9eff2",
+                "sha256:c6377e647bbfd0a0b159fe557f2c6c602c159fc752fa316572f012fc0bf67150",
+                "sha256:c638144ce971df84650d3ed0096e2ae7af8e62ecbbb7b201c8935c370df00a2c",
+                "sha256:ce9845054c13696f7af7f2b353e6b4f676dab1b4b215d7fe5e05c6f8bb06f965",
+                "sha256:cf258ede5bc22a45c8e726b29835b9303c285ab46fc7c3a4cc770736b5304c9f",
+                "sha256:d0a26ffe9d4dd35e4dfdd1e71f46401cff0181c75ac174711ccff0459135fa58",
+                "sha256:d0b67d87bb45ed1cd020e8fbf2307d449b68abc45402fe1a4ac9e46c3c8b192b",
+                "sha256:d20277fd62e1b992a50c43f13fbe13277a31f8c9f70d59759c88f644d66c619f",
+                "sha256:d454b8749b4bd70dd0a79f428731ee263fa6995f83ccb8bada706e8d1d3ff89d",
+                "sha256:d4c7d1a051eeb39f5c9547e82ea27cbcc28338482242e3e0b7768033cb083821",
+                "sha256:d72278a30111e5b5525c1dd96120d9e958464316f55adb030433ea905866f4de",
+                "sha256:d72a210824facfdaf8768cf2d7ca25a042c30320b3020de2fa04640920d4e121",
+                "sha256:d807dc2051abe041b6649681dce568f8e10668e3c1c6543ebae58f2d7e617855",
+                "sha256:dbe982f38565bb50cb7fb061ebf762c2f254ca3d8c20d4006878766e84266272",
+                "sha256:dcedf0b42bcb4cfff4101d7771a10532415a6106062f005ab97d1d0ab5681c60",
+                "sha256:deb62214c42a261cb3eb04d474f7155279c1a8a8c30ac89b7dcb1721d92c3c02",
+                "sha256:def7400461c3a3f26e49078302e1c1b38f6752342c77e3cf72ce91ca69fb1bc1",
+                "sha256:df3de6b7726b52966edf29663e57306b23ef775faf0ac01a3e9f4012a24a4140",
+                "sha256:e1940dae14e715e2e02dfd5b0f64a52e8374a517a1e531ad9412319dc3ac7879",
+                "sha256:e4df1e3b3bec320790f699890d41c59d250f6beda159ea3c44c3f5bac1976940",
+                "sha256:e6900ecdd50ce0facf703f7a00df12374b74bbc8ad9fe0f6559947fb20f82364",
+                "sha256:ea438162a9fcbee3ecf36c23e6c68237479f89f962f82dae83dc15feeceb37e4",
+                "sha256:eb851b7df9dda52dc1415ebee12362047ce771fc36914586b2e9fcbd7d293b3e",
+                "sha256:ec31a99ca63bf3cd7f1a5ac9fe95c5e2d060d3c768a09bc1d16e235840861420",
+                "sha256:f0475242f447cc6cb8a9dd486d68b2ef7fbee84427124c232bff5f63b1fe11e5",
+                "sha256:f2fbf7db2012d4876fb0d66b5b9ba6591197b0f165db8d99371d976546472a24",
+                "sha256:f60012a73aa396be721558caa3a6fd49b3dd0033d1675c6d59c4502e870fcf0c",
+                "sha256:f8e604fe73ba048c06085beaf51147eaec7df856824bfe7b98657cf436623daf",
+                "sha256:f90a4cd061914a60bd51c68bcb4357086991bd0bb93d8aa66a6da7701370708f",
+                "sha256:f918a1a130a6dfe1d7fe0f105064141342e7dd1611f2e6a21cd2f5c8cb1cfb3e",
+                "sha256:fa518bcd7600c584bf42e6617ee8132869e877db2f76bcdc281ec6a4113a53ab",
+                "sha256:faefcc78f53a88f3076b7f8be0a8f8d35133a3ecf7f3770895c25f8813460f08",
+                "sha256:fcaeb7b57f1a1e071ebd748984359fef83ecb026325b9d4ca847c95bc7311c92",
+                "sha256:fd2d84f40633bc475ef2d5490b9c19543fbf18596dcb1b291e3a12ea5d722f7a",
+                "sha256:fdfc3a892927458d98f3d55428ae46b921d1f7543b89382fdb483f5640daaec8"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==0.20.0"
+        },
+        "urllib3": {
+            "hashes": [
+                "sha256:a448b2f64d686155468037e1ace9f2d2199776e17f0a46610480d311f73e3472",
+                "sha256:dd505485549a7a552833da5e6063639d0d177c04f23bc3864e41e5dc5f612168"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==2.2.2"
+        }
+    },
+    "develop": {
+        "astroid": {
+            "hashes": [
+                "sha256:0e14202810b30da1b735827f78f5157be2bbd4a7a59b7707ca0bfc2fb4c0063a",
+                "sha256:413658a61eeca6202a59231abb473f932038fbcbf1666587f66d482083413a25"
+            ],
+            "markers": "python_full_version >= '3.8.0'",
+            "version": "==3.2.4"
+        },
+        "dill": {
+            "hashes": [
+                "sha256:3ebe3c479ad625c4553aca177444d89b486b1d84982eeacded644afc0cf797ca",
+                "sha256:c36ca9ffb54365bdd2f8eb3eff7d2a21237f8452b57ace88b1ac615b7e815bd7"
+            ],
+            "markers": "python_version >= '3.11'",
+            "version": "==0.3.8"
+        },
+        "importlib-metadata": {
+            "hashes": [
+                "sha256:66f342cc6ac9818fc6ff340576acd24d65ba0b3efabb2b4ac08b598965a4a2f1",
+                "sha256:9a547d3bc3608b025f93d403fdd1aae741c24fbb8314df4b155675742ce303c5"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==8.4.0"
+        },
+        "isort": {
+            "hashes": [
+                "sha256:48fdfcb9face5d58a4f6dde2e72a1fb8dcaf8ab26f95ab49fab84c2ddefb0109",
+                "sha256:8ca5e72a8d85860d5a3fa69b8745237f2939afe12dbf656afbcb47fe72d947a6"
+            ],
+            "markers": "python_full_version >= '3.8.0'",
+            "version": "==5.13.2"
+        },
+        "mccabe": {
+            "hashes": [
+                "sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325",
+                "sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==0.7.0"
+        },
+        "platformdirs": {
+            "hashes": [
+                "sha256:9e5e27a08aa095dd127b9f2e764d74254f482fef22b0970773bfba79d091ab8c",
+                "sha256:eb1c8582560b34ed4ba105009a4badf7f6f85768b30126f351328507b2beb617"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==4.3.2"
+        },
+        "pylint": {
+            "hashes": [
+                "sha256:02f4aedeac91be69fb3b4bea997ce580a4ac68ce58b89eaefeaf06749df73f4b",
+                "sha256:1b7a721b575eaeaa7d39db076b6e7743c993ea44f57979127c517c6c572c803e"
+            ],
+            "index": "pypi",
+            "version": "==3.2.7"
+        },
+        "tomli": {
+            "hashes": [
+                "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc",
+                "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==2.0.1"
+        },
+        "tomlkit": {
+            "hashes": [
+                "sha256:7a974427f6e119197f670fbbbeae7bef749a6c14e793db934baefc1b5f03efde",
+                "sha256:fff5fe59a87295b278abd31bec92c15d9bc4a06885ab12bcea52c71119392e79"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==0.13.2"
+        },
+        "yapf": {
+            "hashes": [
+                "sha256:4dab8a5ed7134e26d57c1647c7483afb3f136878b579062b786c9ba16b94637b",
+                "sha256:adc8b5dd02c0143108878c499284205adb258aad6db6634e5b869e7ee2bd548b"
+            ],
+            "index": "pypi",
+            "version": "==0.40.2"
+        },
+        "zipp": {
+            "hashes": [
+                "sha256:9960cd8967c8f85a56f920d5d507274e74f9ff813a0ab8889a5b5be2daf44064",
+                "sha256:c22b14cc4763c5a5b04134207736c107db42e9d3ef2d9779d465f5f1bcba572b"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==3.20.1"
+        }
+    }
+}

--- a/tools/redhat/README.md
+++ b/tools/redhat/README.md
@@ -1,0 +1,23 @@
+# Red Hat CSAF to OSV Converter
+
+## Setup
+
+~~~
+$ pipenv sync
+$ pipenv shell
+~~~
+
+## Usage
+
+Needs to be run in a folder where the Red Hat CSAF documents to convert already exist. Files can be downloaded the [Red Hat Customer Portal Security Data section](https://access.redhat.com/security/data/csaf/v2/advisories/)
+~~~
+$ ./convert_redhat.py csaf/rhsa-2024_4546.json
+~~~
+
+OSV documents will be output in the `osv` directory by default. Override the default with the `--output_directory` option.
+
+## Tests
+
+~~~
+$ python3 -m unittest *_test.py
+~~~

--- a/tools/redhat/convert_redhat.py
+++ b/tools/redhat/convert_redhat.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+""" Convert a CSAF document to OSV format
+    i.e. https://access.redhat.com/security/data/csaf/v2/advisories/2024/rhsa-2024_4546.json
+"""
+import argparse
+import json
+import sys
+from datetime import datetime
+
+import requests
+from jsonschema import validate
+from csaf import CSAF
+from osv import DATE_FORMAT, OSV, OSVEncoder, SCHEMA_VERSION
+
+
+class RedHatConverter:
+    """
+    Class which converts and validates a CSAF string to an OSV string
+    """
+    SCHEMA = (
+        f"https://raw.githubusercontent.com/ossf/osv-schema/v{SCHEMA_VERSION}"
+        "/validation/schema.json")
+    REQUEST_TIMEOUT = 60
+
+    def __init__(self):
+        schema_content = requests.get(self.SCHEMA, timeout=self.REQUEST_TIMEOUT)
+        self.osv_schema = schema_content.json()
+
+    def convert(self,
+                csaf_content: str,
+                modified: str,
+                published: str = "") -> tuple[str, str]:
+        """
+        Converts csaf_content json string into an OSV json string
+        returns an OSV ID and the json string content of the OSV file
+        the json string content will be empty if no content is applicable
+        throws a validation error in the schema doesn't validate correctly.
+        The modified value for osv is passed in so it matches what's in all.json
+        Raises ValueError is CSAF file can't be parsed
+        """
+        csaf = CSAF(csaf_content)
+        osv = OSV(csaf, modified, published)
+
+        # We convert from an OSV object to a JSON string here in order to use the OSVEncoder
+        # Once we OSV json string data we validate it using the OSV schema
+        osv_content = json.dumps(osv, cls=OSVEncoder, indent=2)
+        osv_data = json.loads(osv_content)
+        validate(osv_data, schema=self.osv_schema)
+
+        return osv.id, osv_content
+
+
+def main():
+    """
+    Given a Red Hat CSAF document, covert it to OSV. Writes the OSV file to disk at 'osv' by default
+    """
+    parser = argparse.ArgumentParser(description='CSAF to OSV Converter')
+    parser.add_argument("csaf", metavar="FILE", help='CSAF file to process')
+    parser.add_argument('--output_directory', dest='out_dir', default="osv")
+
+    args = parser.parse_args()
+
+    with open(args.csaf, "r", encoding="utf-8") as in_f:
+        csaf_data = in_f.read()
+
+    converter = RedHatConverter()
+    osv_id, osv_data = converter.convert(csaf_data,
+                                         datetime.now().strftime(DATE_FORMAT))
+
+    if not osv_data:
+        sys.exit(1)
+
+    with open(f"{args.out_dir}/{osv_id}.json", "w", encoding="utf-8") as out_f:
+        out_f.write(osv_data)
+
+
+if __name__ == '__main__':
+    main()

--- a/tools/redhat/convert_redhat_test.py
+++ b/tools/redhat/convert_redhat_test.py
@@ -1,0 +1,34 @@
+"""Tests for converting a CSAF document to OSV format"""
+import unittest
+from datetime import datetime
+import json
+from convert_redhat import RedHatConverter
+from osv import DATE_FORMAT
+
+
+class TestRedHatConverter(unittest.TestCase):
+    """Test end-to-end convertion from RedHAt CSAF to OSV format"""
+
+    def test_convert_redhat(self):
+        """ Test a single demo CSAF file """
+        modified_time = datetime.strptime("2024-09-02T14:30:00",
+                                          "%Y-%m-%dT%H:%M:%S")
+        csaf_file = "testdata/rhsa-2024_4546.json"
+        expected_file = "testdata/RHSA-2024_4546.json"
+
+        with open(csaf_file, "r", encoding="utf-8") as fp:
+            csaf_data = fp.read()
+        converter = RedHatConverter()
+        osv_data = converter.convert(csaf_data,
+                                     modified_time.strftime(DATE_FORMAT))
+
+        assert osv_data[0] == "RHSA-2024:4546"
+        result_data = json.loads(osv_data[1])
+
+        with open(expected_file, "r", encoding="utf-8") as fp:
+            expected_data = json.load(fp)
+        assert expected_data == result_data
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tools/redhat/csaf.py
+++ b/tools/redhat/csaf.py
@@ -1,0 +1,179 @@
+"""Module for parsing CSAF v2 advisories"""
+import json
+from dataclasses import dataclass, InitVar, field
+from typing import Any, Iterable
+
+
+@dataclass
+class Remediation:
+    """
+    class to handle remediation advice in CSAF data
+    """
+
+    csaf_product_id: InitVar[str]
+    cpes: InitVar[dict[str, str]]
+    purls: InitVar[dict[str, str]]
+    product: str = field(init=False)
+    product_version: str = field(init=False)
+    component: str = field(init=False)
+    fixed_version: str = field(init=False)
+    purl: str = field(init=False)
+    cpe: str = field(init=False)
+
+    def __post_init__(self, csaf_product_id: str, cpes: dict[str, str],
+                      purls: dict[str, str]):
+        if ":" not in csaf_product_id:
+            raise ValueError(
+                f"Did not find ':' in product_id: {csaf_product_id}")
+        (self.product, self.product_version) = csaf_product_id.split(":",
+                                                                     maxsplit=1)
+
+        # NEVRA stands for Name Epoch Version Release and Architecture
+        # We split the name from the rest of the 'version' data (EVRA). We store name as component.
+        split_component_version = self.product_version.rsplit("-", maxsplit=2)
+        if len(split_component_version) < 3:
+            raise ValueError(
+                f"Could not convert component into NEVRA: {self.product_version}"
+            )
+        # RHEL Modules have 4 colons in the name part of the NEVRA. If we detect a modular RPM
+        # product ID, discard the module part of the name and look for that in the purl dict.
+        # Ideally we would keep the module information and use it when scanning a RHEL system,
+        # however this is not done today by Clair:  https://github.com/quay/claircore/pull/901/files
+        if split_component_version[0].count(":") == 4:
+            self.component = split_component_version[0].rsplit(":")[-1]
+        else:
+            self.component = split_component_version[0]
+        self.fixed_version = "-".join(
+            (split_component_version[1], split_component_version[2]))
+
+        try:
+            nevra = f"{self.component}-{self.fixed_version}"
+            self.purl = purls[nevra]
+            self.cpe = cpes[self.product]
+        except KeyError:
+            # pylint: disable=raise-missing-from
+            # Raising this as a ValueError instead of as a KeyError allows us to wrap
+            # the entire call to init() in try/catch block with a single exception type
+            raise ValueError(
+                f"Did not find {csaf_product_id} in product branches")
+
+        # There are many pkg:oci/ remediations in Red Hat data. However there are no strict
+        # rules enforced on versioning Red Hat containers, therefore we cant compare container
+        # versions to each other with 100% accuracy at this time.
+        if not self.purl.startswith("pkg:rpm/"):
+            raise ValueError(
+                "Non RPM remediations are not supported in OSV at this time")
+
+
+@dataclass
+class Vulnerability:
+    """
+    class to handle vulnerability information
+    """
+
+    csaf_vuln: InitVar[dict[str, Any]]
+    cpes: InitVar[dict[str, str]]
+    purls: InitVar[dict[str, str]]
+    cve_id: str = field(init=False)
+    cvss_v3_vector: str = field(init=False)
+    cvss_v3_base_score: str = field(init=False, default=None)
+    references: list[dict[str, str]] = field(init=False)
+    remediations: list[Remediation] = field(init=False)
+
+    def __post_init__(self, csaf_vuln: dict[str, Any], cpes: dict[str, str],
+                      purls: dict[str, str]):
+        self.cve_id = csaf_vuln["cve"]
+        for score in csaf_vuln.get("scores", []):
+            if "cvss_v3" in score:
+                self.cvss_v3_vector = score["cvss_v3"]["vectorString"]
+                self.cvss_v3_base_score = score["cvss_v3"]["baseScore"]
+            else:
+                self.cvss_v3_base_score = ""
+                self.cvss_v3_vector = ""
+        self.references = csaf_vuln["references"]
+        self.remediations = []
+        for product_id in csaf_vuln["product_status"]["fixed"]:
+            self.remediations.append(Remediation(product_id, cpes, purls))
+
+
+def gen_dict_extract(key, var: Iterable):
+    """
+    Given a key value and dictionary or list, traverses that dictionary or list returning the value
+    of the given key.
+    From https://stackoverflow.com/questions/9807634/
+        find-all-occurrences-of-a-key-in-nested-dictionaries-and-lists
+    """
+    if hasattr(var, "items"):
+        for k, v in var.items():
+            if k == key:
+                yield v
+            if isinstance(v, dict):
+                yield from gen_dict_extract(key, v)
+            elif isinstance(v, list):
+                for d in v:
+                    yield from gen_dict_extract(key, d)
+
+
+def build_product_maps(
+        product_tree_branches: dict) -> tuple[dict[str, str], dict[str, str]]:
+    """
+    Given a CSAF product tree branch dictionary returns a tuple of CPEs by product ID and PURLs by
+    product ID.
+    """
+    cpe_map = {}
+    purl_map = {}
+    products = gen_dict_extract("product", product_tree_branches)
+    for product in products:
+        product_id = product["product_id"]
+        if "product_identification_helper" in product:
+            helper = product["product_identification_helper"]
+            if "cpe" in helper:
+                cpe_map[product_id] = helper["cpe"]
+            elif "purl" in helper:
+                purl_map[product_id] = helper["purl"]
+    return cpe_map, purl_map
+
+
+class CSAF:
+    """
+    class to handle CSAF data read from a local file path
+    """
+
+    def __init__(self, csaf_content: str):
+        csaf_data = json.loads(csaf_content)
+
+        if not csaf_data:
+            raise ValueError("Unable to load CSAF JSON data.")
+
+        self.doc = csaf_data["document"]
+
+        self.csaf = {
+            "type": self.doc["category"],
+            "csaf_version": self.doc["csaf_version"]
+        }
+
+        # Only support csaf_vex 2.0
+        if self.csaf != {"type": "csaf_vex", "csaf_version": "2.0"}:
+            raise ValueError(
+                f"Can only handle csaf_vex 2.0 documents. Got: {self.csaf}")
+
+        self.cpes, self.purls = build_product_maps(csaf_data["product_tree"])
+
+        self.vulnerabilities = [
+            Vulnerability(v, self.cpes, self.purls)
+            for v in (csaf_data["vulnerabilities"])
+        ]
+
+    @property
+    def title(self):
+        """
+        Document Title
+        """
+        return self.doc["title"]
+
+    @property
+    def references(self):
+        """
+        Document References
+        """
+        return self.doc["references"]

--- a/tools/redhat/csaf_test.py
+++ b/tools/redhat/csaf_test.py
@@ -1,0 +1,25 @@
+"""Test parsing CSAF v2 advisories"""
+import unittest
+
+from csaf import Remediation
+
+
+class CSAFTest(unittest.TestCase):
+    """class to handle remediation advice in CSAF data"""
+
+    def test_parse_remediation(self):
+        """Test parsing a CSAF Remediation and unpacking cpe and purl data"""
+        cpe = "cpe:/a:redhat:rhel_tus:8.4::appstream"
+        purl = "pkg:rpm/redhat/buildah@1.19.9-1.module%2Bel8.4.0%2B21078%2Ba96cfbf6?arch=src"
+        cpes = {"AppStream-8.4.0.Z.TUS": cpe}
+        purls = {"buildah-0:1.19.9-1.module+el8.4.0+21078+a96cfbf6.src": purl}
+        result = Remediation(
+            "AppStream-8.4.0.Z.TUS:container-tools:3.0:8040020240104111259:c0c392d5"
+            ":buildah-0:1.19.9-1.module+el8.4.0+21078+a96cfbf6.src", cpes,
+            purls)
+        self.assertEqual(result.cpe, cpe)
+        self.assertEqual(result.purl, purl)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tools/redhat/osv.py
+++ b/tools/redhat/osv.py
@@ -1,0 +1,203 @@
+"""Module for parsing converting CSAF to OSV data"""
+import re
+from dataclasses import field, dataclass, InitVar
+from json import JSONEncoder
+from typing import Literal
+
+from csaf import Remediation, CSAF
+
+# Update this if verified against a later version
+SCHEMA_VERSION = "1.6.5"
+# This assumes the datetime being formatted is in UTC
+DATE_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
+# Go package advisory reference prefix
+PKG_GO_DEV_VULN = "https://pkg.go.dev/vuln/"
+REDHAT_ADVISORY_URL = "https://access.redhat.com/errata/"
+# Other common advisory prefixes in Red Hat Advisories
+ADVISORY_URL_PREFIXES = (
+    PKG_GO_DEV_VULN,
+    "https://www.cve.org/CVERecord",
+    "https://nvd.nist.gov/vuln/detail/",
+    "https://www.kb.cert.org/vuls/id/",
+    "https://github.com/advisories/",
+)
+
+
+class OSVEncoder(JSONEncoder):
+    """Encodes OSV objects into JSON format"""
+
+    def default(self, o):
+        if isinstance(o, Event):
+            return o.encode_json()
+        return o.__dict__
+
+
+@dataclass
+class Event:
+    """
+    Class to hold event information for a Range. Advisories for Red Hat RPM based products always
+    assume all previous versions are affected.
+    """
+
+    event_type: Literal["introduced", "fixed"]
+    version: str = "0"
+    introduced: Literal["introduced"] = "introduced"
+    fixed: Literal["fixed"] = "fixed"
+
+    def __post_init__(self):
+        if self.event_type not in (self.introduced, self.fixed):
+            raise ValueError(
+                f"Expected one of {(self.introduced, self.fixed)} for type. "
+                f"Got {self.event_type}")
+
+    def encode_json(self):
+        """
+        Custom JSON encoding for event type which changes attribute name depending on the type of
+        event eg. introduced or fixed
+        """
+        if self.event_type == "introduced":
+            return {"introduced": self.version}
+        if self.event_type == "fixed":
+            return {"fixed": self.version}
+        raise ValueError("Unexpected event_type for Event")
+
+
+@dataclass
+class Range:
+    """
+    Class to hold range information for a Package. Ecosystem here refers to RPM versions as defined
+    in https://github.com/rpm-software-management/rpm/blob/master/rpmio/rpmvercmp.c
+    """
+
+    fixed: InitVar[str]
+    type: str = field(init=False)
+    events: list[Event] = field(init=False)
+
+    def __post_init__(self, fixed):
+        self.events = [Event("introduced"), Event("fixed", fixed)]
+        self.type = "ECOSYSTEM"
+
+
+@dataclass
+class Package:
+    """
+    Class to hold package data for an Affect.
+    Expects an ecosystem string that starts with CPE_PATTERN.
+    Replaces the CPE prefix 'redhat' part with 'Red Hat'
+    to match more closely with other ecosystem identifiers in the OSV database
+    """
+
+    cpe_pattern: re.Pattern = field(init=False,
+                                    default=re.compile(r"cpe:/[oa]:(redhat)"))
+    name: str
+    ecosystem: str
+    purl: str
+
+    def __post_init__(self):
+        if not self.cpe_pattern.match(self.ecosystem):
+            raise ValueError(f"Got unsupported ecosystem: {self.ecosystem}")
+        self.ecosystem = f"Red Hat{self.cpe_pattern.split(self.ecosystem, maxsplit=1)[-1]}"
+
+
+@dataclass
+class Affected:
+    """
+    Class to hold affected data for a Vulnerability
+    """
+
+    remediation: InitVar[Remediation]
+    package: Package = field(init=False)
+    ranges: list[Range] = field(init=False)
+
+    def __post_init__(self, remediation: Remediation):
+        self.package = Package(remediation.component, remediation.cpe,
+                               remediation.purl)
+        self.ranges = [Range(remediation.fixed_version)]
+
+
+# pylint: disable=too-many-instance-attributes
+# This class is directly encoded into OSV json so has one instance attribute for each OSV property
+class OSV:
+    """
+    Class to convert CSAF data to OSV
+    """
+
+    def __init__(self, csaf_data: CSAF, modified: str, published: str = ""):
+        self.schema_version = SCHEMA_VERSION
+
+        self.id = ""
+
+        # This attribute is declared after id to make the resulting JSON human-readable. It can only
+        # be populated after reading the csaf vulnerabilities and references sections.
+        self.related: list[str] = []
+
+        if published:
+            self.published = published
+        else:
+            self.published = modified
+        self.modified = modified
+
+        self.summary = csaf_data.title
+
+        # Set severity to the CVSS of the highest CVSSv3 base score
+        vulnerability_scores: dict[str, str] = {}
+        for vulnerability in csaf_data.vulnerabilities:
+            if not vulnerability.cvss_v3_vector or not vulnerability.cvss_v3_base_score:
+                continue
+            vulnerability_scores[
+                vulnerability.cvss_v3_base_score] = vulnerability.cvss_v3_vector
+        if vulnerability_scores:
+            highest_score = sorted(vulnerability_scores.keys())[-1]
+            self.severity = [{
+                "type": "CVSS_V3",
+                "score": vulnerability_scores[highest_score]
+            }]
+
+        self.affected: list[Affected] = []
+        for vulnerability in csaf_data.vulnerabilities:
+            self.related.append(vulnerability.cve_id)
+            for remediation in vulnerability.remediations:
+                self.affected.append(Affected(remediation))
+
+        self.references = self._convert_references(csaf_data)
+
+    def _convert_references(self, csaf) -> list[dict[str, str]]:
+        """
+        CSAF has references for an advisory and each vulnerability has references as well.
+        Collect this into a single references list for OSV and deduplicate them.
+        """
+        references: dict[str, str] = {}
+        for reference in csaf.references:
+            # This will capture both the Advisory URL and the CSAF document for the advisory
+            if reference["category"] == "self":
+                if reference["summary"].startswith(REDHAT_ADVISORY_URL):
+                    self.id = reference["summary"].removeprefix(
+                        REDHAT_ADVISORY_URL)
+                references[reference["url"]] = "ADVISORY"
+            else:
+                references[reference["url"]] = self._get_reference_type_and_add_go_related(
+                    reference)
+        for vulnerability in csaf.vulnerabilities:
+            for reference in vulnerability.references:
+                # This captures the CVE specific information
+                if reference["category"] == "self":
+                    references[reference["url"]] = "REPORT"
+                else:
+                    references[reference["url"]] = self._get_reference_type_and_add_go_related(
+                        reference)
+        return [{"type": t, "url": u} for u, t in references.items()]
+
+    def _get_reference_type_and_add_go_related(self, reference: dict[str, str]) -> str:
+        """
+        Convert references from CSAF into typed referenced in OSV
+        Also make sure to add a related entry for any GO advisory references found
+        """
+        reference_url = reference["url"]
+        if reference_url.startswith(ADVISORY_URL_PREFIXES):
+            if reference_url.startswith(PKG_GO_DEV_VULN):
+                self.related.append(reference_url.removeprefix(PKG_GO_DEV_VULN))
+            return "ADVISORY"
+        if reference_url.startswith("https://bugzilla.redhat.com/show_bug.cgi"):
+            return "REPORT"
+        return "ARTICLE"
+

--- a/tools/redhat/osv_test.py
+++ b/tools/redhat/osv_test.py
@@ -1,0 +1,43 @@
+"""Test Intermediate OSV object creation"""
+import unittest
+
+from csaf import CSAF
+from osv import OSV, Event
+
+
+class ScoreTest(unittest.TestCase):
+    """Tests OSV vulnerability scores"""
+
+    def test_missing_cvss_v3(self):
+        """Test parsing a CSAF file with missing CVSSv3 score"""
+        csaf_file = "testdata/rhsa-2015_0008.json"
+        with open(csaf_file, "r", encoding="utf-8") as fp:
+            csaf_data = fp.read()
+        csaf = CSAF(csaf_data)
+        assert csaf
+        assert len(csaf.vulnerabilities) == 1
+        assert not csaf.vulnerabilities[0].cvss_v3_base_score
+
+        osv = OSV(csaf, "test_date")
+        assert not hasattr(osv, "severity")
+
+
+class EventTest(unittest.TestCase):
+    """ Tests OSV affected range events"""
+
+    def test_init_event(self):
+        """Test parsing various Events"""
+        event = Event("introduced")
+        assert event.event_type == "introduced"
+        assert event.version == "0"
+
+        event = Event("fixed", "1")
+        assert event.event_type == "fixed"
+        assert event.version == "1"
+
+        with self.assertRaises(ValueError):
+            Event("test")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tools/redhat/testdata/RHSA-2024_4546.json
+++ b/tools/redhat/testdata/RHSA-2024_4546.json
@@ -1,0 +1,361 @@
+{
+  "schema_version": "1.6.5",
+  "id": "RHSA-2024:4546",
+  "related": [
+    "CVE-2023-45288",
+    "GO-2024-2687"
+  ],
+  "published": "2024-09-02T14:30:00Z",
+  "modified": "2024-09-02T14:30:00Z",
+  "summary": "Red Hat Security Advisory: git-lfs security update",
+  "severity": [
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+    }
+  ],
+  "affected": [
+    {
+      "package": {
+        "name": "git-lfs",
+        "ecosystem": "Red Hat:rhel_aus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/git-lfs@2.13.3-3.el8_6.1?arch=src"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:2.13.3-3.el8_6.1.src"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "git-lfs",
+        "ecosystem": "Red Hat:rhel_aus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/git-lfs@2.13.3-3.el8_6.1?arch=x86_64"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:2.13.3-3.el8_6.1.x86_64"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "git-lfs-debuginfo",
+        "ecosystem": "Red Hat:rhel_aus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/git-lfs-debuginfo@2.13.3-3.el8_6.1?arch=x86_64"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:2.13.3-3.el8_6.1.x86_64"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "git-lfs-debugsource",
+        "ecosystem": "Red Hat:rhel_aus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/git-lfs-debugsource@2.13.3-3.el8_6.1?arch=x86_64"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:2.13.3-3.el8_6.1.x86_64"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "git-lfs",
+        "ecosystem": "Red Hat:rhel_e4s:8.6::appstream",
+        "purl": "pkg:rpm/redhat/git-lfs@2.13.3-3.el8_6.1?arch=ppc64le"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:2.13.3-3.el8_6.1.ppc64le"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "git-lfs",
+        "ecosystem": "Red Hat:rhel_e4s:8.6::appstream",
+        "purl": "pkg:rpm/redhat/git-lfs@2.13.3-3.el8_6.1?arch=src"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:2.13.3-3.el8_6.1.src"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "git-lfs",
+        "ecosystem": "Red Hat:rhel_e4s:8.6::appstream",
+        "purl": "pkg:rpm/redhat/git-lfs@2.13.3-3.el8_6.1?arch=x86_64"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:2.13.3-3.el8_6.1.x86_64"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "git-lfs-debuginfo",
+        "ecosystem": "Red Hat:rhel_e4s:8.6::appstream",
+        "purl": "pkg:rpm/redhat/git-lfs-debuginfo@2.13.3-3.el8_6.1?arch=ppc64le"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:2.13.3-3.el8_6.1.ppc64le"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "git-lfs-debuginfo",
+        "ecosystem": "Red Hat:rhel_e4s:8.6::appstream",
+        "purl": "pkg:rpm/redhat/git-lfs-debuginfo@2.13.3-3.el8_6.1?arch=x86_64"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:2.13.3-3.el8_6.1.x86_64"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "git-lfs-debugsource",
+        "ecosystem": "Red Hat:rhel_e4s:8.6::appstream",
+        "purl": "pkg:rpm/redhat/git-lfs-debugsource@2.13.3-3.el8_6.1?arch=ppc64le"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:2.13.3-3.el8_6.1.ppc64le"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "git-lfs-debugsource",
+        "ecosystem": "Red Hat:rhel_e4s:8.6::appstream",
+        "purl": "pkg:rpm/redhat/git-lfs-debugsource@2.13.3-3.el8_6.1?arch=x86_64"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:2.13.3-3.el8_6.1.x86_64"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "git-lfs",
+        "ecosystem": "Red Hat:rhel_tus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/git-lfs@2.13.3-3.el8_6.1?arch=src"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:2.13.3-3.el8_6.1.src"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "git-lfs",
+        "ecosystem": "Red Hat:rhel_tus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/git-lfs@2.13.3-3.el8_6.1?arch=x86_64"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:2.13.3-3.el8_6.1.x86_64"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "git-lfs-debuginfo",
+        "ecosystem": "Red Hat:rhel_tus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/git-lfs-debuginfo@2.13.3-3.el8_6.1?arch=x86_64"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:2.13.3-3.el8_6.1.x86_64"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "git-lfs-debugsource",
+        "ecosystem": "Red Hat:rhel_tus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/git-lfs-debugsource@2.13.3-3.el8_6.1?arch=x86_64"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:2.13.3-3.el8_6.1.x86_64"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "ADVISORY",
+      "url": "https://access.redhat.com/errata/RHSA-2024:4546"
+    },
+    {
+      "type": "ARTICLE",
+      "url": "https://access.redhat.com/security/updates/classification/#important"
+    },
+    {
+      "type": "REPORT",
+      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=2268273"
+    },
+    {
+      "type": "ADVISORY",
+      "url": "https://access.redhat.com/security/data/csaf/v2/advisories/2024/rhsa-2024_4546.json"
+    },
+    {
+      "type": "REPORT",
+      "url": "https://access.redhat.com/security/cve/CVE-2023-45288"
+    },
+    {
+      "type": "ADVISORY",
+      "url": "https://www.cve.org/CVERecord?id=CVE-2023-45288"
+    },
+    {
+      "type": "ADVISORY",
+      "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-45288"
+    },
+    {
+      "type": "ARTICLE",
+      "url": "https://nowotarski.info/http2-continuation-flood/"
+    },
+    {
+      "type": "ADVISORY",
+      "url": "https://pkg.go.dev/vuln/GO-2024-2687"
+    },
+    {
+      "type": "ADVISORY",
+      "url": "https://www.kb.cert.org/vuls/id/421644"
+    }
+  ]
+}

--- a/tools/redhat/testdata/rhsa-2015_0008.json
+++ b/tools/redhat/testdata/rhsa-2015_0008.json
@@ -1,0 +1,7529 @@
+{
+  "document": {
+    "aggregate_severity": {
+      "namespace": "https://access.redhat.com/security/updates/classification/",
+      "text": "Low"
+    },
+    "category": "csaf_vex",
+    "csaf_version": "2.0",
+    "distribution": {
+      "text": "Copyright © Red Hat, Inc. All rights reserved.",
+      "tlp": {
+        "label": "WHITE",
+        "url": "https://www.first.org/tlp/"
+      }
+    },
+    "lang": "en",
+    "notes": [
+      {
+        "category": "summary",
+        "text": "Updated libvirt packages that fix one security issue and three bugs are now\navailable for Red Hat Enterprise Linux 7.\n\nRed Hat Product Security has rated this update as having Low security\nimpact. A Common Vulnerability Scoring System (CVSS) base score, which\ngives a detailed severity rating, is available from the CVE link in the\nReferences section.",
+        "title": "Topic"
+      },
+      {
+        "category": "general",
+        "text": "The libvirt library is a C API for managing and interacting with the\nvirtualization capabilities of Linux and other operating systems.\nIn addition, libvirt provides tools for remote management of\nvirtualized systems.\n\nIt was found that when the VIR_DOMAIN_XML_MIGRATABLE flag was used, the\nQEMU driver implementation of the virDomainGetXMLDesc() function could\nbypass the restrictions of the VIR_DOMAIN_XML_SECURE flag. A remote\nattacker able to establish a read-only connection to libvirtd could use\nthis flaw to leak certain limited information from the domain XML data.\n(CVE-2014-7823)\n\nThis issue was discovered by Eric Blake of Red Hat.\n\nThis update also fixes the following bugs:\n\n* In Red Hat Enterprise Linux 6, libvirt relies on the QEMU emulator to\nsupply the error message when an active commit is attempted. However, with\nRed Hat Enterprise Linux 7, QEMU added support for an active commit, but an\nadditional interaction from libvirt to fully enable active commits is still\nmissing. As a consequence, attempts to perform an active commit caused\nlibvirt to become unresponsive. With this update, libvirt has been fixed to\ndetect an active commit by itself, and now properly declares the feature as\nunsupported. As a result, libvirt no longer hangs when an active commit is\nattempted and instead produces an error message.\n\nNote that the missing libvirt interaction will be added in Red Hat\nEnterprise Linux 7.1, adding full support for active commits. (BZ#1150379)\n\n* Prior to this update, the libvirt API did not properly check whether a\nDiscretionary Access Control (DAC) security label is non-NULL before trying\nto parse user/group ownership from it. In addition, the DAC security label\nof a transient domain that had just finished migrating to another host is\nin some cases NULL. As a consequence, when the virDomainGetBlockInfo API\nwas called on such a domain, the libvirtd daemon sometimes terminated\nunexpectedly. With this update, libvirt properly checks DAC labels before\ntrying to parse them, and libvirtd thus no longer crashes in the described\nscenario. (BZ#1171124)\n\n* If a block copy operation was attempted while another block copy was\nalready in progress to an explicit raw destination, libvirt previously\nstopped regarding the destination as raw. As a consequence, if the\nqemu.conf file was edited to allow file format probing, triggering the bug\ncould allow a malicious guest to bypass sVirt protection by making libvirt\nregard the file as non-raw. With this update, libvirt has been fixed to\nconsistently remember when a block copy destination is raw, and guests can\nno longer circumvent sVirt protection when the host is configured to allow\nformat probing. (BZ#1149078)\n\nAll libvirt users are advised to upgrade to these updated packages, which\ncontain backported patches to correct these issues. After installing the\nupdated packages, libvirtd will be restarted automatically.",
+        "title": "Details"
+      },
+      {
+        "category": "legal_disclaimer",
+        "text": "This content is licensed under the Creative Commons Attribution 4.0 International License (https://creativecommons.org/licenses/by/4.0/). If you distribute this content, or a modified version of it, you must provide attribution to Red Hat Inc. and provide a link to the original.",
+        "title": "Terms of Use"
+      }
+    ],
+    "publisher": {
+      "category": "vendor",
+      "contact_details": "https://access.redhat.com/security/team/contact/",
+      "issuing_authority": "Red Hat Product Security is responsible for vulnerability handling across all Red Hat offerings.",
+      "name": "Red Hat Product Security",
+      "namespace": "https://www.redhat.com"
+    },
+    "references": [
+      {
+        "category": "self",
+        "summary": "https://access.redhat.com/errata/RHSA-2015:0008",
+        "url": "https://access.redhat.com/errata/RHSA-2015:0008"
+      },
+      {
+        "category": "external",
+        "summary": "https://access.redhat.com/security/updates/classification/#low",
+        "url": "https://access.redhat.com/security/updates/classification/#low"
+      },
+      {
+        "category": "external",
+        "summary": "1150379",
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1150379"
+      },
+      {
+        "category": "external",
+        "summary": "1160817",
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1160817"
+      },
+      {
+        "category": "external",
+        "summary": "1171124",
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1171124"
+      },
+      {
+        "category": "self",
+        "summary": "Canonical URL",
+        "url": "https://access.redhat.com/security/data/csaf/v2/advisories/2015/rhsa-2015_0008.json"
+      }
+    ],
+    "title": "Red Hat Security Advisory: libvirt security and bug fix update",
+    "tracking": {
+      "current_release_date": "2024-08-14T21:06:00+00:00",
+      "generator": {
+        "date": "2024-08-14T21:06:00+00:00",
+        "engine": {
+          "name": "Red Hat SDEngine",
+          "version": "3.32.0"
+        }
+      },
+      "id": "RHSA-2015:0008",
+      "initial_release_date": "2015-01-05T20:29:48+00:00",
+      "revision_history": [
+        {
+          "date": "2015-01-05T20:29:48+00:00",
+          "number": "1",
+          "summary": "Initial version"
+        },
+        {
+          "date": "2015-01-05T20:29:48+00:00",
+          "number": "2",
+          "summary": "Last updated version"
+        },
+        {
+          "date": "2024-08-14T21:06:00+00:00",
+          "number": "3",
+          "summary": "Last generated version"
+        }
+      ],
+      "status": "final",
+      "version": "3"
+    }
+  },
+  "product_tree": {
+    "branches": [
+      {
+        "branches": [
+          {
+            "branches": [
+              {
+                "category": "product_name",
+                "name": "Red Hat Enterprise Linux Client (v. 7)",
+                "product": {
+                  "name": "Red Hat Enterprise Linux Client (v. 7)",
+                  "product_id": "7Client-7.0.Z",
+                  "product_identification_helper": {
+                    "cpe": "cpe:/o:redhat:enterprise_linux:7::client"
+                  }
+                }
+              },
+              {
+                "category": "product_name",
+                "name": "Red Hat Enterprise Linux Client Optional (v. 7)",
+                "product": {
+                  "name": "Red Hat Enterprise Linux Client Optional (v. 7)",
+                  "product_id": "7Client-optional-7.0.Z",
+                  "product_identification_helper": {
+                    "cpe": "cpe:/o:redhat:enterprise_linux:7::client"
+                  }
+                }
+              },
+              {
+                "category": "product_name",
+                "name": "Red Hat Enterprise Linux ComputeNode (v. 7)",
+                "product": {
+                  "name": "Red Hat Enterprise Linux ComputeNode (v. 7)",
+                  "product_id": "7ComputeNode-7.0.Z",
+                  "product_identification_helper": {
+                    "cpe": "cpe:/o:redhat:enterprise_linux:7::computenode"
+                  }
+                }
+              },
+              {
+                "category": "product_name",
+                "name": "Red Hat Enterprise Linux ComputeNode Optional (v. 7)",
+                "product": {
+                  "name": "Red Hat Enterprise Linux ComputeNode Optional (v. 7)",
+                  "product_id": "7ComputeNode-optional-7.0.Z",
+                  "product_identification_helper": {
+                    "cpe": "cpe:/o:redhat:enterprise_linux:7::computenode"
+                  }
+                }
+              },
+              {
+                "category": "product_name",
+                "name": "Red Hat Enterprise Linux Server (v. 7)",
+                "product": {
+                  "name": "Red Hat Enterprise Linux Server (v. 7)",
+                  "product_id": "7Server-7.0.Z",
+                  "product_identification_helper": {
+                    "cpe": "cpe:/o:redhat:enterprise_linux:7::server"
+                  }
+                }
+              },
+              {
+                "category": "product_name",
+                "name": "Red Hat Enterprise Linux Server Optional (v. 7)",
+                "product": {
+                  "name": "Red Hat Enterprise Linux Server Optional (v. 7)",
+                  "product_id": "7Server-optional-7.0.Z",
+                  "product_identification_helper": {
+                    "cpe": "cpe:/o:redhat:enterprise_linux:7::server"
+                  }
+                }
+              },
+              {
+                "category": "product_name",
+                "name": "Red Hat Enterprise Linux Workstation (v. 7)",
+                "product": {
+                  "name": "Red Hat Enterprise Linux Workstation (v. 7)",
+                  "product_id": "7Workstation-7.0.Z",
+                  "product_identification_helper": {
+                    "cpe": "cpe:/o:redhat:enterprise_linux:7::workstation"
+                  }
+                }
+              },
+              {
+                "category": "product_name",
+                "name": "Red Hat Enterprise Linux Workstation Optional (v. 7)",
+                "product": {
+                  "name": "Red Hat Enterprise Linux Workstation Optional (v. 7)",
+                  "product_id": "7Workstation-optional-7.0.Z",
+                  "product_identification_helper": {
+                    "cpe": "cpe:/o:redhat:enterprise_linux:7::workstation"
+                  }
+                }
+              }
+            ],
+            "category": "product_family",
+            "name": "Red Hat Enterprise Linux"
+          },
+          {
+            "branches": [
+              {
+                "category": "product_version",
+                "name": "libvirt-0:1.1.1-29.el7_0.4.src",
+                "product": {
+                  "name": "libvirt-0:1.1.1-29.el7_0.4.src",
+                  "product_id": "libvirt-0:1.1.1-29.el7_0.4.src",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/libvirt@1.1.1-29.el7_0.4?arch=src"
+                  }
+                }
+              }
+            ],
+            "category": "architecture",
+            "name": "src"
+          },
+          {
+            "branches": [
+              {
+                "category": "product_version",
+                "name": "libvirt-debuginfo-0:1.1.1-29.el7_0.4.x86_64",
+                "product": {
+                  "name": "libvirt-debuginfo-0:1.1.1-29.el7_0.4.x86_64",
+                  "product_id": "libvirt-debuginfo-0:1.1.1-29.el7_0.4.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/libvirt-debuginfo@1.1.1-29.el7_0.4?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "libvirt-client-0:1.1.1-29.el7_0.4.x86_64",
+                "product": {
+                  "name": "libvirt-client-0:1.1.1-29.el7_0.4.x86_64",
+                  "product_id": "libvirt-client-0:1.1.1-29.el7_0.4.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/libvirt-client@1.1.1-29.el7_0.4?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.x86_64",
+                "product": {
+                  "name": "libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.x86_64",
+                  "product_id": "libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/libvirt-daemon-driver-nwfilter@1.1.1-29.el7_0.4?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "libvirt-devel-0:1.1.1-29.el7_0.4.x86_64",
+                "product": {
+                  "name": "libvirt-devel-0:1.1.1-29.el7_0.4.x86_64",
+                  "product_id": "libvirt-devel-0:1.1.1-29.el7_0.4.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/libvirt-devel@1.1.1-29.el7_0.4?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "libvirt-daemon-0:1.1.1-29.el7_0.4.x86_64",
+                "product": {
+                  "name": "libvirt-daemon-0:1.1.1-29.el7_0.4.x86_64",
+                  "product_id": "libvirt-daemon-0:1.1.1-29.el7_0.4.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/libvirt-daemon@1.1.1-29.el7_0.4?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.x86_64",
+                "product": {
+                  "name": "libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.x86_64",
+                  "product_id": "libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/libvirt-daemon-driver-storage@1.1.1-29.el7_0.4?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "libvirt-0:1.1.1-29.el7_0.4.x86_64",
+                "product": {
+                  "name": "libvirt-0:1.1.1-29.el7_0.4.x86_64",
+                  "product_id": "libvirt-0:1.1.1-29.el7_0.4.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/libvirt@1.1.1-29.el7_0.4?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.x86_64",
+                "product": {
+                  "name": "libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.x86_64",
+                  "product_id": "libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/libvirt-daemon-driver-network@1.1.1-29.el7_0.4?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.x86_64",
+                "product": {
+                  "name": "libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.x86_64",
+                  "product_id": "libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/libvirt-daemon-config-nwfilter@1.1.1-29.el7_0.4?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "libvirt-daemon-kvm-0:1.1.1-29.el7_0.4.x86_64",
+                "product": {
+                  "name": "libvirt-daemon-kvm-0:1.1.1-29.el7_0.4.x86_64",
+                  "product_id": "libvirt-daemon-kvm-0:1.1.1-29.el7_0.4.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/libvirt-daemon-kvm@1.1.1-29.el7_0.4?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.x86_64",
+                "product": {
+                  "name": "libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.x86_64",
+                  "product_id": "libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/libvirt-daemon-driver-nodedev@1.1.1-29.el7_0.4?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "libvirt-python-0:1.1.1-29.el7_0.4.x86_64",
+                "product": {
+                  "name": "libvirt-python-0:1.1.1-29.el7_0.4.x86_64",
+                  "product_id": "libvirt-python-0:1.1.1-29.el7_0.4.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/libvirt-python@1.1.1-29.el7_0.4?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "libvirt-docs-0:1.1.1-29.el7_0.4.x86_64",
+                "product": {
+                  "name": "libvirt-docs-0:1.1.1-29.el7_0.4.x86_64",
+                  "product_id": "libvirt-docs-0:1.1.1-29.el7_0.4.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/libvirt-docs@1.1.1-29.el7_0.4?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.x86_64",
+                "product": {
+                  "name": "libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.x86_64",
+                  "product_id": "libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/libvirt-daemon-lxc@1.1.1-29.el7_0.4?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.x86_64",
+                "product": {
+                  "name": "libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.x86_64",
+                  "product_id": "libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/libvirt-daemon-driver-lxc@1.1.1-29.el7_0.4?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "libvirt-login-shell-0:1.1.1-29.el7_0.4.x86_64",
+                "product": {
+                  "name": "libvirt-login-shell-0:1.1.1-29.el7_0.4.x86_64",
+                  "product_id": "libvirt-login-shell-0:1.1.1-29.el7_0.4.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/libvirt-login-shell@1.1.1-29.el7_0.4?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.x86_64",
+                "product": {
+                  "name": "libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.x86_64",
+                  "product_id": "libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/libvirt-daemon-driver-interface@1.1.1-29.el7_0.4?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.x86_64",
+                "product": {
+                  "name": "libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.x86_64",
+                  "product_id": "libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/libvirt-daemon-config-network@1.1.1-29.el7_0.4?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "libvirt-daemon-driver-qemu-0:1.1.1-29.el7_0.4.x86_64",
+                "product": {
+                  "name": "libvirt-daemon-driver-qemu-0:1.1.1-29.el7_0.4.x86_64",
+                  "product_id": "libvirt-daemon-driver-qemu-0:1.1.1-29.el7_0.4.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/libvirt-daemon-driver-qemu@1.1.1-29.el7_0.4?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.x86_64",
+                "product": {
+                  "name": "libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.x86_64",
+                  "product_id": "libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/libvirt-daemon-driver-secret@1.1.1-29.el7_0.4?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "libvirt-lock-sanlock-0:1.1.1-29.el7_0.4.x86_64",
+                "product": {
+                  "name": "libvirt-lock-sanlock-0:1.1.1-29.el7_0.4.x86_64",
+                  "product_id": "libvirt-lock-sanlock-0:1.1.1-29.el7_0.4.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/libvirt-lock-sanlock@1.1.1-29.el7_0.4?arch=x86_64"
+                  }
+                }
+              }
+            ],
+            "category": "architecture",
+            "name": "x86_64"
+          },
+          {
+            "branches": [
+              {
+                "category": "product_version",
+                "name": "libvirt-debuginfo-0:1.1.1-29.el7_0.4.i686",
+                "product": {
+                  "name": "libvirt-debuginfo-0:1.1.1-29.el7_0.4.i686",
+                  "product_id": "libvirt-debuginfo-0:1.1.1-29.el7_0.4.i686",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/libvirt-debuginfo@1.1.1-29.el7_0.4?arch=i686"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "libvirt-client-0:1.1.1-29.el7_0.4.i686",
+                "product": {
+                  "name": "libvirt-client-0:1.1.1-29.el7_0.4.i686",
+                  "product_id": "libvirt-client-0:1.1.1-29.el7_0.4.i686",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/libvirt-client@1.1.1-29.el7_0.4?arch=i686"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "libvirt-devel-0:1.1.1-29.el7_0.4.i686",
+                "product": {
+                  "name": "libvirt-devel-0:1.1.1-29.el7_0.4.i686",
+                  "product_id": "libvirt-devel-0:1.1.1-29.el7_0.4.i686",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/libvirt-devel@1.1.1-29.el7_0.4?arch=i686"
+                  }
+                }
+              }
+            ],
+            "category": "architecture",
+            "name": "i686"
+          },
+          {
+            "branches": [
+              {
+                "category": "product_version",
+                "name": "libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.s390x",
+                "product": {
+                  "name": "libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.s390x",
+                  "product_id": "libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/libvirt-daemon-driver-nwfilter@1.1.1-29.el7_0.4?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "libvirt-devel-0:1.1.1-29.el7_0.4.s390x",
+                "product": {
+                  "name": "libvirt-devel-0:1.1.1-29.el7_0.4.s390x",
+                  "product_id": "libvirt-devel-0:1.1.1-29.el7_0.4.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/libvirt-devel@1.1.1-29.el7_0.4?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "libvirt-daemon-0:1.1.1-29.el7_0.4.s390x",
+                "product": {
+                  "name": "libvirt-daemon-0:1.1.1-29.el7_0.4.s390x",
+                  "product_id": "libvirt-daemon-0:1.1.1-29.el7_0.4.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/libvirt-daemon@1.1.1-29.el7_0.4?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.s390x",
+                "product": {
+                  "name": "libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.s390x",
+                  "product_id": "libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/libvirt-daemon-driver-storage@1.1.1-29.el7_0.4?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "libvirt-0:1.1.1-29.el7_0.4.s390x",
+                "product": {
+                  "name": "libvirt-0:1.1.1-29.el7_0.4.s390x",
+                  "product_id": "libvirt-0:1.1.1-29.el7_0.4.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/libvirt@1.1.1-29.el7_0.4?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "libvirt-debuginfo-0:1.1.1-29.el7_0.4.s390x",
+                "product": {
+                  "name": "libvirt-debuginfo-0:1.1.1-29.el7_0.4.s390x",
+                  "product_id": "libvirt-debuginfo-0:1.1.1-29.el7_0.4.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/libvirt-debuginfo@1.1.1-29.el7_0.4?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.s390x",
+                "product": {
+                  "name": "libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.s390x",
+                  "product_id": "libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/libvirt-daemon-driver-network@1.1.1-29.el7_0.4?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.s390x",
+                "product": {
+                  "name": "libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.s390x",
+                  "product_id": "libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/libvirt-daemon-config-nwfilter@1.1.1-29.el7_0.4?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.s390x",
+                "product": {
+                  "name": "libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.s390x",
+                  "product_id": "libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/libvirt-daemon-driver-nodedev@1.1.1-29.el7_0.4?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "libvirt-python-0:1.1.1-29.el7_0.4.s390x",
+                "product": {
+                  "name": "libvirt-python-0:1.1.1-29.el7_0.4.s390x",
+                  "product_id": "libvirt-python-0:1.1.1-29.el7_0.4.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/libvirt-python@1.1.1-29.el7_0.4?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "libvirt-docs-0:1.1.1-29.el7_0.4.s390x",
+                "product": {
+                  "name": "libvirt-docs-0:1.1.1-29.el7_0.4.s390x",
+                  "product_id": "libvirt-docs-0:1.1.1-29.el7_0.4.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/libvirt-docs@1.1.1-29.el7_0.4?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.s390x",
+                "product": {
+                  "name": "libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.s390x",
+                  "product_id": "libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/libvirt-daemon-driver-lxc@1.1.1-29.el7_0.4?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.s390x",
+                "product": {
+                  "name": "libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.s390x",
+                  "product_id": "libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/libvirt-daemon-driver-interface@1.1.1-29.el7_0.4?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.s390x",
+                "product": {
+                  "name": "libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.s390x",
+                  "product_id": "libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/libvirt-daemon-config-network@1.1.1-29.el7_0.4?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.s390x",
+                "product": {
+                  "name": "libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.s390x",
+                  "product_id": "libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/libvirt-daemon-driver-secret@1.1.1-29.el7_0.4?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "libvirt-client-0:1.1.1-29.el7_0.4.s390x",
+                "product": {
+                  "name": "libvirt-client-0:1.1.1-29.el7_0.4.s390x",
+                  "product_id": "libvirt-client-0:1.1.1-29.el7_0.4.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/libvirt-client@1.1.1-29.el7_0.4?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.s390x",
+                "product": {
+                  "name": "libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.s390x",
+                  "product_id": "libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/libvirt-daemon-lxc@1.1.1-29.el7_0.4?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "libvirt-login-shell-0:1.1.1-29.el7_0.4.s390x",
+                "product": {
+                  "name": "libvirt-login-shell-0:1.1.1-29.el7_0.4.s390x",
+                  "product_id": "libvirt-login-shell-0:1.1.1-29.el7_0.4.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/libvirt-login-shell@1.1.1-29.el7_0.4?arch=s390x"
+                  }
+                }
+              }
+            ],
+            "category": "architecture",
+            "name": "s390x"
+          },
+          {
+            "branches": [
+              {
+                "category": "product_version",
+                "name": "libvirt-devel-0:1.1.1-29.el7_0.4.s390",
+                "product": {
+                  "name": "libvirt-devel-0:1.1.1-29.el7_0.4.s390",
+                  "product_id": "libvirt-devel-0:1.1.1-29.el7_0.4.s390",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/libvirt-devel@1.1.1-29.el7_0.4?arch=s390"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "libvirt-debuginfo-0:1.1.1-29.el7_0.4.s390",
+                "product": {
+                  "name": "libvirt-debuginfo-0:1.1.1-29.el7_0.4.s390",
+                  "product_id": "libvirt-debuginfo-0:1.1.1-29.el7_0.4.s390",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/libvirt-debuginfo@1.1.1-29.el7_0.4?arch=s390"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "libvirt-client-0:1.1.1-29.el7_0.4.s390",
+                "product": {
+                  "name": "libvirt-client-0:1.1.1-29.el7_0.4.s390",
+                  "product_id": "libvirt-client-0:1.1.1-29.el7_0.4.s390",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/libvirt-client@1.1.1-29.el7_0.4?arch=s390"
+                  }
+                }
+              }
+            ],
+            "category": "architecture",
+            "name": "s390"
+          },
+          {
+            "branches": [
+              {
+                "category": "product_version",
+                "name": "libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.ppc64",
+                "product": {
+                  "name": "libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.ppc64",
+                  "product_id": "libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.ppc64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/libvirt-daemon-driver-nwfilter@1.1.1-29.el7_0.4?arch=ppc64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "libvirt-devel-0:1.1.1-29.el7_0.4.ppc64",
+                "product": {
+                  "name": "libvirt-devel-0:1.1.1-29.el7_0.4.ppc64",
+                  "product_id": "libvirt-devel-0:1.1.1-29.el7_0.4.ppc64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/libvirt-devel@1.1.1-29.el7_0.4?arch=ppc64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "libvirt-daemon-0:1.1.1-29.el7_0.4.ppc64",
+                "product": {
+                  "name": "libvirt-daemon-0:1.1.1-29.el7_0.4.ppc64",
+                  "product_id": "libvirt-daemon-0:1.1.1-29.el7_0.4.ppc64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/libvirt-daemon@1.1.1-29.el7_0.4?arch=ppc64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.ppc64",
+                "product": {
+                  "name": "libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.ppc64",
+                  "product_id": "libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.ppc64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/libvirt-daemon-driver-storage@1.1.1-29.el7_0.4?arch=ppc64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "libvirt-0:1.1.1-29.el7_0.4.ppc64",
+                "product": {
+                  "name": "libvirt-0:1.1.1-29.el7_0.4.ppc64",
+                  "product_id": "libvirt-0:1.1.1-29.el7_0.4.ppc64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/libvirt@1.1.1-29.el7_0.4?arch=ppc64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "libvirt-debuginfo-0:1.1.1-29.el7_0.4.ppc64",
+                "product": {
+                  "name": "libvirt-debuginfo-0:1.1.1-29.el7_0.4.ppc64",
+                  "product_id": "libvirt-debuginfo-0:1.1.1-29.el7_0.4.ppc64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/libvirt-debuginfo@1.1.1-29.el7_0.4?arch=ppc64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.ppc64",
+                "product": {
+                  "name": "libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.ppc64",
+                  "product_id": "libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.ppc64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/libvirt-daemon-driver-network@1.1.1-29.el7_0.4?arch=ppc64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.ppc64",
+                "product": {
+                  "name": "libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.ppc64",
+                  "product_id": "libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.ppc64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/libvirt-daemon-config-nwfilter@1.1.1-29.el7_0.4?arch=ppc64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.ppc64",
+                "product": {
+                  "name": "libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.ppc64",
+                  "product_id": "libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.ppc64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/libvirt-daemon-driver-nodedev@1.1.1-29.el7_0.4?arch=ppc64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "libvirt-python-0:1.1.1-29.el7_0.4.ppc64",
+                "product": {
+                  "name": "libvirt-python-0:1.1.1-29.el7_0.4.ppc64",
+                  "product_id": "libvirt-python-0:1.1.1-29.el7_0.4.ppc64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/libvirt-python@1.1.1-29.el7_0.4?arch=ppc64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "libvirt-docs-0:1.1.1-29.el7_0.4.ppc64",
+                "product": {
+                  "name": "libvirt-docs-0:1.1.1-29.el7_0.4.ppc64",
+                  "product_id": "libvirt-docs-0:1.1.1-29.el7_0.4.ppc64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/libvirt-docs@1.1.1-29.el7_0.4?arch=ppc64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.ppc64",
+                "product": {
+                  "name": "libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.ppc64",
+                  "product_id": "libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.ppc64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/libvirt-daemon-driver-lxc@1.1.1-29.el7_0.4?arch=ppc64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.ppc64",
+                "product": {
+                  "name": "libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.ppc64",
+                  "product_id": "libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.ppc64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/libvirt-daemon-driver-interface@1.1.1-29.el7_0.4?arch=ppc64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.ppc64",
+                "product": {
+                  "name": "libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.ppc64",
+                  "product_id": "libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.ppc64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/libvirt-daemon-config-network@1.1.1-29.el7_0.4?arch=ppc64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.ppc64",
+                "product": {
+                  "name": "libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.ppc64",
+                  "product_id": "libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.ppc64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/libvirt-daemon-driver-secret@1.1.1-29.el7_0.4?arch=ppc64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "libvirt-client-0:1.1.1-29.el7_0.4.ppc64",
+                "product": {
+                  "name": "libvirt-client-0:1.1.1-29.el7_0.4.ppc64",
+                  "product_id": "libvirt-client-0:1.1.1-29.el7_0.4.ppc64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/libvirt-client@1.1.1-29.el7_0.4?arch=ppc64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.ppc64",
+                "product": {
+                  "name": "libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.ppc64",
+                  "product_id": "libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.ppc64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/libvirt-daemon-lxc@1.1.1-29.el7_0.4?arch=ppc64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "libvirt-login-shell-0:1.1.1-29.el7_0.4.ppc64",
+                "product": {
+                  "name": "libvirt-login-shell-0:1.1.1-29.el7_0.4.ppc64",
+                  "product_id": "libvirt-login-shell-0:1.1.1-29.el7_0.4.ppc64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/libvirt-login-shell@1.1.1-29.el7_0.4?arch=ppc64"
+                  }
+                }
+              }
+            ],
+            "category": "architecture",
+            "name": "ppc64"
+          },
+          {
+            "branches": [
+              {
+                "category": "product_version",
+                "name": "libvirt-devel-0:1.1.1-29.el7_0.4.ppc",
+                "product": {
+                  "name": "libvirt-devel-0:1.1.1-29.el7_0.4.ppc",
+                  "product_id": "libvirt-devel-0:1.1.1-29.el7_0.4.ppc",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/libvirt-devel@1.1.1-29.el7_0.4?arch=ppc"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "libvirt-debuginfo-0:1.1.1-29.el7_0.4.ppc",
+                "product": {
+                  "name": "libvirt-debuginfo-0:1.1.1-29.el7_0.4.ppc",
+                  "product_id": "libvirt-debuginfo-0:1.1.1-29.el7_0.4.ppc",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/libvirt-debuginfo@1.1.1-29.el7_0.4?arch=ppc"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "libvirt-client-0:1.1.1-29.el7_0.4.ppc",
+                "product": {
+                  "name": "libvirt-client-0:1.1.1-29.el7_0.4.ppc",
+                  "product_id": "libvirt-client-0:1.1.1-29.el7_0.4.ppc",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/libvirt-client@1.1.1-29.el7_0.4?arch=ppc"
+                  }
+                }
+              }
+            ],
+            "category": "architecture",
+            "name": "ppc"
+          }
+        ],
+        "category": "vendor",
+        "name": "Red Hat"
+      }
+    ],
+    "relationships": [
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux Client (v. 7)",
+          "product_id": "7Client-7.0.Z:libvirt-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7Client-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux Client (v. 7)",
+          "product_id": "7Client-7.0.Z:libvirt-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7Client-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-0:1.1.1-29.el7_0.4.src as a component of Red Hat Enterprise Linux Client (v. 7)",
+          "product_id": "7Client-7.0.Z:libvirt-0:1.1.1-29.el7_0.4.src"
+        },
+        "product_reference": "libvirt-0:1.1.1-29.el7_0.4.src",
+        "relates_to_product_reference": "7Client-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux Client (v. 7)",
+          "product_id": "7Client-7.0.Z:libvirt-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7Client-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-client-0:1.1.1-29.el7_0.4.i686 as a component of Red Hat Enterprise Linux Client (v. 7)",
+          "product_id": "7Client-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.i686"
+        },
+        "product_reference": "libvirt-client-0:1.1.1-29.el7_0.4.i686",
+        "relates_to_product_reference": "7Client-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-client-0:1.1.1-29.el7_0.4.ppc as a component of Red Hat Enterprise Linux Client (v. 7)",
+          "product_id": "7Client-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.ppc"
+        },
+        "product_reference": "libvirt-client-0:1.1.1-29.el7_0.4.ppc",
+        "relates_to_product_reference": "7Client-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-client-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux Client (v. 7)",
+          "product_id": "7Client-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-client-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7Client-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-client-0:1.1.1-29.el7_0.4.s390 as a component of Red Hat Enterprise Linux Client (v. 7)",
+          "product_id": "7Client-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.s390"
+        },
+        "product_reference": "libvirt-client-0:1.1.1-29.el7_0.4.s390",
+        "relates_to_product_reference": "7Client-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-client-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux Client (v. 7)",
+          "product_id": "7Client-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-client-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7Client-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-client-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux Client (v. 7)",
+          "product_id": "7Client-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-client-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7Client-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux Client (v. 7)",
+          "product_id": "7Client-7.0.Z:libvirt-daemon-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-daemon-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7Client-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux Client (v. 7)",
+          "product_id": "7Client-7.0.Z:libvirt-daemon-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-daemon-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7Client-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux Client (v. 7)",
+          "product_id": "7Client-7.0.Z:libvirt-daemon-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-daemon-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7Client-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux Client (v. 7)",
+          "product_id": "7Client-7.0.Z:libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7Client-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux Client (v. 7)",
+          "product_id": "7Client-7.0.Z:libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7Client-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux Client (v. 7)",
+          "product_id": "7Client-7.0.Z:libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7Client-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux Client (v. 7)",
+          "product_id": "7Client-7.0.Z:libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7Client-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux Client (v. 7)",
+          "product_id": "7Client-7.0.Z:libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7Client-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux Client (v. 7)",
+          "product_id": "7Client-7.0.Z:libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7Client-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux Client (v. 7)",
+          "product_id": "7Client-7.0.Z:libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7Client-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux Client (v. 7)",
+          "product_id": "7Client-7.0.Z:libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7Client-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux Client (v. 7)",
+          "product_id": "7Client-7.0.Z:libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7Client-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux Client (v. 7)",
+          "product_id": "7Client-7.0.Z:libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7Client-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux Client (v. 7)",
+          "product_id": "7Client-7.0.Z:libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7Client-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux Client (v. 7)",
+          "product_id": "7Client-7.0.Z:libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7Client-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux Client (v. 7)",
+          "product_id": "7Client-7.0.Z:libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7Client-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux Client (v. 7)",
+          "product_id": "7Client-7.0.Z:libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7Client-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux Client (v. 7)",
+          "product_id": "7Client-7.0.Z:libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7Client-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux Client (v. 7)",
+          "product_id": "7Client-7.0.Z:libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7Client-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux Client (v. 7)",
+          "product_id": "7Client-7.0.Z:libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7Client-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux Client (v. 7)",
+          "product_id": "7Client-7.0.Z:libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7Client-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux Client (v. 7)",
+          "product_id": "7Client-7.0.Z:libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7Client-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux Client (v. 7)",
+          "product_id": "7Client-7.0.Z:libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7Client-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux Client (v. 7)",
+          "product_id": "7Client-7.0.Z:libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7Client-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-qemu-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux Client (v. 7)",
+          "product_id": "7Client-7.0.Z:libvirt-daemon-driver-qemu-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-daemon-driver-qemu-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7Client-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux Client (v. 7)",
+          "product_id": "7Client-7.0.Z:libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7Client-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux Client (v. 7)",
+          "product_id": "7Client-7.0.Z:libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7Client-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux Client (v. 7)",
+          "product_id": "7Client-7.0.Z:libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7Client-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux Client (v. 7)",
+          "product_id": "7Client-7.0.Z:libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7Client-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux Client (v. 7)",
+          "product_id": "7Client-7.0.Z:libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7Client-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux Client (v. 7)",
+          "product_id": "7Client-7.0.Z:libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7Client-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-kvm-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux Client (v. 7)",
+          "product_id": "7Client-7.0.Z:libvirt-daemon-kvm-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-daemon-kvm-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7Client-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux Client (v. 7)",
+          "product_id": "7Client-7.0.Z:libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7Client-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux Client (v. 7)",
+          "product_id": "7Client-7.0.Z:libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7Client-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux Client (v. 7)",
+          "product_id": "7Client-7.0.Z:libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7Client-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-debuginfo-0:1.1.1-29.el7_0.4.i686 as a component of Red Hat Enterprise Linux Client (v. 7)",
+          "product_id": "7Client-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.i686"
+        },
+        "product_reference": "libvirt-debuginfo-0:1.1.1-29.el7_0.4.i686",
+        "relates_to_product_reference": "7Client-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-debuginfo-0:1.1.1-29.el7_0.4.ppc as a component of Red Hat Enterprise Linux Client (v. 7)",
+          "product_id": "7Client-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.ppc"
+        },
+        "product_reference": "libvirt-debuginfo-0:1.1.1-29.el7_0.4.ppc",
+        "relates_to_product_reference": "7Client-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-debuginfo-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux Client (v. 7)",
+          "product_id": "7Client-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-debuginfo-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7Client-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-debuginfo-0:1.1.1-29.el7_0.4.s390 as a component of Red Hat Enterprise Linux Client (v. 7)",
+          "product_id": "7Client-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.s390"
+        },
+        "product_reference": "libvirt-debuginfo-0:1.1.1-29.el7_0.4.s390",
+        "relates_to_product_reference": "7Client-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-debuginfo-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux Client (v. 7)",
+          "product_id": "7Client-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-debuginfo-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7Client-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-debuginfo-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux Client (v. 7)",
+          "product_id": "7Client-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-debuginfo-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7Client-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-devel-0:1.1.1-29.el7_0.4.i686 as a component of Red Hat Enterprise Linux Client (v. 7)",
+          "product_id": "7Client-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.i686"
+        },
+        "product_reference": "libvirt-devel-0:1.1.1-29.el7_0.4.i686",
+        "relates_to_product_reference": "7Client-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-devel-0:1.1.1-29.el7_0.4.ppc as a component of Red Hat Enterprise Linux Client (v. 7)",
+          "product_id": "7Client-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.ppc"
+        },
+        "product_reference": "libvirt-devel-0:1.1.1-29.el7_0.4.ppc",
+        "relates_to_product_reference": "7Client-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-devel-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux Client (v. 7)",
+          "product_id": "7Client-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-devel-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7Client-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-devel-0:1.1.1-29.el7_0.4.s390 as a component of Red Hat Enterprise Linux Client (v. 7)",
+          "product_id": "7Client-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.s390"
+        },
+        "product_reference": "libvirt-devel-0:1.1.1-29.el7_0.4.s390",
+        "relates_to_product_reference": "7Client-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-devel-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux Client (v. 7)",
+          "product_id": "7Client-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-devel-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7Client-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-devel-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux Client (v. 7)",
+          "product_id": "7Client-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-devel-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7Client-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-docs-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux Client (v. 7)",
+          "product_id": "7Client-7.0.Z:libvirt-docs-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-docs-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7Client-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-docs-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux Client (v. 7)",
+          "product_id": "7Client-7.0.Z:libvirt-docs-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-docs-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7Client-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-docs-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux Client (v. 7)",
+          "product_id": "7Client-7.0.Z:libvirt-docs-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-docs-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7Client-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-lock-sanlock-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux Client (v. 7)",
+          "product_id": "7Client-7.0.Z:libvirt-lock-sanlock-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-lock-sanlock-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7Client-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-login-shell-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux Client (v. 7)",
+          "product_id": "7Client-7.0.Z:libvirt-login-shell-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-login-shell-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7Client-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-login-shell-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux Client (v. 7)",
+          "product_id": "7Client-7.0.Z:libvirt-login-shell-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-login-shell-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7Client-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-login-shell-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux Client (v. 7)",
+          "product_id": "7Client-7.0.Z:libvirt-login-shell-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-login-shell-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7Client-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-python-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux Client (v. 7)",
+          "product_id": "7Client-7.0.Z:libvirt-python-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-python-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7Client-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-python-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux Client (v. 7)",
+          "product_id": "7Client-7.0.Z:libvirt-python-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-python-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7Client-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-python-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux Client (v. 7)",
+          "product_id": "7Client-7.0.Z:libvirt-python-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-python-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7Client-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux Client Optional (v. 7)",
+          "product_id": "7Client-optional-7.0.Z:libvirt-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7Client-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux Client Optional (v. 7)",
+          "product_id": "7Client-optional-7.0.Z:libvirt-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7Client-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-0:1.1.1-29.el7_0.4.src as a component of Red Hat Enterprise Linux Client Optional (v. 7)",
+          "product_id": "7Client-optional-7.0.Z:libvirt-0:1.1.1-29.el7_0.4.src"
+        },
+        "product_reference": "libvirt-0:1.1.1-29.el7_0.4.src",
+        "relates_to_product_reference": "7Client-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux Client Optional (v. 7)",
+          "product_id": "7Client-optional-7.0.Z:libvirt-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7Client-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-client-0:1.1.1-29.el7_0.4.i686 as a component of Red Hat Enterprise Linux Client Optional (v. 7)",
+          "product_id": "7Client-optional-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.i686"
+        },
+        "product_reference": "libvirt-client-0:1.1.1-29.el7_0.4.i686",
+        "relates_to_product_reference": "7Client-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-client-0:1.1.1-29.el7_0.4.ppc as a component of Red Hat Enterprise Linux Client Optional (v. 7)",
+          "product_id": "7Client-optional-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.ppc"
+        },
+        "product_reference": "libvirt-client-0:1.1.1-29.el7_0.4.ppc",
+        "relates_to_product_reference": "7Client-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-client-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux Client Optional (v. 7)",
+          "product_id": "7Client-optional-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-client-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7Client-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-client-0:1.1.1-29.el7_0.4.s390 as a component of Red Hat Enterprise Linux Client Optional (v. 7)",
+          "product_id": "7Client-optional-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.s390"
+        },
+        "product_reference": "libvirt-client-0:1.1.1-29.el7_0.4.s390",
+        "relates_to_product_reference": "7Client-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-client-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux Client Optional (v. 7)",
+          "product_id": "7Client-optional-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-client-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7Client-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-client-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux Client Optional (v. 7)",
+          "product_id": "7Client-optional-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-client-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7Client-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux Client Optional (v. 7)",
+          "product_id": "7Client-optional-7.0.Z:libvirt-daemon-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-daemon-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7Client-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux Client Optional (v. 7)",
+          "product_id": "7Client-optional-7.0.Z:libvirt-daemon-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-daemon-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7Client-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux Client Optional (v. 7)",
+          "product_id": "7Client-optional-7.0.Z:libvirt-daemon-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-daemon-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7Client-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux Client Optional (v. 7)",
+          "product_id": "7Client-optional-7.0.Z:libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7Client-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux Client Optional (v. 7)",
+          "product_id": "7Client-optional-7.0.Z:libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7Client-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux Client Optional (v. 7)",
+          "product_id": "7Client-optional-7.0.Z:libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7Client-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux Client Optional (v. 7)",
+          "product_id": "7Client-optional-7.0.Z:libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7Client-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux Client Optional (v. 7)",
+          "product_id": "7Client-optional-7.0.Z:libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7Client-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux Client Optional (v. 7)",
+          "product_id": "7Client-optional-7.0.Z:libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7Client-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux Client Optional (v. 7)",
+          "product_id": "7Client-optional-7.0.Z:libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7Client-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux Client Optional (v. 7)",
+          "product_id": "7Client-optional-7.0.Z:libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7Client-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux Client Optional (v. 7)",
+          "product_id": "7Client-optional-7.0.Z:libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7Client-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux Client Optional (v. 7)",
+          "product_id": "7Client-optional-7.0.Z:libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7Client-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux Client Optional (v. 7)",
+          "product_id": "7Client-optional-7.0.Z:libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7Client-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux Client Optional (v. 7)",
+          "product_id": "7Client-optional-7.0.Z:libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7Client-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux Client Optional (v. 7)",
+          "product_id": "7Client-optional-7.0.Z:libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7Client-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux Client Optional (v. 7)",
+          "product_id": "7Client-optional-7.0.Z:libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7Client-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux Client Optional (v. 7)",
+          "product_id": "7Client-optional-7.0.Z:libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7Client-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux Client Optional (v. 7)",
+          "product_id": "7Client-optional-7.0.Z:libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7Client-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux Client Optional (v. 7)",
+          "product_id": "7Client-optional-7.0.Z:libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7Client-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux Client Optional (v. 7)",
+          "product_id": "7Client-optional-7.0.Z:libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7Client-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux Client Optional (v. 7)",
+          "product_id": "7Client-optional-7.0.Z:libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7Client-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux Client Optional (v. 7)",
+          "product_id": "7Client-optional-7.0.Z:libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7Client-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux Client Optional (v. 7)",
+          "product_id": "7Client-optional-7.0.Z:libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7Client-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-qemu-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux Client Optional (v. 7)",
+          "product_id": "7Client-optional-7.0.Z:libvirt-daemon-driver-qemu-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-daemon-driver-qemu-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7Client-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux Client Optional (v. 7)",
+          "product_id": "7Client-optional-7.0.Z:libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7Client-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux Client Optional (v. 7)",
+          "product_id": "7Client-optional-7.0.Z:libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7Client-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux Client Optional (v. 7)",
+          "product_id": "7Client-optional-7.0.Z:libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7Client-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux Client Optional (v. 7)",
+          "product_id": "7Client-optional-7.0.Z:libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7Client-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux Client Optional (v. 7)",
+          "product_id": "7Client-optional-7.0.Z:libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7Client-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux Client Optional (v. 7)",
+          "product_id": "7Client-optional-7.0.Z:libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7Client-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-kvm-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux Client Optional (v. 7)",
+          "product_id": "7Client-optional-7.0.Z:libvirt-daemon-kvm-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-daemon-kvm-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7Client-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux Client Optional (v. 7)",
+          "product_id": "7Client-optional-7.0.Z:libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7Client-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux Client Optional (v. 7)",
+          "product_id": "7Client-optional-7.0.Z:libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7Client-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux Client Optional (v. 7)",
+          "product_id": "7Client-optional-7.0.Z:libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7Client-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-debuginfo-0:1.1.1-29.el7_0.4.i686 as a component of Red Hat Enterprise Linux Client Optional (v. 7)",
+          "product_id": "7Client-optional-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.i686"
+        },
+        "product_reference": "libvirt-debuginfo-0:1.1.1-29.el7_0.4.i686",
+        "relates_to_product_reference": "7Client-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-debuginfo-0:1.1.1-29.el7_0.4.ppc as a component of Red Hat Enterprise Linux Client Optional (v. 7)",
+          "product_id": "7Client-optional-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.ppc"
+        },
+        "product_reference": "libvirt-debuginfo-0:1.1.1-29.el7_0.4.ppc",
+        "relates_to_product_reference": "7Client-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-debuginfo-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux Client Optional (v. 7)",
+          "product_id": "7Client-optional-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-debuginfo-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7Client-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-debuginfo-0:1.1.1-29.el7_0.4.s390 as a component of Red Hat Enterprise Linux Client Optional (v. 7)",
+          "product_id": "7Client-optional-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.s390"
+        },
+        "product_reference": "libvirt-debuginfo-0:1.1.1-29.el7_0.4.s390",
+        "relates_to_product_reference": "7Client-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-debuginfo-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux Client Optional (v. 7)",
+          "product_id": "7Client-optional-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-debuginfo-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7Client-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-debuginfo-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux Client Optional (v. 7)",
+          "product_id": "7Client-optional-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-debuginfo-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7Client-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-devel-0:1.1.1-29.el7_0.4.i686 as a component of Red Hat Enterprise Linux Client Optional (v. 7)",
+          "product_id": "7Client-optional-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.i686"
+        },
+        "product_reference": "libvirt-devel-0:1.1.1-29.el7_0.4.i686",
+        "relates_to_product_reference": "7Client-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-devel-0:1.1.1-29.el7_0.4.ppc as a component of Red Hat Enterprise Linux Client Optional (v. 7)",
+          "product_id": "7Client-optional-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.ppc"
+        },
+        "product_reference": "libvirt-devel-0:1.1.1-29.el7_0.4.ppc",
+        "relates_to_product_reference": "7Client-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-devel-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux Client Optional (v. 7)",
+          "product_id": "7Client-optional-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-devel-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7Client-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-devel-0:1.1.1-29.el7_0.4.s390 as a component of Red Hat Enterprise Linux Client Optional (v. 7)",
+          "product_id": "7Client-optional-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.s390"
+        },
+        "product_reference": "libvirt-devel-0:1.1.1-29.el7_0.4.s390",
+        "relates_to_product_reference": "7Client-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-devel-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux Client Optional (v. 7)",
+          "product_id": "7Client-optional-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-devel-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7Client-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-devel-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux Client Optional (v. 7)",
+          "product_id": "7Client-optional-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-devel-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7Client-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-docs-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux Client Optional (v. 7)",
+          "product_id": "7Client-optional-7.0.Z:libvirt-docs-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-docs-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7Client-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-docs-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux Client Optional (v. 7)",
+          "product_id": "7Client-optional-7.0.Z:libvirt-docs-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-docs-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7Client-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-docs-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux Client Optional (v. 7)",
+          "product_id": "7Client-optional-7.0.Z:libvirt-docs-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-docs-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7Client-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-lock-sanlock-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux Client Optional (v. 7)",
+          "product_id": "7Client-optional-7.0.Z:libvirt-lock-sanlock-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-lock-sanlock-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7Client-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-login-shell-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux Client Optional (v. 7)",
+          "product_id": "7Client-optional-7.0.Z:libvirt-login-shell-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-login-shell-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7Client-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-login-shell-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux Client Optional (v. 7)",
+          "product_id": "7Client-optional-7.0.Z:libvirt-login-shell-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-login-shell-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7Client-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-login-shell-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux Client Optional (v. 7)",
+          "product_id": "7Client-optional-7.0.Z:libvirt-login-shell-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-login-shell-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7Client-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-python-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux Client Optional (v. 7)",
+          "product_id": "7Client-optional-7.0.Z:libvirt-python-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-python-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7Client-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-python-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux Client Optional (v. 7)",
+          "product_id": "7Client-optional-7.0.Z:libvirt-python-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-python-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7Client-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-python-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux Client Optional (v. 7)",
+          "product_id": "7Client-optional-7.0.Z:libvirt-python-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-python-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7Client-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux ComputeNode (v. 7)",
+          "product_id": "7ComputeNode-7.0.Z:libvirt-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7ComputeNode-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux ComputeNode (v. 7)",
+          "product_id": "7ComputeNode-7.0.Z:libvirt-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7ComputeNode-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-0:1.1.1-29.el7_0.4.src as a component of Red Hat Enterprise Linux ComputeNode (v. 7)",
+          "product_id": "7ComputeNode-7.0.Z:libvirt-0:1.1.1-29.el7_0.4.src"
+        },
+        "product_reference": "libvirt-0:1.1.1-29.el7_0.4.src",
+        "relates_to_product_reference": "7ComputeNode-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux ComputeNode (v. 7)",
+          "product_id": "7ComputeNode-7.0.Z:libvirt-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7ComputeNode-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-client-0:1.1.1-29.el7_0.4.i686 as a component of Red Hat Enterprise Linux ComputeNode (v. 7)",
+          "product_id": "7ComputeNode-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.i686"
+        },
+        "product_reference": "libvirt-client-0:1.1.1-29.el7_0.4.i686",
+        "relates_to_product_reference": "7ComputeNode-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-client-0:1.1.1-29.el7_0.4.ppc as a component of Red Hat Enterprise Linux ComputeNode (v. 7)",
+          "product_id": "7ComputeNode-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.ppc"
+        },
+        "product_reference": "libvirt-client-0:1.1.1-29.el7_0.4.ppc",
+        "relates_to_product_reference": "7ComputeNode-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-client-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux ComputeNode (v. 7)",
+          "product_id": "7ComputeNode-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-client-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7ComputeNode-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-client-0:1.1.1-29.el7_0.4.s390 as a component of Red Hat Enterprise Linux ComputeNode (v. 7)",
+          "product_id": "7ComputeNode-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.s390"
+        },
+        "product_reference": "libvirt-client-0:1.1.1-29.el7_0.4.s390",
+        "relates_to_product_reference": "7ComputeNode-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-client-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux ComputeNode (v. 7)",
+          "product_id": "7ComputeNode-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-client-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7ComputeNode-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-client-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux ComputeNode (v. 7)",
+          "product_id": "7ComputeNode-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-client-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7ComputeNode-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux ComputeNode (v. 7)",
+          "product_id": "7ComputeNode-7.0.Z:libvirt-daemon-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-daemon-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7ComputeNode-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux ComputeNode (v. 7)",
+          "product_id": "7ComputeNode-7.0.Z:libvirt-daemon-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-daemon-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7ComputeNode-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux ComputeNode (v. 7)",
+          "product_id": "7ComputeNode-7.0.Z:libvirt-daemon-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-daemon-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7ComputeNode-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux ComputeNode (v. 7)",
+          "product_id": "7ComputeNode-7.0.Z:libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7ComputeNode-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux ComputeNode (v. 7)",
+          "product_id": "7ComputeNode-7.0.Z:libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7ComputeNode-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux ComputeNode (v. 7)",
+          "product_id": "7ComputeNode-7.0.Z:libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7ComputeNode-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux ComputeNode (v. 7)",
+          "product_id": "7ComputeNode-7.0.Z:libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7ComputeNode-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux ComputeNode (v. 7)",
+          "product_id": "7ComputeNode-7.0.Z:libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7ComputeNode-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux ComputeNode (v. 7)",
+          "product_id": "7ComputeNode-7.0.Z:libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7ComputeNode-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux ComputeNode (v. 7)",
+          "product_id": "7ComputeNode-7.0.Z:libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7ComputeNode-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux ComputeNode (v. 7)",
+          "product_id": "7ComputeNode-7.0.Z:libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7ComputeNode-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux ComputeNode (v. 7)",
+          "product_id": "7ComputeNode-7.0.Z:libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7ComputeNode-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux ComputeNode (v. 7)",
+          "product_id": "7ComputeNode-7.0.Z:libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7ComputeNode-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux ComputeNode (v. 7)",
+          "product_id": "7ComputeNode-7.0.Z:libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7ComputeNode-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux ComputeNode (v. 7)",
+          "product_id": "7ComputeNode-7.0.Z:libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7ComputeNode-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux ComputeNode (v. 7)",
+          "product_id": "7ComputeNode-7.0.Z:libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7ComputeNode-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux ComputeNode (v. 7)",
+          "product_id": "7ComputeNode-7.0.Z:libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7ComputeNode-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux ComputeNode (v. 7)",
+          "product_id": "7ComputeNode-7.0.Z:libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7ComputeNode-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux ComputeNode (v. 7)",
+          "product_id": "7ComputeNode-7.0.Z:libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7ComputeNode-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux ComputeNode (v. 7)",
+          "product_id": "7ComputeNode-7.0.Z:libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7ComputeNode-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux ComputeNode (v. 7)",
+          "product_id": "7ComputeNode-7.0.Z:libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7ComputeNode-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux ComputeNode (v. 7)",
+          "product_id": "7ComputeNode-7.0.Z:libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7ComputeNode-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux ComputeNode (v. 7)",
+          "product_id": "7ComputeNode-7.0.Z:libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7ComputeNode-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux ComputeNode (v. 7)",
+          "product_id": "7ComputeNode-7.0.Z:libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7ComputeNode-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-qemu-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux ComputeNode (v. 7)",
+          "product_id": "7ComputeNode-7.0.Z:libvirt-daemon-driver-qemu-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-daemon-driver-qemu-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7ComputeNode-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux ComputeNode (v. 7)",
+          "product_id": "7ComputeNode-7.0.Z:libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7ComputeNode-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux ComputeNode (v. 7)",
+          "product_id": "7ComputeNode-7.0.Z:libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7ComputeNode-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux ComputeNode (v. 7)",
+          "product_id": "7ComputeNode-7.0.Z:libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7ComputeNode-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux ComputeNode (v. 7)",
+          "product_id": "7ComputeNode-7.0.Z:libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7ComputeNode-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux ComputeNode (v. 7)",
+          "product_id": "7ComputeNode-7.0.Z:libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7ComputeNode-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux ComputeNode (v. 7)",
+          "product_id": "7ComputeNode-7.0.Z:libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7ComputeNode-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-kvm-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux ComputeNode (v. 7)",
+          "product_id": "7ComputeNode-7.0.Z:libvirt-daemon-kvm-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-daemon-kvm-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7ComputeNode-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux ComputeNode (v. 7)",
+          "product_id": "7ComputeNode-7.0.Z:libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7ComputeNode-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux ComputeNode (v. 7)",
+          "product_id": "7ComputeNode-7.0.Z:libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7ComputeNode-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux ComputeNode (v. 7)",
+          "product_id": "7ComputeNode-7.0.Z:libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7ComputeNode-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-debuginfo-0:1.1.1-29.el7_0.4.i686 as a component of Red Hat Enterprise Linux ComputeNode (v. 7)",
+          "product_id": "7ComputeNode-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.i686"
+        },
+        "product_reference": "libvirt-debuginfo-0:1.1.1-29.el7_0.4.i686",
+        "relates_to_product_reference": "7ComputeNode-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-debuginfo-0:1.1.1-29.el7_0.4.ppc as a component of Red Hat Enterprise Linux ComputeNode (v. 7)",
+          "product_id": "7ComputeNode-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.ppc"
+        },
+        "product_reference": "libvirt-debuginfo-0:1.1.1-29.el7_0.4.ppc",
+        "relates_to_product_reference": "7ComputeNode-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-debuginfo-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux ComputeNode (v. 7)",
+          "product_id": "7ComputeNode-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-debuginfo-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7ComputeNode-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-debuginfo-0:1.1.1-29.el7_0.4.s390 as a component of Red Hat Enterprise Linux ComputeNode (v. 7)",
+          "product_id": "7ComputeNode-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.s390"
+        },
+        "product_reference": "libvirt-debuginfo-0:1.1.1-29.el7_0.4.s390",
+        "relates_to_product_reference": "7ComputeNode-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-debuginfo-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux ComputeNode (v. 7)",
+          "product_id": "7ComputeNode-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-debuginfo-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7ComputeNode-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-debuginfo-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux ComputeNode (v. 7)",
+          "product_id": "7ComputeNode-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-debuginfo-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7ComputeNode-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-devel-0:1.1.1-29.el7_0.4.i686 as a component of Red Hat Enterprise Linux ComputeNode (v. 7)",
+          "product_id": "7ComputeNode-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.i686"
+        },
+        "product_reference": "libvirt-devel-0:1.1.1-29.el7_0.4.i686",
+        "relates_to_product_reference": "7ComputeNode-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-devel-0:1.1.1-29.el7_0.4.ppc as a component of Red Hat Enterprise Linux ComputeNode (v. 7)",
+          "product_id": "7ComputeNode-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.ppc"
+        },
+        "product_reference": "libvirt-devel-0:1.1.1-29.el7_0.4.ppc",
+        "relates_to_product_reference": "7ComputeNode-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-devel-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux ComputeNode (v. 7)",
+          "product_id": "7ComputeNode-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-devel-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7ComputeNode-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-devel-0:1.1.1-29.el7_0.4.s390 as a component of Red Hat Enterprise Linux ComputeNode (v. 7)",
+          "product_id": "7ComputeNode-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.s390"
+        },
+        "product_reference": "libvirt-devel-0:1.1.1-29.el7_0.4.s390",
+        "relates_to_product_reference": "7ComputeNode-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-devel-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux ComputeNode (v. 7)",
+          "product_id": "7ComputeNode-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-devel-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7ComputeNode-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-devel-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux ComputeNode (v. 7)",
+          "product_id": "7ComputeNode-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-devel-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7ComputeNode-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-docs-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux ComputeNode (v. 7)",
+          "product_id": "7ComputeNode-7.0.Z:libvirt-docs-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-docs-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7ComputeNode-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-docs-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux ComputeNode (v. 7)",
+          "product_id": "7ComputeNode-7.0.Z:libvirt-docs-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-docs-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7ComputeNode-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-docs-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux ComputeNode (v. 7)",
+          "product_id": "7ComputeNode-7.0.Z:libvirt-docs-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-docs-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7ComputeNode-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-lock-sanlock-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux ComputeNode (v. 7)",
+          "product_id": "7ComputeNode-7.0.Z:libvirt-lock-sanlock-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-lock-sanlock-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7ComputeNode-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-login-shell-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux ComputeNode (v. 7)",
+          "product_id": "7ComputeNode-7.0.Z:libvirt-login-shell-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-login-shell-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7ComputeNode-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-login-shell-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux ComputeNode (v. 7)",
+          "product_id": "7ComputeNode-7.0.Z:libvirt-login-shell-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-login-shell-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7ComputeNode-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-login-shell-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux ComputeNode (v. 7)",
+          "product_id": "7ComputeNode-7.0.Z:libvirt-login-shell-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-login-shell-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7ComputeNode-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-python-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux ComputeNode (v. 7)",
+          "product_id": "7ComputeNode-7.0.Z:libvirt-python-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-python-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7ComputeNode-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-python-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux ComputeNode (v. 7)",
+          "product_id": "7ComputeNode-7.0.Z:libvirt-python-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-python-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7ComputeNode-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-python-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux ComputeNode (v. 7)",
+          "product_id": "7ComputeNode-7.0.Z:libvirt-python-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-python-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7ComputeNode-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux ComputeNode Optional (v. 7)",
+          "product_id": "7ComputeNode-optional-7.0.Z:libvirt-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7ComputeNode-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux ComputeNode Optional (v. 7)",
+          "product_id": "7ComputeNode-optional-7.0.Z:libvirt-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7ComputeNode-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-0:1.1.1-29.el7_0.4.src as a component of Red Hat Enterprise Linux ComputeNode Optional (v. 7)",
+          "product_id": "7ComputeNode-optional-7.0.Z:libvirt-0:1.1.1-29.el7_0.4.src"
+        },
+        "product_reference": "libvirt-0:1.1.1-29.el7_0.4.src",
+        "relates_to_product_reference": "7ComputeNode-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux ComputeNode Optional (v. 7)",
+          "product_id": "7ComputeNode-optional-7.0.Z:libvirt-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7ComputeNode-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-client-0:1.1.1-29.el7_0.4.i686 as a component of Red Hat Enterprise Linux ComputeNode Optional (v. 7)",
+          "product_id": "7ComputeNode-optional-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.i686"
+        },
+        "product_reference": "libvirt-client-0:1.1.1-29.el7_0.4.i686",
+        "relates_to_product_reference": "7ComputeNode-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-client-0:1.1.1-29.el7_0.4.ppc as a component of Red Hat Enterprise Linux ComputeNode Optional (v. 7)",
+          "product_id": "7ComputeNode-optional-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.ppc"
+        },
+        "product_reference": "libvirt-client-0:1.1.1-29.el7_0.4.ppc",
+        "relates_to_product_reference": "7ComputeNode-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-client-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux ComputeNode Optional (v. 7)",
+          "product_id": "7ComputeNode-optional-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-client-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7ComputeNode-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-client-0:1.1.1-29.el7_0.4.s390 as a component of Red Hat Enterprise Linux ComputeNode Optional (v. 7)",
+          "product_id": "7ComputeNode-optional-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.s390"
+        },
+        "product_reference": "libvirt-client-0:1.1.1-29.el7_0.4.s390",
+        "relates_to_product_reference": "7ComputeNode-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-client-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux ComputeNode Optional (v. 7)",
+          "product_id": "7ComputeNode-optional-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-client-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7ComputeNode-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-client-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux ComputeNode Optional (v. 7)",
+          "product_id": "7ComputeNode-optional-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-client-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7ComputeNode-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux ComputeNode Optional (v. 7)",
+          "product_id": "7ComputeNode-optional-7.0.Z:libvirt-daemon-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-daemon-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7ComputeNode-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux ComputeNode Optional (v. 7)",
+          "product_id": "7ComputeNode-optional-7.0.Z:libvirt-daemon-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-daemon-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7ComputeNode-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux ComputeNode Optional (v. 7)",
+          "product_id": "7ComputeNode-optional-7.0.Z:libvirt-daemon-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-daemon-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7ComputeNode-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux ComputeNode Optional (v. 7)",
+          "product_id": "7ComputeNode-optional-7.0.Z:libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7ComputeNode-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux ComputeNode Optional (v. 7)",
+          "product_id": "7ComputeNode-optional-7.0.Z:libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7ComputeNode-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux ComputeNode Optional (v. 7)",
+          "product_id": "7ComputeNode-optional-7.0.Z:libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7ComputeNode-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux ComputeNode Optional (v. 7)",
+          "product_id": "7ComputeNode-optional-7.0.Z:libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7ComputeNode-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux ComputeNode Optional (v. 7)",
+          "product_id": "7ComputeNode-optional-7.0.Z:libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7ComputeNode-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux ComputeNode Optional (v. 7)",
+          "product_id": "7ComputeNode-optional-7.0.Z:libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7ComputeNode-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux ComputeNode Optional (v. 7)",
+          "product_id": "7ComputeNode-optional-7.0.Z:libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7ComputeNode-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux ComputeNode Optional (v. 7)",
+          "product_id": "7ComputeNode-optional-7.0.Z:libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7ComputeNode-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux ComputeNode Optional (v. 7)",
+          "product_id": "7ComputeNode-optional-7.0.Z:libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7ComputeNode-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux ComputeNode Optional (v. 7)",
+          "product_id": "7ComputeNode-optional-7.0.Z:libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7ComputeNode-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux ComputeNode Optional (v. 7)",
+          "product_id": "7ComputeNode-optional-7.0.Z:libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7ComputeNode-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux ComputeNode Optional (v. 7)",
+          "product_id": "7ComputeNode-optional-7.0.Z:libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7ComputeNode-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux ComputeNode Optional (v. 7)",
+          "product_id": "7ComputeNode-optional-7.0.Z:libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7ComputeNode-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux ComputeNode Optional (v. 7)",
+          "product_id": "7ComputeNode-optional-7.0.Z:libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7ComputeNode-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux ComputeNode Optional (v. 7)",
+          "product_id": "7ComputeNode-optional-7.0.Z:libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7ComputeNode-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux ComputeNode Optional (v. 7)",
+          "product_id": "7ComputeNode-optional-7.0.Z:libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7ComputeNode-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux ComputeNode Optional (v. 7)",
+          "product_id": "7ComputeNode-optional-7.0.Z:libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7ComputeNode-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux ComputeNode Optional (v. 7)",
+          "product_id": "7ComputeNode-optional-7.0.Z:libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7ComputeNode-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux ComputeNode Optional (v. 7)",
+          "product_id": "7ComputeNode-optional-7.0.Z:libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7ComputeNode-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux ComputeNode Optional (v. 7)",
+          "product_id": "7ComputeNode-optional-7.0.Z:libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7ComputeNode-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux ComputeNode Optional (v. 7)",
+          "product_id": "7ComputeNode-optional-7.0.Z:libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7ComputeNode-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-qemu-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux ComputeNode Optional (v. 7)",
+          "product_id": "7ComputeNode-optional-7.0.Z:libvirt-daemon-driver-qemu-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-daemon-driver-qemu-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7ComputeNode-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux ComputeNode Optional (v. 7)",
+          "product_id": "7ComputeNode-optional-7.0.Z:libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7ComputeNode-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux ComputeNode Optional (v. 7)",
+          "product_id": "7ComputeNode-optional-7.0.Z:libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7ComputeNode-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux ComputeNode Optional (v. 7)",
+          "product_id": "7ComputeNode-optional-7.0.Z:libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7ComputeNode-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux ComputeNode Optional (v. 7)",
+          "product_id": "7ComputeNode-optional-7.0.Z:libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7ComputeNode-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux ComputeNode Optional (v. 7)",
+          "product_id": "7ComputeNode-optional-7.0.Z:libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7ComputeNode-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux ComputeNode Optional (v. 7)",
+          "product_id": "7ComputeNode-optional-7.0.Z:libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7ComputeNode-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-kvm-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux ComputeNode Optional (v. 7)",
+          "product_id": "7ComputeNode-optional-7.0.Z:libvirt-daemon-kvm-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-daemon-kvm-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7ComputeNode-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux ComputeNode Optional (v. 7)",
+          "product_id": "7ComputeNode-optional-7.0.Z:libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7ComputeNode-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux ComputeNode Optional (v. 7)",
+          "product_id": "7ComputeNode-optional-7.0.Z:libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7ComputeNode-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux ComputeNode Optional (v. 7)",
+          "product_id": "7ComputeNode-optional-7.0.Z:libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7ComputeNode-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-debuginfo-0:1.1.1-29.el7_0.4.i686 as a component of Red Hat Enterprise Linux ComputeNode Optional (v. 7)",
+          "product_id": "7ComputeNode-optional-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.i686"
+        },
+        "product_reference": "libvirt-debuginfo-0:1.1.1-29.el7_0.4.i686",
+        "relates_to_product_reference": "7ComputeNode-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-debuginfo-0:1.1.1-29.el7_0.4.ppc as a component of Red Hat Enterprise Linux ComputeNode Optional (v. 7)",
+          "product_id": "7ComputeNode-optional-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.ppc"
+        },
+        "product_reference": "libvirt-debuginfo-0:1.1.1-29.el7_0.4.ppc",
+        "relates_to_product_reference": "7ComputeNode-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-debuginfo-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux ComputeNode Optional (v. 7)",
+          "product_id": "7ComputeNode-optional-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-debuginfo-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7ComputeNode-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-debuginfo-0:1.1.1-29.el7_0.4.s390 as a component of Red Hat Enterprise Linux ComputeNode Optional (v. 7)",
+          "product_id": "7ComputeNode-optional-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.s390"
+        },
+        "product_reference": "libvirt-debuginfo-0:1.1.1-29.el7_0.4.s390",
+        "relates_to_product_reference": "7ComputeNode-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-debuginfo-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux ComputeNode Optional (v. 7)",
+          "product_id": "7ComputeNode-optional-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-debuginfo-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7ComputeNode-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-debuginfo-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux ComputeNode Optional (v. 7)",
+          "product_id": "7ComputeNode-optional-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-debuginfo-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7ComputeNode-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-devel-0:1.1.1-29.el7_0.4.i686 as a component of Red Hat Enterprise Linux ComputeNode Optional (v. 7)",
+          "product_id": "7ComputeNode-optional-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.i686"
+        },
+        "product_reference": "libvirt-devel-0:1.1.1-29.el7_0.4.i686",
+        "relates_to_product_reference": "7ComputeNode-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-devel-0:1.1.1-29.el7_0.4.ppc as a component of Red Hat Enterprise Linux ComputeNode Optional (v. 7)",
+          "product_id": "7ComputeNode-optional-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.ppc"
+        },
+        "product_reference": "libvirt-devel-0:1.1.1-29.el7_0.4.ppc",
+        "relates_to_product_reference": "7ComputeNode-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-devel-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux ComputeNode Optional (v. 7)",
+          "product_id": "7ComputeNode-optional-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-devel-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7ComputeNode-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-devel-0:1.1.1-29.el7_0.4.s390 as a component of Red Hat Enterprise Linux ComputeNode Optional (v. 7)",
+          "product_id": "7ComputeNode-optional-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.s390"
+        },
+        "product_reference": "libvirt-devel-0:1.1.1-29.el7_0.4.s390",
+        "relates_to_product_reference": "7ComputeNode-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-devel-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux ComputeNode Optional (v. 7)",
+          "product_id": "7ComputeNode-optional-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-devel-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7ComputeNode-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-devel-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux ComputeNode Optional (v. 7)",
+          "product_id": "7ComputeNode-optional-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-devel-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7ComputeNode-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-docs-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux ComputeNode Optional (v. 7)",
+          "product_id": "7ComputeNode-optional-7.0.Z:libvirt-docs-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-docs-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7ComputeNode-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-docs-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux ComputeNode Optional (v. 7)",
+          "product_id": "7ComputeNode-optional-7.0.Z:libvirt-docs-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-docs-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7ComputeNode-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-docs-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux ComputeNode Optional (v. 7)",
+          "product_id": "7ComputeNode-optional-7.0.Z:libvirt-docs-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-docs-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7ComputeNode-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-lock-sanlock-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux ComputeNode Optional (v. 7)",
+          "product_id": "7ComputeNode-optional-7.0.Z:libvirt-lock-sanlock-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-lock-sanlock-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7ComputeNode-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-login-shell-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux ComputeNode Optional (v. 7)",
+          "product_id": "7ComputeNode-optional-7.0.Z:libvirt-login-shell-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-login-shell-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7ComputeNode-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-login-shell-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux ComputeNode Optional (v. 7)",
+          "product_id": "7ComputeNode-optional-7.0.Z:libvirt-login-shell-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-login-shell-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7ComputeNode-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-login-shell-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux ComputeNode Optional (v. 7)",
+          "product_id": "7ComputeNode-optional-7.0.Z:libvirt-login-shell-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-login-shell-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7ComputeNode-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-python-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux ComputeNode Optional (v. 7)",
+          "product_id": "7ComputeNode-optional-7.0.Z:libvirt-python-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-python-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7ComputeNode-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-python-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux ComputeNode Optional (v. 7)",
+          "product_id": "7ComputeNode-optional-7.0.Z:libvirt-python-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-python-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7ComputeNode-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-python-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux ComputeNode Optional (v. 7)",
+          "product_id": "7ComputeNode-optional-7.0.Z:libvirt-python-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-python-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7ComputeNode-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux Server (v. 7)",
+          "product_id": "7Server-7.0.Z:libvirt-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7Server-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux Server (v. 7)",
+          "product_id": "7Server-7.0.Z:libvirt-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7Server-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-0:1.1.1-29.el7_0.4.src as a component of Red Hat Enterprise Linux Server (v. 7)",
+          "product_id": "7Server-7.0.Z:libvirt-0:1.1.1-29.el7_0.4.src"
+        },
+        "product_reference": "libvirt-0:1.1.1-29.el7_0.4.src",
+        "relates_to_product_reference": "7Server-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux Server (v. 7)",
+          "product_id": "7Server-7.0.Z:libvirt-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7Server-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-client-0:1.1.1-29.el7_0.4.i686 as a component of Red Hat Enterprise Linux Server (v. 7)",
+          "product_id": "7Server-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.i686"
+        },
+        "product_reference": "libvirt-client-0:1.1.1-29.el7_0.4.i686",
+        "relates_to_product_reference": "7Server-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-client-0:1.1.1-29.el7_0.4.ppc as a component of Red Hat Enterprise Linux Server (v. 7)",
+          "product_id": "7Server-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.ppc"
+        },
+        "product_reference": "libvirt-client-0:1.1.1-29.el7_0.4.ppc",
+        "relates_to_product_reference": "7Server-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-client-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux Server (v. 7)",
+          "product_id": "7Server-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-client-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7Server-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-client-0:1.1.1-29.el7_0.4.s390 as a component of Red Hat Enterprise Linux Server (v. 7)",
+          "product_id": "7Server-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.s390"
+        },
+        "product_reference": "libvirt-client-0:1.1.1-29.el7_0.4.s390",
+        "relates_to_product_reference": "7Server-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-client-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux Server (v. 7)",
+          "product_id": "7Server-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-client-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7Server-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-client-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux Server (v. 7)",
+          "product_id": "7Server-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-client-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7Server-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux Server (v. 7)",
+          "product_id": "7Server-7.0.Z:libvirt-daemon-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-daemon-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7Server-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux Server (v. 7)",
+          "product_id": "7Server-7.0.Z:libvirt-daemon-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-daemon-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7Server-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux Server (v. 7)",
+          "product_id": "7Server-7.0.Z:libvirt-daemon-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-daemon-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7Server-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux Server (v. 7)",
+          "product_id": "7Server-7.0.Z:libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7Server-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux Server (v. 7)",
+          "product_id": "7Server-7.0.Z:libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7Server-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux Server (v. 7)",
+          "product_id": "7Server-7.0.Z:libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7Server-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux Server (v. 7)",
+          "product_id": "7Server-7.0.Z:libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7Server-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux Server (v. 7)",
+          "product_id": "7Server-7.0.Z:libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7Server-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux Server (v. 7)",
+          "product_id": "7Server-7.0.Z:libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7Server-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux Server (v. 7)",
+          "product_id": "7Server-7.0.Z:libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7Server-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux Server (v. 7)",
+          "product_id": "7Server-7.0.Z:libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7Server-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux Server (v. 7)",
+          "product_id": "7Server-7.0.Z:libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7Server-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux Server (v. 7)",
+          "product_id": "7Server-7.0.Z:libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7Server-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux Server (v. 7)",
+          "product_id": "7Server-7.0.Z:libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7Server-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux Server (v. 7)",
+          "product_id": "7Server-7.0.Z:libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7Server-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux Server (v. 7)",
+          "product_id": "7Server-7.0.Z:libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7Server-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux Server (v. 7)",
+          "product_id": "7Server-7.0.Z:libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7Server-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux Server (v. 7)",
+          "product_id": "7Server-7.0.Z:libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7Server-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux Server (v. 7)",
+          "product_id": "7Server-7.0.Z:libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7Server-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux Server (v. 7)",
+          "product_id": "7Server-7.0.Z:libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7Server-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux Server (v. 7)",
+          "product_id": "7Server-7.0.Z:libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7Server-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux Server (v. 7)",
+          "product_id": "7Server-7.0.Z:libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7Server-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux Server (v. 7)",
+          "product_id": "7Server-7.0.Z:libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7Server-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux Server (v. 7)",
+          "product_id": "7Server-7.0.Z:libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7Server-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-qemu-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux Server (v. 7)",
+          "product_id": "7Server-7.0.Z:libvirt-daemon-driver-qemu-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-daemon-driver-qemu-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7Server-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux Server (v. 7)",
+          "product_id": "7Server-7.0.Z:libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7Server-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux Server (v. 7)",
+          "product_id": "7Server-7.0.Z:libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7Server-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux Server (v. 7)",
+          "product_id": "7Server-7.0.Z:libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7Server-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux Server (v. 7)",
+          "product_id": "7Server-7.0.Z:libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7Server-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux Server (v. 7)",
+          "product_id": "7Server-7.0.Z:libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7Server-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux Server (v. 7)",
+          "product_id": "7Server-7.0.Z:libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7Server-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-kvm-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux Server (v. 7)",
+          "product_id": "7Server-7.0.Z:libvirt-daemon-kvm-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-daemon-kvm-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7Server-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux Server (v. 7)",
+          "product_id": "7Server-7.0.Z:libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7Server-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux Server (v. 7)",
+          "product_id": "7Server-7.0.Z:libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7Server-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux Server (v. 7)",
+          "product_id": "7Server-7.0.Z:libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7Server-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-debuginfo-0:1.1.1-29.el7_0.4.i686 as a component of Red Hat Enterprise Linux Server (v. 7)",
+          "product_id": "7Server-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.i686"
+        },
+        "product_reference": "libvirt-debuginfo-0:1.1.1-29.el7_0.4.i686",
+        "relates_to_product_reference": "7Server-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-debuginfo-0:1.1.1-29.el7_0.4.ppc as a component of Red Hat Enterprise Linux Server (v. 7)",
+          "product_id": "7Server-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.ppc"
+        },
+        "product_reference": "libvirt-debuginfo-0:1.1.1-29.el7_0.4.ppc",
+        "relates_to_product_reference": "7Server-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-debuginfo-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux Server (v. 7)",
+          "product_id": "7Server-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-debuginfo-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7Server-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-debuginfo-0:1.1.1-29.el7_0.4.s390 as a component of Red Hat Enterprise Linux Server (v. 7)",
+          "product_id": "7Server-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.s390"
+        },
+        "product_reference": "libvirt-debuginfo-0:1.1.1-29.el7_0.4.s390",
+        "relates_to_product_reference": "7Server-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-debuginfo-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux Server (v. 7)",
+          "product_id": "7Server-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-debuginfo-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7Server-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-debuginfo-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux Server (v. 7)",
+          "product_id": "7Server-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-debuginfo-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7Server-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-devel-0:1.1.1-29.el7_0.4.i686 as a component of Red Hat Enterprise Linux Server (v. 7)",
+          "product_id": "7Server-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.i686"
+        },
+        "product_reference": "libvirt-devel-0:1.1.1-29.el7_0.4.i686",
+        "relates_to_product_reference": "7Server-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-devel-0:1.1.1-29.el7_0.4.ppc as a component of Red Hat Enterprise Linux Server (v. 7)",
+          "product_id": "7Server-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.ppc"
+        },
+        "product_reference": "libvirt-devel-0:1.1.1-29.el7_0.4.ppc",
+        "relates_to_product_reference": "7Server-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-devel-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux Server (v. 7)",
+          "product_id": "7Server-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-devel-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7Server-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-devel-0:1.1.1-29.el7_0.4.s390 as a component of Red Hat Enterprise Linux Server (v. 7)",
+          "product_id": "7Server-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.s390"
+        },
+        "product_reference": "libvirt-devel-0:1.1.1-29.el7_0.4.s390",
+        "relates_to_product_reference": "7Server-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-devel-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux Server (v. 7)",
+          "product_id": "7Server-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-devel-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7Server-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-devel-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux Server (v. 7)",
+          "product_id": "7Server-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-devel-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7Server-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-docs-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux Server (v. 7)",
+          "product_id": "7Server-7.0.Z:libvirt-docs-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-docs-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7Server-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-docs-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux Server (v. 7)",
+          "product_id": "7Server-7.0.Z:libvirt-docs-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-docs-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7Server-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-docs-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux Server (v. 7)",
+          "product_id": "7Server-7.0.Z:libvirt-docs-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-docs-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7Server-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-lock-sanlock-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux Server (v. 7)",
+          "product_id": "7Server-7.0.Z:libvirt-lock-sanlock-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-lock-sanlock-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7Server-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-login-shell-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux Server (v. 7)",
+          "product_id": "7Server-7.0.Z:libvirt-login-shell-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-login-shell-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7Server-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-login-shell-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux Server (v. 7)",
+          "product_id": "7Server-7.0.Z:libvirt-login-shell-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-login-shell-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7Server-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-login-shell-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux Server (v. 7)",
+          "product_id": "7Server-7.0.Z:libvirt-login-shell-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-login-shell-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7Server-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-python-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux Server (v. 7)",
+          "product_id": "7Server-7.0.Z:libvirt-python-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-python-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7Server-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-python-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux Server (v. 7)",
+          "product_id": "7Server-7.0.Z:libvirt-python-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-python-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7Server-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-python-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux Server (v. 7)",
+          "product_id": "7Server-7.0.Z:libvirt-python-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-python-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7Server-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux Server Optional (v. 7)",
+          "product_id": "7Server-optional-7.0.Z:libvirt-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7Server-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux Server Optional (v. 7)",
+          "product_id": "7Server-optional-7.0.Z:libvirt-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7Server-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-0:1.1.1-29.el7_0.4.src as a component of Red Hat Enterprise Linux Server Optional (v. 7)",
+          "product_id": "7Server-optional-7.0.Z:libvirt-0:1.1.1-29.el7_0.4.src"
+        },
+        "product_reference": "libvirt-0:1.1.1-29.el7_0.4.src",
+        "relates_to_product_reference": "7Server-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux Server Optional (v. 7)",
+          "product_id": "7Server-optional-7.0.Z:libvirt-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7Server-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-client-0:1.1.1-29.el7_0.4.i686 as a component of Red Hat Enterprise Linux Server Optional (v. 7)",
+          "product_id": "7Server-optional-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.i686"
+        },
+        "product_reference": "libvirt-client-0:1.1.1-29.el7_0.4.i686",
+        "relates_to_product_reference": "7Server-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-client-0:1.1.1-29.el7_0.4.ppc as a component of Red Hat Enterprise Linux Server Optional (v. 7)",
+          "product_id": "7Server-optional-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.ppc"
+        },
+        "product_reference": "libvirt-client-0:1.1.1-29.el7_0.4.ppc",
+        "relates_to_product_reference": "7Server-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-client-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux Server Optional (v. 7)",
+          "product_id": "7Server-optional-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-client-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7Server-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-client-0:1.1.1-29.el7_0.4.s390 as a component of Red Hat Enterprise Linux Server Optional (v. 7)",
+          "product_id": "7Server-optional-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.s390"
+        },
+        "product_reference": "libvirt-client-0:1.1.1-29.el7_0.4.s390",
+        "relates_to_product_reference": "7Server-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-client-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux Server Optional (v. 7)",
+          "product_id": "7Server-optional-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-client-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7Server-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-client-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux Server Optional (v. 7)",
+          "product_id": "7Server-optional-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-client-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7Server-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux Server Optional (v. 7)",
+          "product_id": "7Server-optional-7.0.Z:libvirt-daemon-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-daemon-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7Server-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux Server Optional (v. 7)",
+          "product_id": "7Server-optional-7.0.Z:libvirt-daemon-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-daemon-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7Server-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux Server Optional (v. 7)",
+          "product_id": "7Server-optional-7.0.Z:libvirt-daemon-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-daemon-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7Server-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux Server Optional (v. 7)",
+          "product_id": "7Server-optional-7.0.Z:libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7Server-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux Server Optional (v. 7)",
+          "product_id": "7Server-optional-7.0.Z:libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7Server-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux Server Optional (v. 7)",
+          "product_id": "7Server-optional-7.0.Z:libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7Server-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux Server Optional (v. 7)",
+          "product_id": "7Server-optional-7.0.Z:libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7Server-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux Server Optional (v. 7)",
+          "product_id": "7Server-optional-7.0.Z:libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7Server-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux Server Optional (v. 7)",
+          "product_id": "7Server-optional-7.0.Z:libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7Server-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux Server Optional (v. 7)",
+          "product_id": "7Server-optional-7.0.Z:libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7Server-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux Server Optional (v. 7)",
+          "product_id": "7Server-optional-7.0.Z:libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7Server-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux Server Optional (v. 7)",
+          "product_id": "7Server-optional-7.0.Z:libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7Server-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux Server Optional (v. 7)",
+          "product_id": "7Server-optional-7.0.Z:libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7Server-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux Server Optional (v. 7)",
+          "product_id": "7Server-optional-7.0.Z:libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7Server-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux Server Optional (v. 7)",
+          "product_id": "7Server-optional-7.0.Z:libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7Server-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux Server Optional (v. 7)",
+          "product_id": "7Server-optional-7.0.Z:libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7Server-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux Server Optional (v. 7)",
+          "product_id": "7Server-optional-7.0.Z:libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7Server-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux Server Optional (v. 7)",
+          "product_id": "7Server-optional-7.0.Z:libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7Server-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux Server Optional (v. 7)",
+          "product_id": "7Server-optional-7.0.Z:libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7Server-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux Server Optional (v. 7)",
+          "product_id": "7Server-optional-7.0.Z:libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7Server-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux Server Optional (v. 7)",
+          "product_id": "7Server-optional-7.0.Z:libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7Server-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux Server Optional (v. 7)",
+          "product_id": "7Server-optional-7.0.Z:libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7Server-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux Server Optional (v. 7)",
+          "product_id": "7Server-optional-7.0.Z:libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7Server-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux Server Optional (v. 7)",
+          "product_id": "7Server-optional-7.0.Z:libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7Server-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-qemu-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux Server Optional (v. 7)",
+          "product_id": "7Server-optional-7.0.Z:libvirt-daemon-driver-qemu-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-daemon-driver-qemu-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7Server-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux Server Optional (v. 7)",
+          "product_id": "7Server-optional-7.0.Z:libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7Server-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux Server Optional (v. 7)",
+          "product_id": "7Server-optional-7.0.Z:libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7Server-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux Server Optional (v. 7)",
+          "product_id": "7Server-optional-7.0.Z:libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7Server-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux Server Optional (v. 7)",
+          "product_id": "7Server-optional-7.0.Z:libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7Server-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux Server Optional (v. 7)",
+          "product_id": "7Server-optional-7.0.Z:libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7Server-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux Server Optional (v. 7)",
+          "product_id": "7Server-optional-7.0.Z:libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7Server-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-kvm-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux Server Optional (v. 7)",
+          "product_id": "7Server-optional-7.0.Z:libvirt-daemon-kvm-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-daemon-kvm-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7Server-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux Server Optional (v. 7)",
+          "product_id": "7Server-optional-7.0.Z:libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7Server-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux Server Optional (v. 7)",
+          "product_id": "7Server-optional-7.0.Z:libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7Server-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux Server Optional (v. 7)",
+          "product_id": "7Server-optional-7.0.Z:libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7Server-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-debuginfo-0:1.1.1-29.el7_0.4.i686 as a component of Red Hat Enterprise Linux Server Optional (v. 7)",
+          "product_id": "7Server-optional-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.i686"
+        },
+        "product_reference": "libvirt-debuginfo-0:1.1.1-29.el7_0.4.i686",
+        "relates_to_product_reference": "7Server-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-debuginfo-0:1.1.1-29.el7_0.4.ppc as a component of Red Hat Enterprise Linux Server Optional (v. 7)",
+          "product_id": "7Server-optional-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.ppc"
+        },
+        "product_reference": "libvirt-debuginfo-0:1.1.1-29.el7_0.4.ppc",
+        "relates_to_product_reference": "7Server-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-debuginfo-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux Server Optional (v. 7)",
+          "product_id": "7Server-optional-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-debuginfo-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7Server-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-debuginfo-0:1.1.1-29.el7_0.4.s390 as a component of Red Hat Enterprise Linux Server Optional (v. 7)",
+          "product_id": "7Server-optional-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.s390"
+        },
+        "product_reference": "libvirt-debuginfo-0:1.1.1-29.el7_0.4.s390",
+        "relates_to_product_reference": "7Server-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-debuginfo-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux Server Optional (v. 7)",
+          "product_id": "7Server-optional-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-debuginfo-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7Server-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-debuginfo-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux Server Optional (v. 7)",
+          "product_id": "7Server-optional-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-debuginfo-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7Server-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-devel-0:1.1.1-29.el7_0.4.i686 as a component of Red Hat Enterprise Linux Server Optional (v. 7)",
+          "product_id": "7Server-optional-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.i686"
+        },
+        "product_reference": "libvirt-devel-0:1.1.1-29.el7_0.4.i686",
+        "relates_to_product_reference": "7Server-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-devel-0:1.1.1-29.el7_0.4.ppc as a component of Red Hat Enterprise Linux Server Optional (v. 7)",
+          "product_id": "7Server-optional-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.ppc"
+        },
+        "product_reference": "libvirt-devel-0:1.1.1-29.el7_0.4.ppc",
+        "relates_to_product_reference": "7Server-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-devel-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux Server Optional (v. 7)",
+          "product_id": "7Server-optional-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-devel-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7Server-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-devel-0:1.1.1-29.el7_0.4.s390 as a component of Red Hat Enterprise Linux Server Optional (v. 7)",
+          "product_id": "7Server-optional-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.s390"
+        },
+        "product_reference": "libvirt-devel-0:1.1.1-29.el7_0.4.s390",
+        "relates_to_product_reference": "7Server-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-devel-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux Server Optional (v. 7)",
+          "product_id": "7Server-optional-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-devel-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7Server-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-devel-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux Server Optional (v. 7)",
+          "product_id": "7Server-optional-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-devel-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7Server-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-docs-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux Server Optional (v. 7)",
+          "product_id": "7Server-optional-7.0.Z:libvirt-docs-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-docs-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7Server-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-docs-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux Server Optional (v. 7)",
+          "product_id": "7Server-optional-7.0.Z:libvirt-docs-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-docs-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7Server-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-docs-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux Server Optional (v. 7)",
+          "product_id": "7Server-optional-7.0.Z:libvirt-docs-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-docs-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7Server-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-lock-sanlock-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux Server Optional (v. 7)",
+          "product_id": "7Server-optional-7.0.Z:libvirt-lock-sanlock-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-lock-sanlock-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7Server-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-login-shell-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux Server Optional (v. 7)",
+          "product_id": "7Server-optional-7.0.Z:libvirt-login-shell-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-login-shell-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7Server-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-login-shell-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux Server Optional (v. 7)",
+          "product_id": "7Server-optional-7.0.Z:libvirt-login-shell-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-login-shell-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7Server-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-login-shell-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux Server Optional (v. 7)",
+          "product_id": "7Server-optional-7.0.Z:libvirt-login-shell-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-login-shell-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7Server-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-python-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux Server Optional (v. 7)",
+          "product_id": "7Server-optional-7.0.Z:libvirt-python-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-python-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7Server-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-python-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux Server Optional (v. 7)",
+          "product_id": "7Server-optional-7.0.Z:libvirt-python-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-python-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7Server-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-python-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux Server Optional (v. 7)",
+          "product_id": "7Server-optional-7.0.Z:libvirt-python-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-python-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7Server-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux Workstation (v. 7)",
+          "product_id": "7Workstation-7.0.Z:libvirt-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7Workstation-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux Workstation (v. 7)",
+          "product_id": "7Workstation-7.0.Z:libvirt-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7Workstation-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-0:1.1.1-29.el7_0.4.src as a component of Red Hat Enterprise Linux Workstation (v. 7)",
+          "product_id": "7Workstation-7.0.Z:libvirt-0:1.1.1-29.el7_0.4.src"
+        },
+        "product_reference": "libvirt-0:1.1.1-29.el7_0.4.src",
+        "relates_to_product_reference": "7Workstation-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux Workstation (v. 7)",
+          "product_id": "7Workstation-7.0.Z:libvirt-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7Workstation-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-client-0:1.1.1-29.el7_0.4.i686 as a component of Red Hat Enterprise Linux Workstation (v. 7)",
+          "product_id": "7Workstation-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.i686"
+        },
+        "product_reference": "libvirt-client-0:1.1.1-29.el7_0.4.i686",
+        "relates_to_product_reference": "7Workstation-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-client-0:1.1.1-29.el7_0.4.ppc as a component of Red Hat Enterprise Linux Workstation (v. 7)",
+          "product_id": "7Workstation-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.ppc"
+        },
+        "product_reference": "libvirt-client-0:1.1.1-29.el7_0.4.ppc",
+        "relates_to_product_reference": "7Workstation-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-client-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux Workstation (v. 7)",
+          "product_id": "7Workstation-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-client-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7Workstation-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-client-0:1.1.1-29.el7_0.4.s390 as a component of Red Hat Enterprise Linux Workstation (v. 7)",
+          "product_id": "7Workstation-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.s390"
+        },
+        "product_reference": "libvirt-client-0:1.1.1-29.el7_0.4.s390",
+        "relates_to_product_reference": "7Workstation-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-client-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux Workstation (v. 7)",
+          "product_id": "7Workstation-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-client-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7Workstation-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-client-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux Workstation (v. 7)",
+          "product_id": "7Workstation-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-client-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7Workstation-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux Workstation (v. 7)",
+          "product_id": "7Workstation-7.0.Z:libvirt-daemon-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-daemon-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7Workstation-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux Workstation (v. 7)",
+          "product_id": "7Workstation-7.0.Z:libvirt-daemon-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-daemon-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7Workstation-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux Workstation (v. 7)",
+          "product_id": "7Workstation-7.0.Z:libvirt-daemon-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-daemon-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7Workstation-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux Workstation (v. 7)",
+          "product_id": "7Workstation-7.0.Z:libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7Workstation-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux Workstation (v. 7)",
+          "product_id": "7Workstation-7.0.Z:libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7Workstation-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux Workstation (v. 7)",
+          "product_id": "7Workstation-7.0.Z:libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7Workstation-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux Workstation (v. 7)",
+          "product_id": "7Workstation-7.0.Z:libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7Workstation-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux Workstation (v. 7)",
+          "product_id": "7Workstation-7.0.Z:libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7Workstation-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux Workstation (v. 7)",
+          "product_id": "7Workstation-7.0.Z:libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7Workstation-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux Workstation (v. 7)",
+          "product_id": "7Workstation-7.0.Z:libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7Workstation-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux Workstation (v. 7)",
+          "product_id": "7Workstation-7.0.Z:libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7Workstation-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux Workstation (v. 7)",
+          "product_id": "7Workstation-7.0.Z:libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7Workstation-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux Workstation (v. 7)",
+          "product_id": "7Workstation-7.0.Z:libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7Workstation-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux Workstation (v. 7)",
+          "product_id": "7Workstation-7.0.Z:libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7Workstation-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux Workstation (v. 7)",
+          "product_id": "7Workstation-7.0.Z:libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7Workstation-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux Workstation (v. 7)",
+          "product_id": "7Workstation-7.0.Z:libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7Workstation-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux Workstation (v. 7)",
+          "product_id": "7Workstation-7.0.Z:libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7Workstation-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux Workstation (v. 7)",
+          "product_id": "7Workstation-7.0.Z:libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7Workstation-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux Workstation (v. 7)",
+          "product_id": "7Workstation-7.0.Z:libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7Workstation-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux Workstation (v. 7)",
+          "product_id": "7Workstation-7.0.Z:libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7Workstation-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux Workstation (v. 7)",
+          "product_id": "7Workstation-7.0.Z:libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7Workstation-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux Workstation (v. 7)",
+          "product_id": "7Workstation-7.0.Z:libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7Workstation-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux Workstation (v. 7)",
+          "product_id": "7Workstation-7.0.Z:libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7Workstation-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux Workstation (v. 7)",
+          "product_id": "7Workstation-7.0.Z:libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7Workstation-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-qemu-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux Workstation (v. 7)",
+          "product_id": "7Workstation-7.0.Z:libvirt-daemon-driver-qemu-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-daemon-driver-qemu-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7Workstation-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux Workstation (v. 7)",
+          "product_id": "7Workstation-7.0.Z:libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7Workstation-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux Workstation (v. 7)",
+          "product_id": "7Workstation-7.0.Z:libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7Workstation-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux Workstation (v. 7)",
+          "product_id": "7Workstation-7.0.Z:libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7Workstation-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux Workstation (v. 7)",
+          "product_id": "7Workstation-7.0.Z:libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7Workstation-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux Workstation (v. 7)",
+          "product_id": "7Workstation-7.0.Z:libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7Workstation-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux Workstation (v. 7)",
+          "product_id": "7Workstation-7.0.Z:libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7Workstation-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-kvm-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux Workstation (v. 7)",
+          "product_id": "7Workstation-7.0.Z:libvirt-daemon-kvm-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-daemon-kvm-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7Workstation-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux Workstation (v. 7)",
+          "product_id": "7Workstation-7.0.Z:libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7Workstation-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux Workstation (v. 7)",
+          "product_id": "7Workstation-7.0.Z:libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7Workstation-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux Workstation (v. 7)",
+          "product_id": "7Workstation-7.0.Z:libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7Workstation-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-debuginfo-0:1.1.1-29.el7_0.4.i686 as a component of Red Hat Enterprise Linux Workstation (v. 7)",
+          "product_id": "7Workstation-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.i686"
+        },
+        "product_reference": "libvirt-debuginfo-0:1.1.1-29.el7_0.4.i686",
+        "relates_to_product_reference": "7Workstation-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-debuginfo-0:1.1.1-29.el7_0.4.ppc as a component of Red Hat Enterprise Linux Workstation (v. 7)",
+          "product_id": "7Workstation-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.ppc"
+        },
+        "product_reference": "libvirt-debuginfo-0:1.1.1-29.el7_0.4.ppc",
+        "relates_to_product_reference": "7Workstation-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-debuginfo-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux Workstation (v. 7)",
+          "product_id": "7Workstation-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-debuginfo-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7Workstation-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-debuginfo-0:1.1.1-29.el7_0.4.s390 as a component of Red Hat Enterprise Linux Workstation (v. 7)",
+          "product_id": "7Workstation-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.s390"
+        },
+        "product_reference": "libvirt-debuginfo-0:1.1.1-29.el7_0.4.s390",
+        "relates_to_product_reference": "7Workstation-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-debuginfo-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux Workstation (v. 7)",
+          "product_id": "7Workstation-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-debuginfo-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7Workstation-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-debuginfo-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux Workstation (v. 7)",
+          "product_id": "7Workstation-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-debuginfo-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7Workstation-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-devel-0:1.1.1-29.el7_0.4.i686 as a component of Red Hat Enterprise Linux Workstation (v. 7)",
+          "product_id": "7Workstation-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.i686"
+        },
+        "product_reference": "libvirt-devel-0:1.1.1-29.el7_0.4.i686",
+        "relates_to_product_reference": "7Workstation-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-devel-0:1.1.1-29.el7_0.4.ppc as a component of Red Hat Enterprise Linux Workstation (v. 7)",
+          "product_id": "7Workstation-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.ppc"
+        },
+        "product_reference": "libvirt-devel-0:1.1.1-29.el7_0.4.ppc",
+        "relates_to_product_reference": "7Workstation-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-devel-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux Workstation (v. 7)",
+          "product_id": "7Workstation-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-devel-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7Workstation-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-devel-0:1.1.1-29.el7_0.4.s390 as a component of Red Hat Enterprise Linux Workstation (v. 7)",
+          "product_id": "7Workstation-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.s390"
+        },
+        "product_reference": "libvirt-devel-0:1.1.1-29.el7_0.4.s390",
+        "relates_to_product_reference": "7Workstation-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-devel-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux Workstation (v. 7)",
+          "product_id": "7Workstation-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-devel-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7Workstation-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-devel-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux Workstation (v. 7)",
+          "product_id": "7Workstation-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-devel-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7Workstation-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-docs-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux Workstation (v. 7)",
+          "product_id": "7Workstation-7.0.Z:libvirt-docs-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-docs-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7Workstation-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-docs-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux Workstation (v. 7)",
+          "product_id": "7Workstation-7.0.Z:libvirt-docs-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-docs-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7Workstation-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-docs-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux Workstation (v. 7)",
+          "product_id": "7Workstation-7.0.Z:libvirt-docs-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-docs-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7Workstation-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-lock-sanlock-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux Workstation (v. 7)",
+          "product_id": "7Workstation-7.0.Z:libvirt-lock-sanlock-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-lock-sanlock-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7Workstation-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-login-shell-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux Workstation (v. 7)",
+          "product_id": "7Workstation-7.0.Z:libvirt-login-shell-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-login-shell-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7Workstation-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-login-shell-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux Workstation (v. 7)",
+          "product_id": "7Workstation-7.0.Z:libvirt-login-shell-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-login-shell-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7Workstation-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-login-shell-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux Workstation (v. 7)",
+          "product_id": "7Workstation-7.0.Z:libvirt-login-shell-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-login-shell-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7Workstation-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-python-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux Workstation (v. 7)",
+          "product_id": "7Workstation-7.0.Z:libvirt-python-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-python-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7Workstation-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-python-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux Workstation (v. 7)",
+          "product_id": "7Workstation-7.0.Z:libvirt-python-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-python-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7Workstation-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-python-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux Workstation (v. 7)",
+          "product_id": "7Workstation-7.0.Z:libvirt-python-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-python-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7Workstation-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux Workstation Optional (v. 7)",
+          "product_id": "7Workstation-optional-7.0.Z:libvirt-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7Workstation-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux Workstation Optional (v. 7)",
+          "product_id": "7Workstation-optional-7.0.Z:libvirt-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7Workstation-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-0:1.1.1-29.el7_0.4.src as a component of Red Hat Enterprise Linux Workstation Optional (v. 7)",
+          "product_id": "7Workstation-optional-7.0.Z:libvirt-0:1.1.1-29.el7_0.4.src"
+        },
+        "product_reference": "libvirt-0:1.1.1-29.el7_0.4.src",
+        "relates_to_product_reference": "7Workstation-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux Workstation Optional (v. 7)",
+          "product_id": "7Workstation-optional-7.0.Z:libvirt-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7Workstation-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-client-0:1.1.1-29.el7_0.4.i686 as a component of Red Hat Enterprise Linux Workstation Optional (v. 7)",
+          "product_id": "7Workstation-optional-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.i686"
+        },
+        "product_reference": "libvirt-client-0:1.1.1-29.el7_0.4.i686",
+        "relates_to_product_reference": "7Workstation-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-client-0:1.1.1-29.el7_0.4.ppc as a component of Red Hat Enterprise Linux Workstation Optional (v. 7)",
+          "product_id": "7Workstation-optional-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.ppc"
+        },
+        "product_reference": "libvirt-client-0:1.1.1-29.el7_0.4.ppc",
+        "relates_to_product_reference": "7Workstation-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-client-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux Workstation Optional (v. 7)",
+          "product_id": "7Workstation-optional-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-client-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7Workstation-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-client-0:1.1.1-29.el7_0.4.s390 as a component of Red Hat Enterprise Linux Workstation Optional (v. 7)",
+          "product_id": "7Workstation-optional-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.s390"
+        },
+        "product_reference": "libvirt-client-0:1.1.1-29.el7_0.4.s390",
+        "relates_to_product_reference": "7Workstation-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-client-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux Workstation Optional (v. 7)",
+          "product_id": "7Workstation-optional-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-client-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7Workstation-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-client-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux Workstation Optional (v. 7)",
+          "product_id": "7Workstation-optional-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-client-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7Workstation-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux Workstation Optional (v. 7)",
+          "product_id": "7Workstation-optional-7.0.Z:libvirt-daemon-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-daemon-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7Workstation-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux Workstation Optional (v. 7)",
+          "product_id": "7Workstation-optional-7.0.Z:libvirt-daemon-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-daemon-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7Workstation-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux Workstation Optional (v. 7)",
+          "product_id": "7Workstation-optional-7.0.Z:libvirt-daemon-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-daemon-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7Workstation-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux Workstation Optional (v. 7)",
+          "product_id": "7Workstation-optional-7.0.Z:libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7Workstation-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux Workstation Optional (v. 7)",
+          "product_id": "7Workstation-optional-7.0.Z:libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7Workstation-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux Workstation Optional (v. 7)",
+          "product_id": "7Workstation-optional-7.0.Z:libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7Workstation-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux Workstation Optional (v. 7)",
+          "product_id": "7Workstation-optional-7.0.Z:libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7Workstation-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux Workstation Optional (v. 7)",
+          "product_id": "7Workstation-optional-7.0.Z:libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7Workstation-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux Workstation Optional (v. 7)",
+          "product_id": "7Workstation-optional-7.0.Z:libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7Workstation-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux Workstation Optional (v. 7)",
+          "product_id": "7Workstation-optional-7.0.Z:libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7Workstation-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux Workstation Optional (v. 7)",
+          "product_id": "7Workstation-optional-7.0.Z:libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7Workstation-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux Workstation Optional (v. 7)",
+          "product_id": "7Workstation-optional-7.0.Z:libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7Workstation-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux Workstation Optional (v. 7)",
+          "product_id": "7Workstation-optional-7.0.Z:libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7Workstation-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux Workstation Optional (v. 7)",
+          "product_id": "7Workstation-optional-7.0.Z:libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7Workstation-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux Workstation Optional (v. 7)",
+          "product_id": "7Workstation-optional-7.0.Z:libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7Workstation-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux Workstation Optional (v. 7)",
+          "product_id": "7Workstation-optional-7.0.Z:libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7Workstation-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux Workstation Optional (v. 7)",
+          "product_id": "7Workstation-optional-7.0.Z:libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7Workstation-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux Workstation Optional (v. 7)",
+          "product_id": "7Workstation-optional-7.0.Z:libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7Workstation-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux Workstation Optional (v. 7)",
+          "product_id": "7Workstation-optional-7.0.Z:libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7Workstation-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux Workstation Optional (v. 7)",
+          "product_id": "7Workstation-optional-7.0.Z:libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7Workstation-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux Workstation Optional (v. 7)",
+          "product_id": "7Workstation-optional-7.0.Z:libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7Workstation-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux Workstation Optional (v. 7)",
+          "product_id": "7Workstation-optional-7.0.Z:libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7Workstation-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux Workstation Optional (v. 7)",
+          "product_id": "7Workstation-optional-7.0.Z:libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7Workstation-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux Workstation Optional (v. 7)",
+          "product_id": "7Workstation-optional-7.0.Z:libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7Workstation-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-qemu-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux Workstation Optional (v. 7)",
+          "product_id": "7Workstation-optional-7.0.Z:libvirt-daemon-driver-qemu-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-daemon-driver-qemu-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7Workstation-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux Workstation Optional (v. 7)",
+          "product_id": "7Workstation-optional-7.0.Z:libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7Workstation-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux Workstation Optional (v. 7)",
+          "product_id": "7Workstation-optional-7.0.Z:libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7Workstation-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux Workstation Optional (v. 7)",
+          "product_id": "7Workstation-optional-7.0.Z:libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7Workstation-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux Workstation Optional (v. 7)",
+          "product_id": "7Workstation-optional-7.0.Z:libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7Workstation-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux Workstation Optional (v. 7)",
+          "product_id": "7Workstation-optional-7.0.Z:libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7Workstation-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux Workstation Optional (v. 7)",
+          "product_id": "7Workstation-optional-7.0.Z:libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7Workstation-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-kvm-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux Workstation Optional (v. 7)",
+          "product_id": "7Workstation-optional-7.0.Z:libvirt-daemon-kvm-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-daemon-kvm-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7Workstation-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux Workstation Optional (v. 7)",
+          "product_id": "7Workstation-optional-7.0.Z:libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7Workstation-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux Workstation Optional (v. 7)",
+          "product_id": "7Workstation-optional-7.0.Z:libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7Workstation-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux Workstation Optional (v. 7)",
+          "product_id": "7Workstation-optional-7.0.Z:libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7Workstation-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-debuginfo-0:1.1.1-29.el7_0.4.i686 as a component of Red Hat Enterprise Linux Workstation Optional (v. 7)",
+          "product_id": "7Workstation-optional-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.i686"
+        },
+        "product_reference": "libvirt-debuginfo-0:1.1.1-29.el7_0.4.i686",
+        "relates_to_product_reference": "7Workstation-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-debuginfo-0:1.1.1-29.el7_0.4.ppc as a component of Red Hat Enterprise Linux Workstation Optional (v. 7)",
+          "product_id": "7Workstation-optional-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.ppc"
+        },
+        "product_reference": "libvirt-debuginfo-0:1.1.1-29.el7_0.4.ppc",
+        "relates_to_product_reference": "7Workstation-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-debuginfo-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux Workstation Optional (v. 7)",
+          "product_id": "7Workstation-optional-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-debuginfo-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7Workstation-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-debuginfo-0:1.1.1-29.el7_0.4.s390 as a component of Red Hat Enterprise Linux Workstation Optional (v. 7)",
+          "product_id": "7Workstation-optional-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.s390"
+        },
+        "product_reference": "libvirt-debuginfo-0:1.1.1-29.el7_0.4.s390",
+        "relates_to_product_reference": "7Workstation-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-debuginfo-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux Workstation Optional (v. 7)",
+          "product_id": "7Workstation-optional-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-debuginfo-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7Workstation-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-debuginfo-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux Workstation Optional (v. 7)",
+          "product_id": "7Workstation-optional-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-debuginfo-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7Workstation-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-devel-0:1.1.1-29.el7_0.4.i686 as a component of Red Hat Enterprise Linux Workstation Optional (v. 7)",
+          "product_id": "7Workstation-optional-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.i686"
+        },
+        "product_reference": "libvirt-devel-0:1.1.1-29.el7_0.4.i686",
+        "relates_to_product_reference": "7Workstation-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-devel-0:1.1.1-29.el7_0.4.ppc as a component of Red Hat Enterprise Linux Workstation Optional (v. 7)",
+          "product_id": "7Workstation-optional-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.ppc"
+        },
+        "product_reference": "libvirt-devel-0:1.1.1-29.el7_0.4.ppc",
+        "relates_to_product_reference": "7Workstation-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-devel-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux Workstation Optional (v. 7)",
+          "product_id": "7Workstation-optional-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-devel-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7Workstation-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-devel-0:1.1.1-29.el7_0.4.s390 as a component of Red Hat Enterprise Linux Workstation Optional (v. 7)",
+          "product_id": "7Workstation-optional-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.s390"
+        },
+        "product_reference": "libvirt-devel-0:1.1.1-29.el7_0.4.s390",
+        "relates_to_product_reference": "7Workstation-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-devel-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux Workstation Optional (v. 7)",
+          "product_id": "7Workstation-optional-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-devel-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7Workstation-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-devel-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux Workstation Optional (v. 7)",
+          "product_id": "7Workstation-optional-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-devel-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7Workstation-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-docs-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux Workstation Optional (v. 7)",
+          "product_id": "7Workstation-optional-7.0.Z:libvirt-docs-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-docs-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7Workstation-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-docs-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux Workstation Optional (v. 7)",
+          "product_id": "7Workstation-optional-7.0.Z:libvirt-docs-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-docs-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7Workstation-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-docs-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux Workstation Optional (v. 7)",
+          "product_id": "7Workstation-optional-7.0.Z:libvirt-docs-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-docs-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7Workstation-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-lock-sanlock-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux Workstation Optional (v. 7)",
+          "product_id": "7Workstation-optional-7.0.Z:libvirt-lock-sanlock-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-lock-sanlock-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7Workstation-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-login-shell-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux Workstation Optional (v. 7)",
+          "product_id": "7Workstation-optional-7.0.Z:libvirt-login-shell-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-login-shell-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7Workstation-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-login-shell-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux Workstation Optional (v. 7)",
+          "product_id": "7Workstation-optional-7.0.Z:libvirt-login-shell-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-login-shell-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7Workstation-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-login-shell-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux Workstation Optional (v. 7)",
+          "product_id": "7Workstation-optional-7.0.Z:libvirt-login-shell-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-login-shell-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7Workstation-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-python-0:1.1.1-29.el7_0.4.ppc64 as a component of Red Hat Enterprise Linux Workstation Optional (v. 7)",
+          "product_id": "7Workstation-optional-7.0.Z:libvirt-python-0:1.1.1-29.el7_0.4.ppc64"
+        },
+        "product_reference": "libvirt-python-0:1.1.1-29.el7_0.4.ppc64",
+        "relates_to_product_reference": "7Workstation-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-python-0:1.1.1-29.el7_0.4.s390x as a component of Red Hat Enterprise Linux Workstation Optional (v. 7)",
+          "product_id": "7Workstation-optional-7.0.Z:libvirt-python-0:1.1.1-29.el7_0.4.s390x"
+        },
+        "product_reference": "libvirt-python-0:1.1.1-29.el7_0.4.s390x",
+        "relates_to_product_reference": "7Workstation-optional-7.0.Z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "libvirt-python-0:1.1.1-29.el7_0.4.x86_64 as a component of Red Hat Enterprise Linux Workstation Optional (v. 7)",
+          "product_id": "7Workstation-optional-7.0.Z:libvirt-python-0:1.1.1-29.el7_0.4.x86_64"
+        },
+        "product_reference": "libvirt-python-0:1.1.1-29.el7_0.4.x86_64",
+        "relates_to_product_reference": "7Workstation-optional-7.0.Z"
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "acknowledgments": [
+        {
+          "names": [
+            "Eric Blake"
+          ],
+          "organization": "Red Hat",
+          "summary": "This issue was discovered by Red Hat."
+        }
+      ],
+      "cve": "CVE-2014-7823",
+      "discovery_date": "2014-10-30T00:00:00+00:00",
+      "ids": [
+        {
+          "system_name": "Red Hat Bugzilla ID",
+          "text": "1160817"
+        }
+      ],
+      "notes": [
+        {
+          "category": "description",
+          "text": "It was found that when the VIR_DOMAIN_XML_MIGRATABLE flag was used, the QEMU driver implementation of the virDomainGetXMLDesc() function could bypass the restrictions of the VIR_DOMAIN_XML_SECURE flag. A remote attacker able to establish a read-only connection to libvirtd could use this flaw to leak certain limited information from the domain XML data.",
+          "title": "Vulnerability description"
+        },
+        {
+          "category": "summary",
+          "text": "libvirt: dumpxml: information leak with migratable flag",
+          "title": "Vulnerability summary"
+        },
+        {
+          "category": "other",
+          "text": "This issue does not affect the versions of libvirt packages as shipped with\nRed Hat Enterprise Linux 5.\n\nThis issue does affect the versions of libvirt packages as shipped with Red Hat\nEnterprise Linux 6 and 7. Future updates may address this issue in the\nrespective Red Hat Enterprise Linux releases.",
+          "title": "Statement"
+        },
+        {
+          "category": "general",
+          "text": "The CVSS score(s) listed for this vulnerability do not reflect the associated product's status, and are included for informational purposes to better understand the severity of this vulnerability.",
+          "title": "CVSS score applicability"
+        }
+      ],
+      "product_status": {
+        "fixed": [
+          "7Client-7.0.Z:libvirt-0:1.1.1-29.el7_0.4.ppc64",
+          "7Client-7.0.Z:libvirt-0:1.1.1-29.el7_0.4.s390x",
+          "7Client-7.0.Z:libvirt-0:1.1.1-29.el7_0.4.src",
+          "7Client-7.0.Z:libvirt-0:1.1.1-29.el7_0.4.x86_64",
+          "7Client-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.i686",
+          "7Client-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.ppc",
+          "7Client-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.ppc64",
+          "7Client-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.s390",
+          "7Client-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.s390x",
+          "7Client-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.x86_64",
+          "7Client-7.0.Z:libvirt-daemon-0:1.1.1-29.el7_0.4.ppc64",
+          "7Client-7.0.Z:libvirt-daemon-0:1.1.1-29.el7_0.4.s390x",
+          "7Client-7.0.Z:libvirt-daemon-0:1.1.1-29.el7_0.4.x86_64",
+          "7Client-7.0.Z:libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.ppc64",
+          "7Client-7.0.Z:libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.s390x",
+          "7Client-7.0.Z:libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.x86_64",
+          "7Client-7.0.Z:libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.ppc64",
+          "7Client-7.0.Z:libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.s390x",
+          "7Client-7.0.Z:libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.x86_64",
+          "7Client-7.0.Z:libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.ppc64",
+          "7Client-7.0.Z:libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.s390x",
+          "7Client-7.0.Z:libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.x86_64",
+          "7Client-7.0.Z:libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.ppc64",
+          "7Client-7.0.Z:libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.s390x",
+          "7Client-7.0.Z:libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.x86_64",
+          "7Client-7.0.Z:libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.ppc64",
+          "7Client-7.0.Z:libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.s390x",
+          "7Client-7.0.Z:libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.x86_64",
+          "7Client-7.0.Z:libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.ppc64",
+          "7Client-7.0.Z:libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.s390x",
+          "7Client-7.0.Z:libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.x86_64",
+          "7Client-7.0.Z:libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.ppc64",
+          "7Client-7.0.Z:libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.s390x",
+          "7Client-7.0.Z:libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.x86_64",
+          "7Client-7.0.Z:libvirt-daemon-driver-qemu-0:1.1.1-29.el7_0.4.x86_64",
+          "7Client-7.0.Z:libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.ppc64",
+          "7Client-7.0.Z:libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.s390x",
+          "7Client-7.0.Z:libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.x86_64",
+          "7Client-7.0.Z:libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.ppc64",
+          "7Client-7.0.Z:libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.s390x",
+          "7Client-7.0.Z:libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.x86_64",
+          "7Client-7.0.Z:libvirt-daemon-kvm-0:1.1.1-29.el7_0.4.x86_64",
+          "7Client-7.0.Z:libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.ppc64",
+          "7Client-7.0.Z:libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.s390x",
+          "7Client-7.0.Z:libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.x86_64",
+          "7Client-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.i686",
+          "7Client-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.ppc",
+          "7Client-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.ppc64",
+          "7Client-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.s390",
+          "7Client-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.s390x",
+          "7Client-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.x86_64",
+          "7Client-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.i686",
+          "7Client-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.ppc",
+          "7Client-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.ppc64",
+          "7Client-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.s390",
+          "7Client-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.s390x",
+          "7Client-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.x86_64",
+          "7Client-7.0.Z:libvirt-docs-0:1.1.1-29.el7_0.4.ppc64",
+          "7Client-7.0.Z:libvirt-docs-0:1.1.1-29.el7_0.4.s390x",
+          "7Client-7.0.Z:libvirt-docs-0:1.1.1-29.el7_0.4.x86_64",
+          "7Client-7.0.Z:libvirt-lock-sanlock-0:1.1.1-29.el7_0.4.x86_64",
+          "7Client-7.0.Z:libvirt-login-shell-0:1.1.1-29.el7_0.4.ppc64",
+          "7Client-7.0.Z:libvirt-login-shell-0:1.1.1-29.el7_0.4.s390x",
+          "7Client-7.0.Z:libvirt-login-shell-0:1.1.1-29.el7_0.4.x86_64",
+          "7Client-7.0.Z:libvirt-python-0:1.1.1-29.el7_0.4.ppc64",
+          "7Client-7.0.Z:libvirt-python-0:1.1.1-29.el7_0.4.s390x",
+          "7Client-7.0.Z:libvirt-python-0:1.1.1-29.el7_0.4.x86_64",
+          "7Client-optional-7.0.Z:libvirt-0:1.1.1-29.el7_0.4.ppc64",
+          "7Client-optional-7.0.Z:libvirt-0:1.1.1-29.el7_0.4.s390x",
+          "7Client-optional-7.0.Z:libvirt-0:1.1.1-29.el7_0.4.src",
+          "7Client-optional-7.0.Z:libvirt-0:1.1.1-29.el7_0.4.x86_64",
+          "7Client-optional-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.i686",
+          "7Client-optional-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.ppc",
+          "7Client-optional-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.ppc64",
+          "7Client-optional-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.s390",
+          "7Client-optional-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.s390x",
+          "7Client-optional-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.x86_64",
+          "7Client-optional-7.0.Z:libvirt-daemon-0:1.1.1-29.el7_0.4.ppc64",
+          "7Client-optional-7.0.Z:libvirt-daemon-0:1.1.1-29.el7_0.4.s390x",
+          "7Client-optional-7.0.Z:libvirt-daemon-0:1.1.1-29.el7_0.4.x86_64",
+          "7Client-optional-7.0.Z:libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.ppc64",
+          "7Client-optional-7.0.Z:libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.s390x",
+          "7Client-optional-7.0.Z:libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.x86_64",
+          "7Client-optional-7.0.Z:libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.ppc64",
+          "7Client-optional-7.0.Z:libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.s390x",
+          "7Client-optional-7.0.Z:libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.x86_64",
+          "7Client-optional-7.0.Z:libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.ppc64",
+          "7Client-optional-7.0.Z:libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.s390x",
+          "7Client-optional-7.0.Z:libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.x86_64",
+          "7Client-optional-7.0.Z:libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.ppc64",
+          "7Client-optional-7.0.Z:libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.s390x",
+          "7Client-optional-7.0.Z:libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.x86_64",
+          "7Client-optional-7.0.Z:libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.ppc64",
+          "7Client-optional-7.0.Z:libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.s390x",
+          "7Client-optional-7.0.Z:libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.x86_64",
+          "7Client-optional-7.0.Z:libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.ppc64",
+          "7Client-optional-7.0.Z:libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.s390x",
+          "7Client-optional-7.0.Z:libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.x86_64",
+          "7Client-optional-7.0.Z:libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.ppc64",
+          "7Client-optional-7.0.Z:libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.s390x",
+          "7Client-optional-7.0.Z:libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.x86_64",
+          "7Client-optional-7.0.Z:libvirt-daemon-driver-qemu-0:1.1.1-29.el7_0.4.x86_64",
+          "7Client-optional-7.0.Z:libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.ppc64",
+          "7Client-optional-7.0.Z:libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.s390x",
+          "7Client-optional-7.0.Z:libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.x86_64",
+          "7Client-optional-7.0.Z:libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.ppc64",
+          "7Client-optional-7.0.Z:libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.s390x",
+          "7Client-optional-7.0.Z:libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.x86_64",
+          "7Client-optional-7.0.Z:libvirt-daemon-kvm-0:1.1.1-29.el7_0.4.x86_64",
+          "7Client-optional-7.0.Z:libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.ppc64",
+          "7Client-optional-7.0.Z:libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.s390x",
+          "7Client-optional-7.0.Z:libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.x86_64",
+          "7Client-optional-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.i686",
+          "7Client-optional-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.ppc",
+          "7Client-optional-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.ppc64",
+          "7Client-optional-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.s390",
+          "7Client-optional-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.s390x",
+          "7Client-optional-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.x86_64",
+          "7Client-optional-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.i686",
+          "7Client-optional-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.ppc",
+          "7Client-optional-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.ppc64",
+          "7Client-optional-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.s390",
+          "7Client-optional-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.s390x",
+          "7Client-optional-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.x86_64",
+          "7Client-optional-7.0.Z:libvirt-docs-0:1.1.1-29.el7_0.4.ppc64",
+          "7Client-optional-7.0.Z:libvirt-docs-0:1.1.1-29.el7_0.4.s390x",
+          "7Client-optional-7.0.Z:libvirt-docs-0:1.1.1-29.el7_0.4.x86_64",
+          "7Client-optional-7.0.Z:libvirt-lock-sanlock-0:1.1.1-29.el7_0.4.x86_64",
+          "7Client-optional-7.0.Z:libvirt-login-shell-0:1.1.1-29.el7_0.4.ppc64",
+          "7Client-optional-7.0.Z:libvirt-login-shell-0:1.1.1-29.el7_0.4.s390x",
+          "7Client-optional-7.0.Z:libvirt-login-shell-0:1.1.1-29.el7_0.4.x86_64",
+          "7Client-optional-7.0.Z:libvirt-python-0:1.1.1-29.el7_0.4.ppc64",
+          "7Client-optional-7.0.Z:libvirt-python-0:1.1.1-29.el7_0.4.s390x",
+          "7Client-optional-7.0.Z:libvirt-python-0:1.1.1-29.el7_0.4.x86_64",
+          "7ComputeNode-7.0.Z:libvirt-0:1.1.1-29.el7_0.4.ppc64",
+          "7ComputeNode-7.0.Z:libvirt-0:1.1.1-29.el7_0.4.s390x",
+          "7ComputeNode-7.0.Z:libvirt-0:1.1.1-29.el7_0.4.src",
+          "7ComputeNode-7.0.Z:libvirt-0:1.1.1-29.el7_0.4.x86_64",
+          "7ComputeNode-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.i686",
+          "7ComputeNode-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.ppc",
+          "7ComputeNode-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.ppc64",
+          "7ComputeNode-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.s390",
+          "7ComputeNode-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.s390x",
+          "7ComputeNode-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.x86_64",
+          "7ComputeNode-7.0.Z:libvirt-daemon-0:1.1.1-29.el7_0.4.ppc64",
+          "7ComputeNode-7.0.Z:libvirt-daemon-0:1.1.1-29.el7_0.4.s390x",
+          "7ComputeNode-7.0.Z:libvirt-daemon-0:1.1.1-29.el7_0.4.x86_64",
+          "7ComputeNode-7.0.Z:libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.ppc64",
+          "7ComputeNode-7.0.Z:libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.s390x",
+          "7ComputeNode-7.0.Z:libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.x86_64",
+          "7ComputeNode-7.0.Z:libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.ppc64",
+          "7ComputeNode-7.0.Z:libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.s390x",
+          "7ComputeNode-7.0.Z:libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.x86_64",
+          "7ComputeNode-7.0.Z:libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.ppc64",
+          "7ComputeNode-7.0.Z:libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.s390x",
+          "7ComputeNode-7.0.Z:libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.x86_64",
+          "7ComputeNode-7.0.Z:libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.ppc64",
+          "7ComputeNode-7.0.Z:libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.s390x",
+          "7ComputeNode-7.0.Z:libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.x86_64",
+          "7ComputeNode-7.0.Z:libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.ppc64",
+          "7ComputeNode-7.0.Z:libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.s390x",
+          "7ComputeNode-7.0.Z:libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.x86_64",
+          "7ComputeNode-7.0.Z:libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.ppc64",
+          "7ComputeNode-7.0.Z:libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.s390x",
+          "7ComputeNode-7.0.Z:libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.x86_64",
+          "7ComputeNode-7.0.Z:libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.ppc64",
+          "7ComputeNode-7.0.Z:libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.s390x",
+          "7ComputeNode-7.0.Z:libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.x86_64",
+          "7ComputeNode-7.0.Z:libvirt-daemon-driver-qemu-0:1.1.1-29.el7_0.4.x86_64",
+          "7ComputeNode-7.0.Z:libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.ppc64",
+          "7ComputeNode-7.0.Z:libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.s390x",
+          "7ComputeNode-7.0.Z:libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.x86_64",
+          "7ComputeNode-7.0.Z:libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.ppc64",
+          "7ComputeNode-7.0.Z:libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.s390x",
+          "7ComputeNode-7.0.Z:libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.x86_64",
+          "7ComputeNode-7.0.Z:libvirt-daemon-kvm-0:1.1.1-29.el7_0.4.x86_64",
+          "7ComputeNode-7.0.Z:libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.ppc64",
+          "7ComputeNode-7.0.Z:libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.s390x",
+          "7ComputeNode-7.0.Z:libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.x86_64",
+          "7ComputeNode-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.i686",
+          "7ComputeNode-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.ppc",
+          "7ComputeNode-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.ppc64",
+          "7ComputeNode-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.s390",
+          "7ComputeNode-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.s390x",
+          "7ComputeNode-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.x86_64",
+          "7ComputeNode-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.i686",
+          "7ComputeNode-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.ppc",
+          "7ComputeNode-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.ppc64",
+          "7ComputeNode-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.s390",
+          "7ComputeNode-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.s390x",
+          "7ComputeNode-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.x86_64",
+          "7ComputeNode-7.0.Z:libvirt-docs-0:1.1.1-29.el7_0.4.ppc64",
+          "7ComputeNode-7.0.Z:libvirt-docs-0:1.1.1-29.el7_0.4.s390x",
+          "7ComputeNode-7.0.Z:libvirt-docs-0:1.1.1-29.el7_0.4.x86_64",
+          "7ComputeNode-7.0.Z:libvirt-lock-sanlock-0:1.1.1-29.el7_0.4.x86_64",
+          "7ComputeNode-7.0.Z:libvirt-login-shell-0:1.1.1-29.el7_0.4.ppc64",
+          "7ComputeNode-7.0.Z:libvirt-login-shell-0:1.1.1-29.el7_0.4.s390x",
+          "7ComputeNode-7.0.Z:libvirt-login-shell-0:1.1.1-29.el7_0.4.x86_64",
+          "7ComputeNode-7.0.Z:libvirt-python-0:1.1.1-29.el7_0.4.ppc64",
+          "7ComputeNode-7.0.Z:libvirt-python-0:1.1.1-29.el7_0.4.s390x",
+          "7ComputeNode-7.0.Z:libvirt-python-0:1.1.1-29.el7_0.4.x86_64",
+          "7ComputeNode-optional-7.0.Z:libvirt-0:1.1.1-29.el7_0.4.ppc64",
+          "7ComputeNode-optional-7.0.Z:libvirt-0:1.1.1-29.el7_0.4.s390x",
+          "7ComputeNode-optional-7.0.Z:libvirt-0:1.1.1-29.el7_0.4.src",
+          "7ComputeNode-optional-7.0.Z:libvirt-0:1.1.1-29.el7_0.4.x86_64",
+          "7ComputeNode-optional-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.i686",
+          "7ComputeNode-optional-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.ppc",
+          "7ComputeNode-optional-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.ppc64",
+          "7ComputeNode-optional-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.s390",
+          "7ComputeNode-optional-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.s390x",
+          "7ComputeNode-optional-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.x86_64",
+          "7ComputeNode-optional-7.0.Z:libvirt-daemon-0:1.1.1-29.el7_0.4.ppc64",
+          "7ComputeNode-optional-7.0.Z:libvirt-daemon-0:1.1.1-29.el7_0.4.s390x",
+          "7ComputeNode-optional-7.0.Z:libvirt-daemon-0:1.1.1-29.el7_0.4.x86_64",
+          "7ComputeNode-optional-7.0.Z:libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.ppc64",
+          "7ComputeNode-optional-7.0.Z:libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.s390x",
+          "7ComputeNode-optional-7.0.Z:libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.x86_64",
+          "7ComputeNode-optional-7.0.Z:libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.ppc64",
+          "7ComputeNode-optional-7.0.Z:libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.s390x",
+          "7ComputeNode-optional-7.0.Z:libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.x86_64",
+          "7ComputeNode-optional-7.0.Z:libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.ppc64",
+          "7ComputeNode-optional-7.0.Z:libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.s390x",
+          "7ComputeNode-optional-7.0.Z:libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.x86_64",
+          "7ComputeNode-optional-7.0.Z:libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.ppc64",
+          "7ComputeNode-optional-7.0.Z:libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.s390x",
+          "7ComputeNode-optional-7.0.Z:libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.x86_64",
+          "7ComputeNode-optional-7.0.Z:libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.ppc64",
+          "7ComputeNode-optional-7.0.Z:libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.s390x",
+          "7ComputeNode-optional-7.0.Z:libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.x86_64",
+          "7ComputeNode-optional-7.0.Z:libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.ppc64",
+          "7ComputeNode-optional-7.0.Z:libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.s390x",
+          "7ComputeNode-optional-7.0.Z:libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.x86_64",
+          "7ComputeNode-optional-7.0.Z:libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.ppc64",
+          "7ComputeNode-optional-7.0.Z:libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.s390x",
+          "7ComputeNode-optional-7.0.Z:libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.x86_64",
+          "7ComputeNode-optional-7.0.Z:libvirt-daemon-driver-qemu-0:1.1.1-29.el7_0.4.x86_64",
+          "7ComputeNode-optional-7.0.Z:libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.ppc64",
+          "7ComputeNode-optional-7.0.Z:libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.s390x",
+          "7ComputeNode-optional-7.0.Z:libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.x86_64",
+          "7ComputeNode-optional-7.0.Z:libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.ppc64",
+          "7ComputeNode-optional-7.0.Z:libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.s390x",
+          "7ComputeNode-optional-7.0.Z:libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.x86_64",
+          "7ComputeNode-optional-7.0.Z:libvirt-daemon-kvm-0:1.1.1-29.el7_0.4.x86_64",
+          "7ComputeNode-optional-7.0.Z:libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.ppc64",
+          "7ComputeNode-optional-7.0.Z:libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.s390x",
+          "7ComputeNode-optional-7.0.Z:libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.x86_64",
+          "7ComputeNode-optional-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.i686",
+          "7ComputeNode-optional-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.ppc",
+          "7ComputeNode-optional-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.ppc64",
+          "7ComputeNode-optional-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.s390",
+          "7ComputeNode-optional-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.s390x",
+          "7ComputeNode-optional-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.x86_64",
+          "7ComputeNode-optional-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.i686",
+          "7ComputeNode-optional-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.ppc",
+          "7ComputeNode-optional-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.ppc64",
+          "7ComputeNode-optional-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.s390",
+          "7ComputeNode-optional-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.s390x",
+          "7ComputeNode-optional-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.x86_64",
+          "7ComputeNode-optional-7.0.Z:libvirt-docs-0:1.1.1-29.el7_0.4.ppc64",
+          "7ComputeNode-optional-7.0.Z:libvirt-docs-0:1.1.1-29.el7_0.4.s390x",
+          "7ComputeNode-optional-7.0.Z:libvirt-docs-0:1.1.1-29.el7_0.4.x86_64",
+          "7ComputeNode-optional-7.0.Z:libvirt-lock-sanlock-0:1.1.1-29.el7_0.4.x86_64",
+          "7ComputeNode-optional-7.0.Z:libvirt-login-shell-0:1.1.1-29.el7_0.4.ppc64",
+          "7ComputeNode-optional-7.0.Z:libvirt-login-shell-0:1.1.1-29.el7_0.4.s390x",
+          "7ComputeNode-optional-7.0.Z:libvirt-login-shell-0:1.1.1-29.el7_0.4.x86_64",
+          "7ComputeNode-optional-7.0.Z:libvirt-python-0:1.1.1-29.el7_0.4.ppc64",
+          "7ComputeNode-optional-7.0.Z:libvirt-python-0:1.1.1-29.el7_0.4.s390x",
+          "7ComputeNode-optional-7.0.Z:libvirt-python-0:1.1.1-29.el7_0.4.x86_64",
+          "7Server-7.0.Z:libvirt-0:1.1.1-29.el7_0.4.ppc64",
+          "7Server-7.0.Z:libvirt-0:1.1.1-29.el7_0.4.s390x",
+          "7Server-7.0.Z:libvirt-0:1.1.1-29.el7_0.4.src",
+          "7Server-7.0.Z:libvirt-0:1.1.1-29.el7_0.4.x86_64",
+          "7Server-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.i686",
+          "7Server-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.ppc",
+          "7Server-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.ppc64",
+          "7Server-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.s390",
+          "7Server-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.s390x",
+          "7Server-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.x86_64",
+          "7Server-7.0.Z:libvirt-daemon-0:1.1.1-29.el7_0.4.ppc64",
+          "7Server-7.0.Z:libvirt-daemon-0:1.1.1-29.el7_0.4.s390x",
+          "7Server-7.0.Z:libvirt-daemon-0:1.1.1-29.el7_0.4.x86_64",
+          "7Server-7.0.Z:libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.ppc64",
+          "7Server-7.0.Z:libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.s390x",
+          "7Server-7.0.Z:libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.x86_64",
+          "7Server-7.0.Z:libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.ppc64",
+          "7Server-7.0.Z:libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.s390x",
+          "7Server-7.0.Z:libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.x86_64",
+          "7Server-7.0.Z:libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.ppc64",
+          "7Server-7.0.Z:libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.s390x",
+          "7Server-7.0.Z:libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.x86_64",
+          "7Server-7.0.Z:libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.ppc64",
+          "7Server-7.0.Z:libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.s390x",
+          "7Server-7.0.Z:libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.x86_64",
+          "7Server-7.0.Z:libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.ppc64",
+          "7Server-7.0.Z:libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.s390x",
+          "7Server-7.0.Z:libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.x86_64",
+          "7Server-7.0.Z:libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.ppc64",
+          "7Server-7.0.Z:libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.s390x",
+          "7Server-7.0.Z:libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.x86_64",
+          "7Server-7.0.Z:libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.ppc64",
+          "7Server-7.0.Z:libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.s390x",
+          "7Server-7.0.Z:libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.x86_64",
+          "7Server-7.0.Z:libvirt-daemon-driver-qemu-0:1.1.1-29.el7_0.4.x86_64",
+          "7Server-7.0.Z:libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.ppc64",
+          "7Server-7.0.Z:libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.s390x",
+          "7Server-7.0.Z:libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.x86_64",
+          "7Server-7.0.Z:libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.ppc64",
+          "7Server-7.0.Z:libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.s390x",
+          "7Server-7.0.Z:libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.x86_64",
+          "7Server-7.0.Z:libvirt-daemon-kvm-0:1.1.1-29.el7_0.4.x86_64",
+          "7Server-7.0.Z:libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.ppc64",
+          "7Server-7.0.Z:libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.s390x",
+          "7Server-7.0.Z:libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.x86_64",
+          "7Server-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.i686",
+          "7Server-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.ppc",
+          "7Server-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.ppc64",
+          "7Server-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.s390",
+          "7Server-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.s390x",
+          "7Server-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.x86_64",
+          "7Server-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.i686",
+          "7Server-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.ppc",
+          "7Server-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.ppc64",
+          "7Server-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.s390",
+          "7Server-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.s390x",
+          "7Server-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.x86_64",
+          "7Server-7.0.Z:libvirt-docs-0:1.1.1-29.el7_0.4.ppc64",
+          "7Server-7.0.Z:libvirt-docs-0:1.1.1-29.el7_0.4.s390x",
+          "7Server-7.0.Z:libvirt-docs-0:1.1.1-29.el7_0.4.x86_64",
+          "7Server-7.0.Z:libvirt-lock-sanlock-0:1.1.1-29.el7_0.4.x86_64",
+          "7Server-7.0.Z:libvirt-login-shell-0:1.1.1-29.el7_0.4.ppc64",
+          "7Server-7.0.Z:libvirt-login-shell-0:1.1.1-29.el7_0.4.s390x",
+          "7Server-7.0.Z:libvirt-login-shell-0:1.1.1-29.el7_0.4.x86_64",
+          "7Server-7.0.Z:libvirt-python-0:1.1.1-29.el7_0.4.ppc64",
+          "7Server-7.0.Z:libvirt-python-0:1.1.1-29.el7_0.4.s390x",
+          "7Server-7.0.Z:libvirt-python-0:1.1.1-29.el7_0.4.x86_64",
+          "7Server-optional-7.0.Z:libvirt-0:1.1.1-29.el7_0.4.ppc64",
+          "7Server-optional-7.0.Z:libvirt-0:1.1.1-29.el7_0.4.s390x",
+          "7Server-optional-7.0.Z:libvirt-0:1.1.1-29.el7_0.4.src",
+          "7Server-optional-7.0.Z:libvirt-0:1.1.1-29.el7_0.4.x86_64",
+          "7Server-optional-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.i686",
+          "7Server-optional-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.ppc",
+          "7Server-optional-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.ppc64",
+          "7Server-optional-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.s390",
+          "7Server-optional-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.s390x",
+          "7Server-optional-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.x86_64",
+          "7Server-optional-7.0.Z:libvirt-daemon-0:1.1.1-29.el7_0.4.ppc64",
+          "7Server-optional-7.0.Z:libvirt-daemon-0:1.1.1-29.el7_0.4.s390x",
+          "7Server-optional-7.0.Z:libvirt-daemon-0:1.1.1-29.el7_0.4.x86_64",
+          "7Server-optional-7.0.Z:libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.ppc64",
+          "7Server-optional-7.0.Z:libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.s390x",
+          "7Server-optional-7.0.Z:libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.x86_64",
+          "7Server-optional-7.0.Z:libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.ppc64",
+          "7Server-optional-7.0.Z:libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.s390x",
+          "7Server-optional-7.0.Z:libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.x86_64",
+          "7Server-optional-7.0.Z:libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.ppc64",
+          "7Server-optional-7.0.Z:libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.s390x",
+          "7Server-optional-7.0.Z:libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.x86_64",
+          "7Server-optional-7.0.Z:libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.ppc64",
+          "7Server-optional-7.0.Z:libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.s390x",
+          "7Server-optional-7.0.Z:libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.x86_64",
+          "7Server-optional-7.0.Z:libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.ppc64",
+          "7Server-optional-7.0.Z:libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.s390x",
+          "7Server-optional-7.0.Z:libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.x86_64",
+          "7Server-optional-7.0.Z:libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.ppc64",
+          "7Server-optional-7.0.Z:libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.s390x",
+          "7Server-optional-7.0.Z:libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.x86_64",
+          "7Server-optional-7.0.Z:libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.ppc64",
+          "7Server-optional-7.0.Z:libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.s390x",
+          "7Server-optional-7.0.Z:libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.x86_64",
+          "7Server-optional-7.0.Z:libvirt-daemon-driver-qemu-0:1.1.1-29.el7_0.4.x86_64",
+          "7Server-optional-7.0.Z:libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.ppc64",
+          "7Server-optional-7.0.Z:libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.s390x",
+          "7Server-optional-7.0.Z:libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.x86_64",
+          "7Server-optional-7.0.Z:libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.ppc64",
+          "7Server-optional-7.0.Z:libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.s390x",
+          "7Server-optional-7.0.Z:libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.x86_64",
+          "7Server-optional-7.0.Z:libvirt-daemon-kvm-0:1.1.1-29.el7_0.4.x86_64",
+          "7Server-optional-7.0.Z:libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.ppc64",
+          "7Server-optional-7.0.Z:libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.s390x",
+          "7Server-optional-7.0.Z:libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.x86_64",
+          "7Server-optional-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.i686",
+          "7Server-optional-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.ppc",
+          "7Server-optional-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.ppc64",
+          "7Server-optional-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.s390",
+          "7Server-optional-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.s390x",
+          "7Server-optional-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.x86_64",
+          "7Server-optional-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.i686",
+          "7Server-optional-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.ppc",
+          "7Server-optional-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.ppc64",
+          "7Server-optional-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.s390",
+          "7Server-optional-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.s390x",
+          "7Server-optional-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.x86_64",
+          "7Server-optional-7.0.Z:libvirt-docs-0:1.1.1-29.el7_0.4.ppc64",
+          "7Server-optional-7.0.Z:libvirt-docs-0:1.1.1-29.el7_0.4.s390x",
+          "7Server-optional-7.0.Z:libvirt-docs-0:1.1.1-29.el7_0.4.x86_64",
+          "7Server-optional-7.0.Z:libvirt-lock-sanlock-0:1.1.1-29.el7_0.4.x86_64",
+          "7Server-optional-7.0.Z:libvirt-login-shell-0:1.1.1-29.el7_0.4.ppc64",
+          "7Server-optional-7.0.Z:libvirt-login-shell-0:1.1.1-29.el7_0.4.s390x",
+          "7Server-optional-7.0.Z:libvirt-login-shell-0:1.1.1-29.el7_0.4.x86_64",
+          "7Server-optional-7.0.Z:libvirt-python-0:1.1.1-29.el7_0.4.ppc64",
+          "7Server-optional-7.0.Z:libvirt-python-0:1.1.1-29.el7_0.4.s390x",
+          "7Server-optional-7.0.Z:libvirt-python-0:1.1.1-29.el7_0.4.x86_64",
+          "7Workstation-7.0.Z:libvirt-0:1.1.1-29.el7_0.4.ppc64",
+          "7Workstation-7.0.Z:libvirt-0:1.1.1-29.el7_0.4.s390x",
+          "7Workstation-7.0.Z:libvirt-0:1.1.1-29.el7_0.4.src",
+          "7Workstation-7.0.Z:libvirt-0:1.1.1-29.el7_0.4.x86_64",
+          "7Workstation-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.i686",
+          "7Workstation-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.ppc",
+          "7Workstation-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.ppc64",
+          "7Workstation-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.s390",
+          "7Workstation-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.s390x",
+          "7Workstation-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.x86_64",
+          "7Workstation-7.0.Z:libvirt-daemon-0:1.1.1-29.el7_0.4.ppc64",
+          "7Workstation-7.0.Z:libvirt-daemon-0:1.1.1-29.el7_0.4.s390x",
+          "7Workstation-7.0.Z:libvirt-daemon-0:1.1.1-29.el7_0.4.x86_64",
+          "7Workstation-7.0.Z:libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.ppc64",
+          "7Workstation-7.0.Z:libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.s390x",
+          "7Workstation-7.0.Z:libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.x86_64",
+          "7Workstation-7.0.Z:libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.ppc64",
+          "7Workstation-7.0.Z:libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.s390x",
+          "7Workstation-7.0.Z:libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.x86_64",
+          "7Workstation-7.0.Z:libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.ppc64",
+          "7Workstation-7.0.Z:libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.s390x",
+          "7Workstation-7.0.Z:libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.x86_64",
+          "7Workstation-7.0.Z:libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.ppc64",
+          "7Workstation-7.0.Z:libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.s390x",
+          "7Workstation-7.0.Z:libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.x86_64",
+          "7Workstation-7.0.Z:libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.ppc64",
+          "7Workstation-7.0.Z:libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.s390x",
+          "7Workstation-7.0.Z:libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.x86_64",
+          "7Workstation-7.0.Z:libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.ppc64",
+          "7Workstation-7.0.Z:libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.s390x",
+          "7Workstation-7.0.Z:libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.x86_64",
+          "7Workstation-7.0.Z:libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.ppc64",
+          "7Workstation-7.0.Z:libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.s390x",
+          "7Workstation-7.0.Z:libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.x86_64",
+          "7Workstation-7.0.Z:libvirt-daemon-driver-qemu-0:1.1.1-29.el7_0.4.x86_64",
+          "7Workstation-7.0.Z:libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.ppc64",
+          "7Workstation-7.0.Z:libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.s390x",
+          "7Workstation-7.0.Z:libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.x86_64",
+          "7Workstation-7.0.Z:libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.ppc64",
+          "7Workstation-7.0.Z:libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.s390x",
+          "7Workstation-7.0.Z:libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.x86_64",
+          "7Workstation-7.0.Z:libvirt-daemon-kvm-0:1.1.1-29.el7_0.4.x86_64",
+          "7Workstation-7.0.Z:libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.ppc64",
+          "7Workstation-7.0.Z:libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.s390x",
+          "7Workstation-7.0.Z:libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.x86_64",
+          "7Workstation-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.i686",
+          "7Workstation-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.ppc",
+          "7Workstation-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.ppc64",
+          "7Workstation-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.s390",
+          "7Workstation-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.s390x",
+          "7Workstation-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.x86_64",
+          "7Workstation-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.i686",
+          "7Workstation-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.ppc",
+          "7Workstation-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.ppc64",
+          "7Workstation-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.s390",
+          "7Workstation-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.s390x",
+          "7Workstation-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.x86_64",
+          "7Workstation-7.0.Z:libvirt-docs-0:1.1.1-29.el7_0.4.ppc64",
+          "7Workstation-7.0.Z:libvirt-docs-0:1.1.1-29.el7_0.4.s390x",
+          "7Workstation-7.0.Z:libvirt-docs-0:1.1.1-29.el7_0.4.x86_64",
+          "7Workstation-7.0.Z:libvirt-lock-sanlock-0:1.1.1-29.el7_0.4.x86_64",
+          "7Workstation-7.0.Z:libvirt-login-shell-0:1.1.1-29.el7_0.4.ppc64",
+          "7Workstation-7.0.Z:libvirt-login-shell-0:1.1.1-29.el7_0.4.s390x",
+          "7Workstation-7.0.Z:libvirt-login-shell-0:1.1.1-29.el7_0.4.x86_64",
+          "7Workstation-7.0.Z:libvirt-python-0:1.1.1-29.el7_0.4.ppc64",
+          "7Workstation-7.0.Z:libvirt-python-0:1.1.1-29.el7_0.4.s390x",
+          "7Workstation-7.0.Z:libvirt-python-0:1.1.1-29.el7_0.4.x86_64",
+          "7Workstation-optional-7.0.Z:libvirt-0:1.1.1-29.el7_0.4.ppc64",
+          "7Workstation-optional-7.0.Z:libvirt-0:1.1.1-29.el7_0.4.s390x",
+          "7Workstation-optional-7.0.Z:libvirt-0:1.1.1-29.el7_0.4.src",
+          "7Workstation-optional-7.0.Z:libvirt-0:1.1.1-29.el7_0.4.x86_64",
+          "7Workstation-optional-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.i686",
+          "7Workstation-optional-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.ppc",
+          "7Workstation-optional-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.ppc64",
+          "7Workstation-optional-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.s390",
+          "7Workstation-optional-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.s390x",
+          "7Workstation-optional-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.x86_64",
+          "7Workstation-optional-7.0.Z:libvirt-daemon-0:1.1.1-29.el7_0.4.ppc64",
+          "7Workstation-optional-7.0.Z:libvirt-daemon-0:1.1.1-29.el7_0.4.s390x",
+          "7Workstation-optional-7.0.Z:libvirt-daemon-0:1.1.1-29.el7_0.4.x86_64",
+          "7Workstation-optional-7.0.Z:libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.ppc64",
+          "7Workstation-optional-7.0.Z:libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.s390x",
+          "7Workstation-optional-7.0.Z:libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.x86_64",
+          "7Workstation-optional-7.0.Z:libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.ppc64",
+          "7Workstation-optional-7.0.Z:libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.s390x",
+          "7Workstation-optional-7.0.Z:libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.x86_64",
+          "7Workstation-optional-7.0.Z:libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.ppc64",
+          "7Workstation-optional-7.0.Z:libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.s390x",
+          "7Workstation-optional-7.0.Z:libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.x86_64",
+          "7Workstation-optional-7.0.Z:libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.ppc64",
+          "7Workstation-optional-7.0.Z:libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.s390x",
+          "7Workstation-optional-7.0.Z:libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.x86_64",
+          "7Workstation-optional-7.0.Z:libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.ppc64",
+          "7Workstation-optional-7.0.Z:libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.s390x",
+          "7Workstation-optional-7.0.Z:libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.x86_64",
+          "7Workstation-optional-7.0.Z:libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.ppc64",
+          "7Workstation-optional-7.0.Z:libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.s390x",
+          "7Workstation-optional-7.0.Z:libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.x86_64",
+          "7Workstation-optional-7.0.Z:libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.ppc64",
+          "7Workstation-optional-7.0.Z:libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.s390x",
+          "7Workstation-optional-7.0.Z:libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.x86_64",
+          "7Workstation-optional-7.0.Z:libvirt-daemon-driver-qemu-0:1.1.1-29.el7_0.4.x86_64",
+          "7Workstation-optional-7.0.Z:libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.ppc64",
+          "7Workstation-optional-7.0.Z:libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.s390x",
+          "7Workstation-optional-7.0.Z:libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.x86_64",
+          "7Workstation-optional-7.0.Z:libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.ppc64",
+          "7Workstation-optional-7.0.Z:libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.s390x",
+          "7Workstation-optional-7.0.Z:libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.x86_64",
+          "7Workstation-optional-7.0.Z:libvirt-daemon-kvm-0:1.1.1-29.el7_0.4.x86_64",
+          "7Workstation-optional-7.0.Z:libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.ppc64",
+          "7Workstation-optional-7.0.Z:libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.s390x",
+          "7Workstation-optional-7.0.Z:libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.x86_64",
+          "7Workstation-optional-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.i686",
+          "7Workstation-optional-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.ppc",
+          "7Workstation-optional-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.ppc64",
+          "7Workstation-optional-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.s390",
+          "7Workstation-optional-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.s390x",
+          "7Workstation-optional-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.x86_64",
+          "7Workstation-optional-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.i686",
+          "7Workstation-optional-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.ppc",
+          "7Workstation-optional-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.ppc64",
+          "7Workstation-optional-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.s390",
+          "7Workstation-optional-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.s390x",
+          "7Workstation-optional-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.x86_64",
+          "7Workstation-optional-7.0.Z:libvirt-docs-0:1.1.1-29.el7_0.4.ppc64",
+          "7Workstation-optional-7.0.Z:libvirt-docs-0:1.1.1-29.el7_0.4.s390x",
+          "7Workstation-optional-7.0.Z:libvirt-docs-0:1.1.1-29.el7_0.4.x86_64",
+          "7Workstation-optional-7.0.Z:libvirt-lock-sanlock-0:1.1.1-29.el7_0.4.x86_64",
+          "7Workstation-optional-7.0.Z:libvirt-login-shell-0:1.1.1-29.el7_0.4.ppc64",
+          "7Workstation-optional-7.0.Z:libvirt-login-shell-0:1.1.1-29.el7_0.4.s390x",
+          "7Workstation-optional-7.0.Z:libvirt-login-shell-0:1.1.1-29.el7_0.4.x86_64",
+          "7Workstation-optional-7.0.Z:libvirt-python-0:1.1.1-29.el7_0.4.ppc64",
+          "7Workstation-optional-7.0.Z:libvirt-python-0:1.1.1-29.el7_0.4.s390x",
+          "7Workstation-optional-7.0.Z:libvirt-python-0:1.1.1-29.el7_0.4.x86_64"
+        ]
+      },
+      "references": [
+        {
+          "category": "self",
+          "summary": "Canonical URL",
+          "url": "https://access.redhat.com/security/cve/CVE-2014-7823"
+        },
+        {
+          "category": "external",
+          "summary": "RHBZ#1160817",
+          "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1160817"
+        },
+        {
+          "category": "external",
+          "summary": "https://www.cve.org/CVERecord?id=CVE-2014-7823",
+          "url": "https://www.cve.org/CVERecord?id=CVE-2014-7823"
+        },
+        {
+          "category": "external",
+          "summary": "https://nvd.nist.gov/vuln/detail/CVE-2014-7823",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2014-7823"
+        }
+      ],
+      "release_date": "2014-11-05T00:00:00+00:00",
+      "remediations": [
+        {
+          "category": "vendor_fix",
+          "details": "Before applying this update, make sure all previously released errata\nrelevant to your system have been applied.\n\nThis update is available via the Red Hat Network. Details on how to use the\nRed Hat Network to apply this update are available at\nhttps://access.redhat.com/articles/11258",
+          "product_ids": [
+            "7Client-7.0.Z:libvirt-0:1.1.1-29.el7_0.4.ppc64",
+            "7Client-7.0.Z:libvirt-0:1.1.1-29.el7_0.4.s390x",
+            "7Client-7.0.Z:libvirt-0:1.1.1-29.el7_0.4.src",
+            "7Client-7.0.Z:libvirt-0:1.1.1-29.el7_0.4.x86_64",
+            "7Client-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.i686",
+            "7Client-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.ppc",
+            "7Client-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.ppc64",
+            "7Client-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.s390",
+            "7Client-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.s390x",
+            "7Client-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.x86_64",
+            "7Client-7.0.Z:libvirt-daemon-0:1.1.1-29.el7_0.4.ppc64",
+            "7Client-7.0.Z:libvirt-daemon-0:1.1.1-29.el7_0.4.s390x",
+            "7Client-7.0.Z:libvirt-daemon-0:1.1.1-29.el7_0.4.x86_64",
+            "7Client-7.0.Z:libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.ppc64",
+            "7Client-7.0.Z:libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.s390x",
+            "7Client-7.0.Z:libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.x86_64",
+            "7Client-7.0.Z:libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.ppc64",
+            "7Client-7.0.Z:libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.s390x",
+            "7Client-7.0.Z:libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.x86_64",
+            "7Client-7.0.Z:libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.ppc64",
+            "7Client-7.0.Z:libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.s390x",
+            "7Client-7.0.Z:libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.x86_64",
+            "7Client-7.0.Z:libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.ppc64",
+            "7Client-7.0.Z:libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.s390x",
+            "7Client-7.0.Z:libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.x86_64",
+            "7Client-7.0.Z:libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.ppc64",
+            "7Client-7.0.Z:libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.s390x",
+            "7Client-7.0.Z:libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.x86_64",
+            "7Client-7.0.Z:libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.ppc64",
+            "7Client-7.0.Z:libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.s390x",
+            "7Client-7.0.Z:libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.x86_64",
+            "7Client-7.0.Z:libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.ppc64",
+            "7Client-7.0.Z:libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.s390x",
+            "7Client-7.0.Z:libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.x86_64",
+            "7Client-7.0.Z:libvirt-daemon-driver-qemu-0:1.1.1-29.el7_0.4.x86_64",
+            "7Client-7.0.Z:libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.ppc64",
+            "7Client-7.0.Z:libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.s390x",
+            "7Client-7.0.Z:libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.x86_64",
+            "7Client-7.0.Z:libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.ppc64",
+            "7Client-7.0.Z:libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.s390x",
+            "7Client-7.0.Z:libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.x86_64",
+            "7Client-7.0.Z:libvirt-daemon-kvm-0:1.1.1-29.el7_0.4.x86_64",
+            "7Client-7.0.Z:libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.ppc64",
+            "7Client-7.0.Z:libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.s390x",
+            "7Client-7.0.Z:libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.x86_64",
+            "7Client-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.i686",
+            "7Client-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.ppc",
+            "7Client-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.ppc64",
+            "7Client-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.s390",
+            "7Client-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.s390x",
+            "7Client-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.x86_64",
+            "7Client-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.i686",
+            "7Client-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.ppc",
+            "7Client-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.ppc64",
+            "7Client-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.s390",
+            "7Client-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.s390x",
+            "7Client-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.x86_64",
+            "7Client-7.0.Z:libvirt-docs-0:1.1.1-29.el7_0.4.ppc64",
+            "7Client-7.0.Z:libvirt-docs-0:1.1.1-29.el7_0.4.s390x",
+            "7Client-7.0.Z:libvirt-docs-0:1.1.1-29.el7_0.4.x86_64",
+            "7Client-7.0.Z:libvirt-lock-sanlock-0:1.1.1-29.el7_0.4.x86_64",
+            "7Client-7.0.Z:libvirt-login-shell-0:1.1.1-29.el7_0.4.ppc64",
+            "7Client-7.0.Z:libvirt-login-shell-0:1.1.1-29.el7_0.4.s390x",
+            "7Client-7.0.Z:libvirt-login-shell-0:1.1.1-29.el7_0.4.x86_64",
+            "7Client-7.0.Z:libvirt-python-0:1.1.1-29.el7_0.4.ppc64",
+            "7Client-7.0.Z:libvirt-python-0:1.1.1-29.el7_0.4.s390x",
+            "7Client-7.0.Z:libvirt-python-0:1.1.1-29.el7_0.4.x86_64",
+            "7Client-optional-7.0.Z:libvirt-0:1.1.1-29.el7_0.4.ppc64",
+            "7Client-optional-7.0.Z:libvirt-0:1.1.1-29.el7_0.4.s390x",
+            "7Client-optional-7.0.Z:libvirt-0:1.1.1-29.el7_0.4.src",
+            "7Client-optional-7.0.Z:libvirt-0:1.1.1-29.el7_0.4.x86_64",
+            "7Client-optional-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.i686",
+            "7Client-optional-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.ppc",
+            "7Client-optional-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.ppc64",
+            "7Client-optional-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.s390",
+            "7Client-optional-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.s390x",
+            "7Client-optional-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.x86_64",
+            "7Client-optional-7.0.Z:libvirt-daemon-0:1.1.1-29.el7_0.4.ppc64",
+            "7Client-optional-7.0.Z:libvirt-daemon-0:1.1.1-29.el7_0.4.s390x",
+            "7Client-optional-7.0.Z:libvirt-daemon-0:1.1.1-29.el7_0.4.x86_64",
+            "7Client-optional-7.0.Z:libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.ppc64",
+            "7Client-optional-7.0.Z:libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.s390x",
+            "7Client-optional-7.0.Z:libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.x86_64",
+            "7Client-optional-7.0.Z:libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.ppc64",
+            "7Client-optional-7.0.Z:libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.s390x",
+            "7Client-optional-7.0.Z:libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.x86_64",
+            "7Client-optional-7.0.Z:libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.ppc64",
+            "7Client-optional-7.0.Z:libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.s390x",
+            "7Client-optional-7.0.Z:libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.x86_64",
+            "7Client-optional-7.0.Z:libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.ppc64",
+            "7Client-optional-7.0.Z:libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.s390x",
+            "7Client-optional-7.0.Z:libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.x86_64",
+            "7Client-optional-7.0.Z:libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.ppc64",
+            "7Client-optional-7.0.Z:libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.s390x",
+            "7Client-optional-7.0.Z:libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.x86_64",
+            "7Client-optional-7.0.Z:libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.ppc64",
+            "7Client-optional-7.0.Z:libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.s390x",
+            "7Client-optional-7.0.Z:libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.x86_64",
+            "7Client-optional-7.0.Z:libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.ppc64",
+            "7Client-optional-7.0.Z:libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.s390x",
+            "7Client-optional-7.0.Z:libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.x86_64",
+            "7Client-optional-7.0.Z:libvirt-daemon-driver-qemu-0:1.1.1-29.el7_0.4.x86_64",
+            "7Client-optional-7.0.Z:libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.ppc64",
+            "7Client-optional-7.0.Z:libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.s390x",
+            "7Client-optional-7.0.Z:libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.x86_64",
+            "7Client-optional-7.0.Z:libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.ppc64",
+            "7Client-optional-7.0.Z:libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.s390x",
+            "7Client-optional-7.0.Z:libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.x86_64",
+            "7Client-optional-7.0.Z:libvirt-daemon-kvm-0:1.1.1-29.el7_0.4.x86_64",
+            "7Client-optional-7.0.Z:libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.ppc64",
+            "7Client-optional-7.0.Z:libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.s390x",
+            "7Client-optional-7.0.Z:libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.x86_64",
+            "7Client-optional-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.i686",
+            "7Client-optional-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.ppc",
+            "7Client-optional-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.ppc64",
+            "7Client-optional-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.s390",
+            "7Client-optional-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.s390x",
+            "7Client-optional-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.x86_64",
+            "7Client-optional-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.i686",
+            "7Client-optional-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.ppc",
+            "7Client-optional-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.ppc64",
+            "7Client-optional-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.s390",
+            "7Client-optional-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.s390x",
+            "7Client-optional-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.x86_64",
+            "7Client-optional-7.0.Z:libvirt-docs-0:1.1.1-29.el7_0.4.ppc64",
+            "7Client-optional-7.0.Z:libvirt-docs-0:1.1.1-29.el7_0.4.s390x",
+            "7Client-optional-7.0.Z:libvirt-docs-0:1.1.1-29.el7_0.4.x86_64",
+            "7Client-optional-7.0.Z:libvirt-lock-sanlock-0:1.1.1-29.el7_0.4.x86_64",
+            "7Client-optional-7.0.Z:libvirt-login-shell-0:1.1.1-29.el7_0.4.ppc64",
+            "7Client-optional-7.0.Z:libvirt-login-shell-0:1.1.1-29.el7_0.4.s390x",
+            "7Client-optional-7.0.Z:libvirt-login-shell-0:1.1.1-29.el7_0.4.x86_64",
+            "7Client-optional-7.0.Z:libvirt-python-0:1.1.1-29.el7_0.4.ppc64",
+            "7Client-optional-7.0.Z:libvirt-python-0:1.1.1-29.el7_0.4.s390x",
+            "7Client-optional-7.0.Z:libvirt-python-0:1.1.1-29.el7_0.4.x86_64",
+            "7ComputeNode-7.0.Z:libvirt-0:1.1.1-29.el7_0.4.ppc64",
+            "7ComputeNode-7.0.Z:libvirt-0:1.1.1-29.el7_0.4.s390x",
+            "7ComputeNode-7.0.Z:libvirt-0:1.1.1-29.el7_0.4.src",
+            "7ComputeNode-7.0.Z:libvirt-0:1.1.1-29.el7_0.4.x86_64",
+            "7ComputeNode-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.i686",
+            "7ComputeNode-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.ppc",
+            "7ComputeNode-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.ppc64",
+            "7ComputeNode-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.s390",
+            "7ComputeNode-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.s390x",
+            "7ComputeNode-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.x86_64",
+            "7ComputeNode-7.0.Z:libvirt-daemon-0:1.1.1-29.el7_0.4.ppc64",
+            "7ComputeNode-7.0.Z:libvirt-daemon-0:1.1.1-29.el7_0.4.s390x",
+            "7ComputeNode-7.0.Z:libvirt-daemon-0:1.1.1-29.el7_0.4.x86_64",
+            "7ComputeNode-7.0.Z:libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.ppc64",
+            "7ComputeNode-7.0.Z:libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.s390x",
+            "7ComputeNode-7.0.Z:libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.x86_64",
+            "7ComputeNode-7.0.Z:libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.ppc64",
+            "7ComputeNode-7.0.Z:libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.s390x",
+            "7ComputeNode-7.0.Z:libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.x86_64",
+            "7ComputeNode-7.0.Z:libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.ppc64",
+            "7ComputeNode-7.0.Z:libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.s390x",
+            "7ComputeNode-7.0.Z:libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.x86_64",
+            "7ComputeNode-7.0.Z:libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.ppc64",
+            "7ComputeNode-7.0.Z:libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.s390x",
+            "7ComputeNode-7.0.Z:libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.x86_64",
+            "7ComputeNode-7.0.Z:libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.ppc64",
+            "7ComputeNode-7.0.Z:libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.s390x",
+            "7ComputeNode-7.0.Z:libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.x86_64",
+            "7ComputeNode-7.0.Z:libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.ppc64",
+            "7ComputeNode-7.0.Z:libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.s390x",
+            "7ComputeNode-7.0.Z:libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.x86_64",
+            "7ComputeNode-7.0.Z:libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.ppc64",
+            "7ComputeNode-7.0.Z:libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.s390x",
+            "7ComputeNode-7.0.Z:libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.x86_64",
+            "7ComputeNode-7.0.Z:libvirt-daemon-driver-qemu-0:1.1.1-29.el7_0.4.x86_64",
+            "7ComputeNode-7.0.Z:libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.ppc64",
+            "7ComputeNode-7.0.Z:libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.s390x",
+            "7ComputeNode-7.0.Z:libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.x86_64",
+            "7ComputeNode-7.0.Z:libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.ppc64",
+            "7ComputeNode-7.0.Z:libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.s390x",
+            "7ComputeNode-7.0.Z:libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.x86_64",
+            "7ComputeNode-7.0.Z:libvirt-daemon-kvm-0:1.1.1-29.el7_0.4.x86_64",
+            "7ComputeNode-7.0.Z:libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.ppc64",
+            "7ComputeNode-7.0.Z:libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.s390x",
+            "7ComputeNode-7.0.Z:libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.x86_64",
+            "7ComputeNode-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.i686",
+            "7ComputeNode-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.ppc",
+            "7ComputeNode-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.ppc64",
+            "7ComputeNode-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.s390",
+            "7ComputeNode-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.s390x",
+            "7ComputeNode-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.x86_64",
+            "7ComputeNode-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.i686",
+            "7ComputeNode-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.ppc",
+            "7ComputeNode-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.ppc64",
+            "7ComputeNode-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.s390",
+            "7ComputeNode-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.s390x",
+            "7ComputeNode-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.x86_64",
+            "7ComputeNode-7.0.Z:libvirt-docs-0:1.1.1-29.el7_0.4.ppc64",
+            "7ComputeNode-7.0.Z:libvirt-docs-0:1.1.1-29.el7_0.4.s390x",
+            "7ComputeNode-7.0.Z:libvirt-docs-0:1.1.1-29.el7_0.4.x86_64",
+            "7ComputeNode-7.0.Z:libvirt-lock-sanlock-0:1.1.1-29.el7_0.4.x86_64",
+            "7ComputeNode-7.0.Z:libvirt-login-shell-0:1.1.1-29.el7_0.4.ppc64",
+            "7ComputeNode-7.0.Z:libvirt-login-shell-0:1.1.1-29.el7_0.4.s390x",
+            "7ComputeNode-7.0.Z:libvirt-login-shell-0:1.1.1-29.el7_0.4.x86_64",
+            "7ComputeNode-7.0.Z:libvirt-python-0:1.1.1-29.el7_0.4.ppc64",
+            "7ComputeNode-7.0.Z:libvirt-python-0:1.1.1-29.el7_0.4.s390x",
+            "7ComputeNode-7.0.Z:libvirt-python-0:1.1.1-29.el7_0.4.x86_64",
+            "7ComputeNode-optional-7.0.Z:libvirt-0:1.1.1-29.el7_0.4.ppc64",
+            "7ComputeNode-optional-7.0.Z:libvirt-0:1.1.1-29.el7_0.4.s390x",
+            "7ComputeNode-optional-7.0.Z:libvirt-0:1.1.1-29.el7_0.4.src",
+            "7ComputeNode-optional-7.0.Z:libvirt-0:1.1.1-29.el7_0.4.x86_64",
+            "7ComputeNode-optional-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.i686",
+            "7ComputeNode-optional-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.ppc",
+            "7ComputeNode-optional-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.ppc64",
+            "7ComputeNode-optional-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.s390",
+            "7ComputeNode-optional-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.s390x",
+            "7ComputeNode-optional-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.x86_64",
+            "7ComputeNode-optional-7.0.Z:libvirt-daemon-0:1.1.1-29.el7_0.4.ppc64",
+            "7ComputeNode-optional-7.0.Z:libvirt-daemon-0:1.1.1-29.el7_0.4.s390x",
+            "7ComputeNode-optional-7.0.Z:libvirt-daemon-0:1.1.1-29.el7_0.4.x86_64",
+            "7ComputeNode-optional-7.0.Z:libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.ppc64",
+            "7ComputeNode-optional-7.0.Z:libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.s390x",
+            "7ComputeNode-optional-7.0.Z:libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.x86_64",
+            "7ComputeNode-optional-7.0.Z:libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.ppc64",
+            "7ComputeNode-optional-7.0.Z:libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.s390x",
+            "7ComputeNode-optional-7.0.Z:libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.x86_64",
+            "7ComputeNode-optional-7.0.Z:libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.ppc64",
+            "7ComputeNode-optional-7.0.Z:libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.s390x",
+            "7ComputeNode-optional-7.0.Z:libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.x86_64",
+            "7ComputeNode-optional-7.0.Z:libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.ppc64",
+            "7ComputeNode-optional-7.0.Z:libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.s390x",
+            "7ComputeNode-optional-7.0.Z:libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.x86_64",
+            "7ComputeNode-optional-7.0.Z:libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.ppc64",
+            "7ComputeNode-optional-7.0.Z:libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.s390x",
+            "7ComputeNode-optional-7.0.Z:libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.x86_64",
+            "7ComputeNode-optional-7.0.Z:libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.ppc64",
+            "7ComputeNode-optional-7.0.Z:libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.s390x",
+            "7ComputeNode-optional-7.0.Z:libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.x86_64",
+            "7ComputeNode-optional-7.0.Z:libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.ppc64",
+            "7ComputeNode-optional-7.0.Z:libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.s390x",
+            "7ComputeNode-optional-7.0.Z:libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.x86_64",
+            "7ComputeNode-optional-7.0.Z:libvirt-daemon-driver-qemu-0:1.1.1-29.el7_0.4.x86_64",
+            "7ComputeNode-optional-7.0.Z:libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.ppc64",
+            "7ComputeNode-optional-7.0.Z:libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.s390x",
+            "7ComputeNode-optional-7.0.Z:libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.x86_64",
+            "7ComputeNode-optional-7.0.Z:libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.ppc64",
+            "7ComputeNode-optional-7.0.Z:libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.s390x",
+            "7ComputeNode-optional-7.0.Z:libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.x86_64",
+            "7ComputeNode-optional-7.0.Z:libvirt-daemon-kvm-0:1.1.1-29.el7_0.4.x86_64",
+            "7ComputeNode-optional-7.0.Z:libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.ppc64",
+            "7ComputeNode-optional-7.0.Z:libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.s390x",
+            "7ComputeNode-optional-7.0.Z:libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.x86_64",
+            "7ComputeNode-optional-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.i686",
+            "7ComputeNode-optional-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.ppc",
+            "7ComputeNode-optional-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.ppc64",
+            "7ComputeNode-optional-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.s390",
+            "7ComputeNode-optional-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.s390x",
+            "7ComputeNode-optional-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.x86_64",
+            "7ComputeNode-optional-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.i686",
+            "7ComputeNode-optional-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.ppc",
+            "7ComputeNode-optional-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.ppc64",
+            "7ComputeNode-optional-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.s390",
+            "7ComputeNode-optional-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.s390x",
+            "7ComputeNode-optional-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.x86_64",
+            "7ComputeNode-optional-7.0.Z:libvirt-docs-0:1.1.1-29.el7_0.4.ppc64",
+            "7ComputeNode-optional-7.0.Z:libvirt-docs-0:1.1.1-29.el7_0.4.s390x",
+            "7ComputeNode-optional-7.0.Z:libvirt-docs-0:1.1.1-29.el7_0.4.x86_64",
+            "7ComputeNode-optional-7.0.Z:libvirt-lock-sanlock-0:1.1.1-29.el7_0.4.x86_64",
+            "7ComputeNode-optional-7.0.Z:libvirt-login-shell-0:1.1.1-29.el7_0.4.ppc64",
+            "7ComputeNode-optional-7.0.Z:libvirt-login-shell-0:1.1.1-29.el7_0.4.s390x",
+            "7ComputeNode-optional-7.0.Z:libvirt-login-shell-0:1.1.1-29.el7_0.4.x86_64",
+            "7ComputeNode-optional-7.0.Z:libvirt-python-0:1.1.1-29.el7_0.4.ppc64",
+            "7ComputeNode-optional-7.0.Z:libvirt-python-0:1.1.1-29.el7_0.4.s390x",
+            "7ComputeNode-optional-7.0.Z:libvirt-python-0:1.1.1-29.el7_0.4.x86_64",
+            "7Server-7.0.Z:libvirt-0:1.1.1-29.el7_0.4.ppc64",
+            "7Server-7.0.Z:libvirt-0:1.1.1-29.el7_0.4.s390x",
+            "7Server-7.0.Z:libvirt-0:1.1.1-29.el7_0.4.src",
+            "7Server-7.0.Z:libvirt-0:1.1.1-29.el7_0.4.x86_64",
+            "7Server-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.i686",
+            "7Server-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.ppc",
+            "7Server-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.ppc64",
+            "7Server-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.s390",
+            "7Server-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.s390x",
+            "7Server-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.x86_64",
+            "7Server-7.0.Z:libvirt-daemon-0:1.1.1-29.el7_0.4.ppc64",
+            "7Server-7.0.Z:libvirt-daemon-0:1.1.1-29.el7_0.4.s390x",
+            "7Server-7.0.Z:libvirt-daemon-0:1.1.1-29.el7_0.4.x86_64",
+            "7Server-7.0.Z:libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.ppc64",
+            "7Server-7.0.Z:libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.s390x",
+            "7Server-7.0.Z:libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.x86_64",
+            "7Server-7.0.Z:libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.ppc64",
+            "7Server-7.0.Z:libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.s390x",
+            "7Server-7.0.Z:libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.x86_64",
+            "7Server-7.0.Z:libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.ppc64",
+            "7Server-7.0.Z:libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.s390x",
+            "7Server-7.0.Z:libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.x86_64",
+            "7Server-7.0.Z:libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.ppc64",
+            "7Server-7.0.Z:libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.s390x",
+            "7Server-7.0.Z:libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.x86_64",
+            "7Server-7.0.Z:libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.ppc64",
+            "7Server-7.0.Z:libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.s390x",
+            "7Server-7.0.Z:libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.x86_64",
+            "7Server-7.0.Z:libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.ppc64",
+            "7Server-7.0.Z:libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.s390x",
+            "7Server-7.0.Z:libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.x86_64",
+            "7Server-7.0.Z:libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.ppc64",
+            "7Server-7.0.Z:libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.s390x",
+            "7Server-7.0.Z:libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.x86_64",
+            "7Server-7.0.Z:libvirt-daemon-driver-qemu-0:1.1.1-29.el7_0.4.x86_64",
+            "7Server-7.0.Z:libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.ppc64",
+            "7Server-7.0.Z:libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.s390x",
+            "7Server-7.0.Z:libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.x86_64",
+            "7Server-7.0.Z:libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.ppc64",
+            "7Server-7.0.Z:libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.s390x",
+            "7Server-7.0.Z:libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.x86_64",
+            "7Server-7.0.Z:libvirt-daemon-kvm-0:1.1.1-29.el7_0.4.x86_64",
+            "7Server-7.0.Z:libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.ppc64",
+            "7Server-7.0.Z:libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.s390x",
+            "7Server-7.0.Z:libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.x86_64",
+            "7Server-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.i686",
+            "7Server-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.ppc",
+            "7Server-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.ppc64",
+            "7Server-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.s390",
+            "7Server-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.s390x",
+            "7Server-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.x86_64",
+            "7Server-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.i686",
+            "7Server-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.ppc",
+            "7Server-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.ppc64",
+            "7Server-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.s390",
+            "7Server-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.s390x",
+            "7Server-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.x86_64",
+            "7Server-7.0.Z:libvirt-docs-0:1.1.1-29.el7_0.4.ppc64",
+            "7Server-7.0.Z:libvirt-docs-0:1.1.1-29.el7_0.4.s390x",
+            "7Server-7.0.Z:libvirt-docs-0:1.1.1-29.el7_0.4.x86_64",
+            "7Server-7.0.Z:libvirt-lock-sanlock-0:1.1.1-29.el7_0.4.x86_64",
+            "7Server-7.0.Z:libvirt-login-shell-0:1.1.1-29.el7_0.4.ppc64",
+            "7Server-7.0.Z:libvirt-login-shell-0:1.1.1-29.el7_0.4.s390x",
+            "7Server-7.0.Z:libvirt-login-shell-0:1.1.1-29.el7_0.4.x86_64",
+            "7Server-7.0.Z:libvirt-python-0:1.1.1-29.el7_0.4.ppc64",
+            "7Server-7.0.Z:libvirt-python-0:1.1.1-29.el7_0.4.s390x",
+            "7Server-7.0.Z:libvirt-python-0:1.1.1-29.el7_0.4.x86_64",
+            "7Server-optional-7.0.Z:libvirt-0:1.1.1-29.el7_0.4.ppc64",
+            "7Server-optional-7.0.Z:libvirt-0:1.1.1-29.el7_0.4.s390x",
+            "7Server-optional-7.0.Z:libvirt-0:1.1.1-29.el7_0.4.src",
+            "7Server-optional-7.0.Z:libvirt-0:1.1.1-29.el7_0.4.x86_64",
+            "7Server-optional-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.i686",
+            "7Server-optional-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.ppc",
+            "7Server-optional-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.ppc64",
+            "7Server-optional-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.s390",
+            "7Server-optional-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.s390x",
+            "7Server-optional-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.x86_64",
+            "7Server-optional-7.0.Z:libvirt-daemon-0:1.1.1-29.el7_0.4.ppc64",
+            "7Server-optional-7.0.Z:libvirt-daemon-0:1.1.1-29.el7_0.4.s390x",
+            "7Server-optional-7.0.Z:libvirt-daemon-0:1.1.1-29.el7_0.4.x86_64",
+            "7Server-optional-7.0.Z:libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.ppc64",
+            "7Server-optional-7.0.Z:libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.s390x",
+            "7Server-optional-7.0.Z:libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.x86_64",
+            "7Server-optional-7.0.Z:libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.ppc64",
+            "7Server-optional-7.0.Z:libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.s390x",
+            "7Server-optional-7.0.Z:libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.x86_64",
+            "7Server-optional-7.0.Z:libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.ppc64",
+            "7Server-optional-7.0.Z:libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.s390x",
+            "7Server-optional-7.0.Z:libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.x86_64",
+            "7Server-optional-7.0.Z:libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.ppc64",
+            "7Server-optional-7.0.Z:libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.s390x",
+            "7Server-optional-7.0.Z:libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.x86_64",
+            "7Server-optional-7.0.Z:libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.ppc64",
+            "7Server-optional-7.0.Z:libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.s390x",
+            "7Server-optional-7.0.Z:libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.x86_64",
+            "7Server-optional-7.0.Z:libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.ppc64",
+            "7Server-optional-7.0.Z:libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.s390x",
+            "7Server-optional-7.0.Z:libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.x86_64",
+            "7Server-optional-7.0.Z:libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.ppc64",
+            "7Server-optional-7.0.Z:libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.s390x",
+            "7Server-optional-7.0.Z:libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.x86_64",
+            "7Server-optional-7.0.Z:libvirt-daemon-driver-qemu-0:1.1.1-29.el7_0.4.x86_64",
+            "7Server-optional-7.0.Z:libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.ppc64",
+            "7Server-optional-7.0.Z:libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.s390x",
+            "7Server-optional-7.0.Z:libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.x86_64",
+            "7Server-optional-7.0.Z:libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.ppc64",
+            "7Server-optional-7.0.Z:libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.s390x",
+            "7Server-optional-7.0.Z:libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.x86_64",
+            "7Server-optional-7.0.Z:libvirt-daemon-kvm-0:1.1.1-29.el7_0.4.x86_64",
+            "7Server-optional-7.0.Z:libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.ppc64",
+            "7Server-optional-7.0.Z:libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.s390x",
+            "7Server-optional-7.0.Z:libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.x86_64",
+            "7Server-optional-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.i686",
+            "7Server-optional-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.ppc",
+            "7Server-optional-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.ppc64",
+            "7Server-optional-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.s390",
+            "7Server-optional-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.s390x",
+            "7Server-optional-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.x86_64",
+            "7Server-optional-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.i686",
+            "7Server-optional-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.ppc",
+            "7Server-optional-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.ppc64",
+            "7Server-optional-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.s390",
+            "7Server-optional-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.s390x",
+            "7Server-optional-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.x86_64",
+            "7Server-optional-7.0.Z:libvirt-docs-0:1.1.1-29.el7_0.4.ppc64",
+            "7Server-optional-7.0.Z:libvirt-docs-0:1.1.1-29.el7_0.4.s390x",
+            "7Server-optional-7.0.Z:libvirt-docs-0:1.1.1-29.el7_0.4.x86_64",
+            "7Server-optional-7.0.Z:libvirt-lock-sanlock-0:1.1.1-29.el7_0.4.x86_64",
+            "7Server-optional-7.0.Z:libvirt-login-shell-0:1.1.1-29.el7_0.4.ppc64",
+            "7Server-optional-7.0.Z:libvirt-login-shell-0:1.1.1-29.el7_0.4.s390x",
+            "7Server-optional-7.0.Z:libvirt-login-shell-0:1.1.1-29.el7_0.4.x86_64",
+            "7Server-optional-7.0.Z:libvirt-python-0:1.1.1-29.el7_0.4.ppc64",
+            "7Server-optional-7.0.Z:libvirt-python-0:1.1.1-29.el7_0.4.s390x",
+            "7Server-optional-7.0.Z:libvirt-python-0:1.1.1-29.el7_0.4.x86_64",
+            "7Workstation-7.0.Z:libvirt-0:1.1.1-29.el7_0.4.ppc64",
+            "7Workstation-7.0.Z:libvirt-0:1.1.1-29.el7_0.4.s390x",
+            "7Workstation-7.0.Z:libvirt-0:1.1.1-29.el7_0.4.src",
+            "7Workstation-7.0.Z:libvirt-0:1.1.1-29.el7_0.4.x86_64",
+            "7Workstation-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.i686",
+            "7Workstation-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.ppc",
+            "7Workstation-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.ppc64",
+            "7Workstation-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.s390",
+            "7Workstation-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.s390x",
+            "7Workstation-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.x86_64",
+            "7Workstation-7.0.Z:libvirt-daemon-0:1.1.1-29.el7_0.4.ppc64",
+            "7Workstation-7.0.Z:libvirt-daemon-0:1.1.1-29.el7_0.4.s390x",
+            "7Workstation-7.0.Z:libvirt-daemon-0:1.1.1-29.el7_0.4.x86_64",
+            "7Workstation-7.0.Z:libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.ppc64",
+            "7Workstation-7.0.Z:libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.s390x",
+            "7Workstation-7.0.Z:libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.x86_64",
+            "7Workstation-7.0.Z:libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.ppc64",
+            "7Workstation-7.0.Z:libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.s390x",
+            "7Workstation-7.0.Z:libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.x86_64",
+            "7Workstation-7.0.Z:libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.ppc64",
+            "7Workstation-7.0.Z:libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.s390x",
+            "7Workstation-7.0.Z:libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.x86_64",
+            "7Workstation-7.0.Z:libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.ppc64",
+            "7Workstation-7.0.Z:libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.s390x",
+            "7Workstation-7.0.Z:libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.x86_64",
+            "7Workstation-7.0.Z:libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.ppc64",
+            "7Workstation-7.0.Z:libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.s390x",
+            "7Workstation-7.0.Z:libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.x86_64",
+            "7Workstation-7.0.Z:libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.ppc64",
+            "7Workstation-7.0.Z:libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.s390x",
+            "7Workstation-7.0.Z:libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.x86_64",
+            "7Workstation-7.0.Z:libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.ppc64",
+            "7Workstation-7.0.Z:libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.s390x",
+            "7Workstation-7.0.Z:libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.x86_64",
+            "7Workstation-7.0.Z:libvirt-daemon-driver-qemu-0:1.1.1-29.el7_0.4.x86_64",
+            "7Workstation-7.0.Z:libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.ppc64",
+            "7Workstation-7.0.Z:libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.s390x",
+            "7Workstation-7.0.Z:libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.x86_64",
+            "7Workstation-7.0.Z:libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.ppc64",
+            "7Workstation-7.0.Z:libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.s390x",
+            "7Workstation-7.0.Z:libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.x86_64",
+            "7Workstation-7.0.Z:libvirt-daemon-kvm-0:1.1.1-29.el7_0.4.x86_64",
+            "7Workstation-7.0.Z:libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.ppc64",
+            "7Workstation-7.0.Z:libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.s390x",
+            "7Workstation-7.0.Z:libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.x86_64",
+            "7Workstation-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.i686",
+            "7Workstation-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.ppc",
+            "7Workstation-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.ppc64",
+            "7Workstation-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.s390",
+            "7Workstation-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.s390x",
+            "7Workstation-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.x86_64",
+            "7Workstation-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.i686",
+            "7Workstation-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.ppc",
+            "7Workstation-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.ppc64",
+            "7Workstation-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.s390",
+            "7Workstation-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.s390x",
+            "7Workstation-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.x86_64",
+            "7Workstation-7.0.Z:libvirt-docs-0:1.1.1-29.el7_0.4.ppc64",
+            "7Workstation-7.0.Z:libvirt-docs-0:1.1.1-29.el7_0.4.s390x",
+            "7Workstation-7.0.Z:libvirt-docs-0:1.1.1-29.el7_0.4.x86_64",
+            "7Workstation-7.0.Z:libvirt-lock-sanlock-0:1.1.1-29.el7_0.4.x86_64",
+            "7Workstation-7.0.Z:libvirt-login-shell-0:1.1.1-29.el7_0.4.ppc64",
+            "7Workstation-7.0.Z:libvirt-login-shell-0:1.1.1-29.el7_0.4.s390x",
+            "7Workstation-7.0.Z:libvirt-login-shell-0:1.1.1-29.el7_0.4.x86_64",
+            "7Workstation-7.0.Z:libvirt-python-0:1.1.1-29.el7_0.4.ppc64",
+            "7Workstation-7.0.Z:libvirt-python-0:1.1.1-29.el7_0.4.s390x",
+            "7Workstation-7.0.Z:libvirt-python-0:1.1.1-29.el7_0.4.x86_64",
+            "7Workstation-optional-7.0.Z:libvirt-0:1.1.1-29.el7_0.4.ppc64",
+            "7Workstation-optional-7.0.Z:libvirt-0:1.1.1-29.el7_0.4.s390x",
+            "7Workstation-optional-7.0.Z:libvirt-0:1.1.1-29.el7_0.4.src",
+            "7Workstation-optional-7.0.Z:libvirt-0:1.1.1-29.el7_0.4.x86_64",
+            "7Workstation-optional-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.i686",
+            "7Workstation-optional-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.ppc",
+            "7Workstation-optional-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.ppc64",
+            "7Workstation-optional-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.s390",
+            "7Workstation-optional-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.s390x",
+            "7Workstation-optional-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.x86_64",
+            "7Workstation-optional-7.0.Z:libvirt-daemon-0:1.1.1-29.el7_0.4.ppc64",
+            "7Workstation-optional-7.0.Z:libvirt-daemon-0:1.1.1-29.el7_0.4.s390x",
+            "7Workstation-optional-7.0.Z:libvirt-daemon-0:1.1.1-29.el7_0.4.x86_64",
+            "7Workstation-optional-7.0.Z:libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.ppc64",
+            "7Workstation-optional-7.0.Z:libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.s390x",
+            "7Workstation-optional-7.0.Z:libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.x86_64",
+            "7Workstation-optional-7.0.Z:libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.ppc64",
+            "7Workstation-optional-7.0.Z:libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.s390x",
+            "7Workstation-optional-7.0.Z:libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.x86_64",
+            "7Workstation-optional-7.0.Z:libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.ppc64",
+            "7Workstation-optional-7.0.Z:libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.s390x",
+            "7Workstation-optional-7.0.Z:libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.x86_64",
+            "7Workstation-optional-7.0.Z:libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.ppc64",
+            "7Workstation-optional-7.0.Z:libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.s390x",
+            "7Workstation-optional-7.0.Z:libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.x86_64",
+            "7Workstation-optional-7.0.Z:libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.ppc64",
+            "7Workstation-optional-7.0.Z:libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.s390x",
+            "7Workstation-optional-7.0.Z:libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.x86_64",
+            "7Workstation-optional-7.0.Z:libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.ppc64",
+            "7Workstation-optional-7.0.Z:libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.s390x",
+            "7Workstation-optional-7.0.Z:libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.x86_64",
+            "7Workstation-optional-7.0.Z:libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.ppc64",
+            "7Workstation-optional-7.0.Z:libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.s390x",
+            "7Workstation-optional-7.0.Z:libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.x86_64",
+            "7Workstation-optional-7.0.Z:libvirt-daemon-driver-qemu-0:1.1.1-29.el7_0.4.x86_64",
+            "7Workstation-optional-7.0.Z:libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.ppc64",
+            "7Workstation-optional-7.0.Z:libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.s390x",
+            "7Workstation-optional-7.0.Z:libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.x86_64",
+            "7Workstation-optional-7.0.Z:libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.ppc64",
+            "7Workstation-optional-7.0.Z:libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.s390x",
+            "7Workstation-optional-7.0.Z:libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.x86_64",
+            "7Workstation-optional-7.0.Z:libvirt-daemon-kvm-0:1.1.1-29.el7_0.4.x86_64",
+            "7Workstation-optional-7.0.Z:libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.ppc64",
+            "7Workstation-optional-7.0.Z:libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.s390x",
+            "7Workstation-optional-7.0.Z:libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.x86_64",
+            "7Workstation-optional-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.i686",
+            "7Workstation-optional-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.ppc",
+            "7Workstation-optional-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.ppc64",
+            "7Workstation-optional-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.s390",
+            "7Workstation-optional-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.s390x",
+            "7Workstation-optional-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.x86_64",
+            "7Workstation-optional-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.i686",
+            "7Workstation-optional-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.ppc",
+            "7Workstation-optional-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.ppc64",
+            "7Workstation-optional-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.s390",
+            "7Workstation-optional-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.s390x",
+            "7Workstation-optional-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.x86_64",
+            "7Workstation-optional-7.0.Z:libvirt-docs-0:1.1.1-29.el7_0.4.ppc64",
+            "7Workstation-optional-7.0.Z:libvirt-docs-0:1.1.1-29.el7_0.4.s390x",
+            "7Workstation-optional-7.0.Z:libvirt-docs-0:1.1.1-29.el7_0.4.x86_64",
+            "7Workstation-optional-7.0.Z:libvirt-lock-sanlock-0:1.1.1-29.el7_0.4.x86_64",
+            "7Workstation-optional-7.0.Z:libvirt-login-shell-0:1.1.1-29.el7_0.4.ppc64",
+            "7Workstation-optional-7.0.Z:libvirt-login-shell-0:1.1.1-29.el7_0.4.s390x",
+            "7Workstation-optional-7.0.Z:libvirt-login-shell-0:1.1.1-29.el7_0.4.x86_64",
+            "7Workstation-optional-7.0.Z:libvirt-python-0:1.1.1-29.el7_0.4.ppc64",
+            "7Workstation-optional-7.0.Z:libvirt-python-0:1.1.1-29.el7_0.4.s390x",
+            "7Workstation-optional-7.0.Z:libvirt-python-0:1.1.1-29.el7_0.4.x86_64"
+          ],
+          "restart_required": {
+            "category": "none"
+          },
+          "url": "https://access.redhat.com/errata/RHSA-2015:0008"
+        }
+      ],
+      "scores": [
+        {
+          "cvss_v2": {
+            "accessComplexity": "LOW",
+            "accessVector": "ADJACENT_NETWORK",
+            "authentication": "NONE",
+            "availabilityImpact": "NONE",
+            "baseScore": 3.3,
+            "confidentialityImpact": "PARTIAL",
+            "integrityImpact": "NONE",
+            "vectorString": "AV:A/AC:L/Au:N/C:P/I:N/A:N",
+            "version": "2.0"
+          },
+          "products": [
+            "7Client-7.0.Z:libvirt-0:1.1.1-29.el7_0.4.ppc64",
+            "7Client-7.0.Z:libvirt-0:1.1.1-29.el7_0.4.s390x",
+            "7Client-7.0.Z:libvirt-0:1.1.1-29.el7_0.4.src",
+            "7Client-7.0.Z:libvirt-0:1.1.1-29.el7_0.4.x86_64",
+            "7Client-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.i686",
+            "7Client-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.ppc",
+            "7Client-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.ppc64",
+            "7Client-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.s390",
+            "7Client-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.s390x",
+            "7Client-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.x86_64",
+            "7Client-7.0.Z:libvirt-daemon-0:1.1.1-29.el7_0.4.ppc64",
+            "7Client-7.0.Z:libvirt-daemon-0:1.1.1-29.el7_0.4.s390x",
+            "7Client-7.0.Z:libvirt-daemon-0:1.1.1-29.el7_0.4.x86_64",
+            "7Client-7.0.Z:libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.ppc64",
+            "7Client-7.0.Z:libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.s390x",
+            "7Client-7.0.Z:libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.x86_64",
+            "7Client-7.0.Z:libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.ppc64",
+            "7Client-7.0.Z:libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.s390x",
+            "7Client-7.0.Z:libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.x86_64",
+            "7Client-7.0.Z:libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.ppc64",
+            "7Client-7.0.Z:libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.s390x",
+            "7Client-7.0.Z:libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.x86_64",
+            "7Client-7.0.Z:libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.ppc64",
+            "7Client-7.0.Z:libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.s390x",
+            "7Client-7.0.Z:libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.x86_64",
+            "7Client-7.0.Z:libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.ppc64",
+            "7Client-7.0.Z:libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.s390x",
+            "7Client-7.0.Z:libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.x86_64",
+            "7Client-7.0.Z:libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.ppc64",
+            "7Client-7.0.Z:libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.s390x",
+            "7Client-7.0.Z:libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.x86_64",
+            "7Client-7.0.Z:libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.ppc64",
+            "7Client-7.0.Z:libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.s390x",
+            "7Client-7.0.Z:libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.x86_64",
+            "7Client-7.0.Z:libvirt-daemon-driver-qemu-0:1.1.1-29.el7_0.4.x86_64",
+            "7Client-7.0.Z:libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.ppc64",
+            "7Client-7.0.Z:libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.s390x",
+            "7Client-7.0.Z:libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.x86_64",
+            "7Client-7.0.Z:libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.ppc64",
+            "7Client-7.0.Z:libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.s390x",
+            "7Client-7.0.Z:libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.x86_64",
+            "7Client-7.0.Z:libvirt-daemon-kvm-0:1.1.1-29.el7_0.4.x86_64",
+            "7Client-7.0.Z:libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.ppc64",
+            "7Client-7.0.Z:libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.s390x",
+            "7Client-7.0.Z:libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.x86_64",
+            "7Client-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.i686",
+            "7Client-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.ppc",
+            "7Client-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.ppc64",
+            "7Client-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.s390",
+            "7Client-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.s390x",
+            "7Client-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.x86_64",
+            "7Client-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.i686",
+            "7Client-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.ppc",
+            "7Client-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.ppc64",
+            "7Client-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.s390",
+            "7Client-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.s390x",
+            "7Client-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.x86_64",
+            "7Client-7.0.Z:libvirt-docs-0:1.1.1-29.el7_0.4.ppc64",
+            "7Client-7.0.Z:libvirt-docs-0:1.1.1-29.el7_0.4.s390x",
+            "7Client-7.0.Z:libvirt-docs-0:1.1.1-29.el7_0.4.x86_64",
+            "7Client-7.0.Z:libvirt-lock-sanlock-0:1.1.1-29.el7_0.4.x86_64",
+            "7Client-7.0.Z:libvirt-login-shell-0:1.1.1-29.el7_0.4.ppc64",
+            "7Client-7.0.Z:libvirt-login-shell-0:1.1.1-29.el7_0.4.s390x",
+            "7Client-7.0.Z:libvirt-login-shell-0:1.1.1-29.el7_0.4.x86_64",
+            "7Client-7.0.Z:libvirt-python-0:1.1.1-29.el7_0.4.ppc64",
+            "7Client-7.0.Z:libvirt-python-0:1.1.1-29.el7_0.4.s390x",
+            "7Client-7.0.Z:libvirt-python-0:1.1.1-29.el7_0.4.x86_64",
+            "7Client-optional-7.0.Z:libvirt-0:1.1.1-29.el7_0.4.ppc64",
+            "7Client-optional-7.0.Z:libvirt-0:1.1.1-29.el7_0.4.s390x",
+            "7Client-optional-7.0.Z:libvirt-0:1.1.1-29.el7_0.4.src",
+            "7Client-optional-7.0.Z:libvirt-0:1.1.1-29.el7_0.4.x86_64",
+            "7Client-optional-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.i686",
+            "7Client-optional-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.ppc",
+            "7Client-optional-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.ppc64",
+            "7Client-optional-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.s390",
+            "7Client-optional-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.s390x",
+            "7Client-optional-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.x86_64",
+            "7Client-optional-7.0.Z:libvirt-daemon-0:1.1.1-29.el7_0.4.ppc64",
+            "7Client-optional-7.0.Z:libvirt-daemon-0:1.1.1-29.el7_0.4.s390x",
+            "7Client-optional-7.0.Z:libvirt-daemon-0:1.1.1-29.el7_0.4.x86_64",
+            "7Client-optional-7.0.Z:libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.ppc64",
+            "7Client-optional-7.0.Z:libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.s390x",
+            "7Client-optional-7.0.Z:libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.x86_64",
+            "7Client-optional-7.0.Z:libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.ppc64",
+            "7Client-optional-7.0.Z:libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.s390x",
+            "7Client-optional-7.0.Z:libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.x86_64",
+            "7Client-optional-7.0.Z:libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.ppc64",
+            "7Client-optional-7.0.Z:libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.s390x",
+            "7Client-optional-7.0.Z:libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.x86_64",
+            "7Client-optional-7.0.Z:libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.ppc64",
+            "7Client-optional-7.0.Z:libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.s390x",
+            "7Client-optional-7.0.Z:libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.x86_64",
+            "7Client-optional-7.0.Z:libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.ppc64",
+            "7Client-optional-7.0.Z:libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.s390x",
+            "7Client-optional-7.0.Z:libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.x86_64",
+            "7Client-optional-7.0.Z:libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.ppc64",
+            "7Client-optional-7.0.Z:libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.s390x",
+            "7Client-optional-7.0.Z:libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.x86_64",
+            "7Client-optional-7.0.Z:libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.ppc64",
+            "7Client-optional-7.0.Z:libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.s390x",
+            "7Client-optional-7.0.Z:libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.x86_64",
+            "7Client-optional-7.0.Z:libvirt-daemon-driver-qemu-0:1.1.1-29.el7_0.4.x86_64",
+            "7Client-optional-7.0.Z:libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.ppc64",
+            "7Client-optional-7.0.Z:libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.s390x",
+            "7Client-optional-7.0.Z:libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.x86_64",
+            "7Client-optional-7.0.Z:libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.ppc64",
+            "7Client-optional-7.0.Z:libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.s390x",
+            "7Client-optional-7.0.Z:libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.x86_64",
+            "7Client-optional-7.0.Z:libvirt-daemon-kvm-0:1.1.1-29.el7_0.4.x86_64",
+            "7Client-optional-7.0.Z:libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.ppc64",
+            "7Client-optional-7.0.Z:libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.s390x",
+            "7Client-optional-7.0.Z:libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.x86_64",
+            "7Client-optional-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.i686",
+            "7Client-optional-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.ppc",
+            "7Client-optional-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.ppc64",
+            "7Client-optional-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.s390",
+            "7Client-optional-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.s390x",
+            "7Client-optional-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.x86_64",
+            "7Client-optional-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.i686",
+            "7Client-optional-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.ppc",
+            "7Client-optional-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.ppc64",
+            "7Client-optional-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.s390",
+            "7Client-optional-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.s390x",
+            "7Client-optional-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.x86_64",
+            "7Client-optional-7.0.Z:libvirt-docs-0:1.1.1-29.el7_0.4.ppc64",
+            "7Client-optional-7.0.Z:libvirt-docs-0:1.1.1-29.el7_0.4.s390x",
+            "7Client-optional-7.0.Z:libvirt-docs-0:1.1.1-29.el7_0.4.x86_64",
+            "7Client-optional-7.0.Z:libvirt-lock-sanlock-0:1.1.1-29.el7_0.4.x86_64",
+            "7Client-optional-7.0.Z:libvirt-login-shell-0:1.1.1-29.el7_0.4.ppc64",
+            "7Client-optional-7.0.Z:libvirt-login-shell-0:1.1.1-29.el7_0.4.s390x",
+            "7Client-optional-7.0.Z:libvirt-login-shell-0:1.1.1-29.el7_0.4.x86_64",
+            "7Client-optional-7.0.Z:libvirt-python-0:1.1.1-29.el7_0.4.ppc64",
+            "7Client-optional-7.0.Z:libvirt-python-0:1.1.1-29.el7_0.4.s390x",
+            "7Client-optional-7.0.Z:libvirt-python-0:1.1.1-29.el7_0.4.x86_64",
+            "7ComputeNode-7.0.Z:libvirt-0:1.1.1-29.el7_0.4.ppc64",
+            "7ComputeNode-7.0.Z:libvirt-0:1.1.1-29.el7_0.4.s390x",
+            "7ComputeNode-7.0.Z:libvirt-0:1.1.1-29.el7_0.4.src",
+            "7ComputeNode-7.0.Z:libvirt-0:1.1.1-29.el7_0.4.x86_64",
+            "7ComputeNode-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.i686",
+            "7ComputeNode-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.ppc",
+            "7ComputeNode-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.ppc64",
+            "7ComputeNode-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.s390",
+            "7ComputeNode-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.s390x",
+            "7ComputeNode-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.x86_64",
+            "7ComputeNode-7.0.Z:libvirt-daemon-0:1.1.1-29.el7_0.4.ppc64",
+            "7ComputeNode-7.0.Z:libvirt-daemon-0:1.1.1-29.el7_0.4.s390x",
+            "7ComputeNode-7.0.Z:libvirt-daemon-0:1.1.1-29.el7_0.4.x86_64",
+            "7ComputeNode-7.0.Z:libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.ppc64",
+            "7ComputeNode-7.0.Z:libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.s390x",
+            "7ComputeNode-7.0.Z:libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.x86_64",
+            "7ComputeNode-7.0.Z:libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.ppc64",
+            "7ComputeNode-7.0.Z:libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.s390x",
+            "7ComputeNode-7.0.Z:libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.x86_64",
+            "7ComputeNode-7.0.Z:libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.ppc64",
+            "7ComputeNode-7.0.Z:libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.s390x",
+            "7ComputeNode-7.0.Z:libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.x86_64",
+            "7ComputeNode-7.0.Z:libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.ppc64",
+            "7ComputeNode-7.0.Z:libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.s390x",
+            "7ComputeNode-7.0.Z:libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.x86_64",
+            "7ComputeNode-7.0.Z:libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.ppc64",
+            "7ComputeNode-7.0.Z:libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.s390x",
+            "7ComputeNode-7.0.Z:libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.x86_64",
+            "7ComputeNode-7.0.Z:libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.ppc64",
+            "7ComputeNode-7.0.Z:libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.s390x",
+            "7ComputeNode-7.0.Z:libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.x86_64",
+            "7ComputeNode-7.0.Z:libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.ppc64",
+            "7ComputeNode-7.0.Z:libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.s390x",
+            "7ComputeNode-7.0.Z:libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.x86_64",
+            "7ComputeNode-7.0.Z:libvirt-daemon-driver-qemu-0:1.1.1-29.el7_0.4.x86_64",
+            "7ComputeNode-7.0.Z:libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.ppc64",
+            "7ComputeNode-7.0.Z:libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.s390x",
+            "7ComputeNode-7.0.Z:libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.x86_64",
+            "7ComputeNode-7.0.Z:libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.ppc64",
+            "7ComputeNode-7.0.Z:libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.s390x",
+            "7ComputeNode-7.0.Z:libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.x86_64",
+            "7ComputeNode-7.0.Z:libvirt-daemon-kvm-0:1.1.1-29.el7_0.4.x86_64",
+            "7ComputeNode-7.0.Z:libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.ppc64",
+            "7ComputeNode-7.0.Z:libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.s390x",
+            "7ComputeNode-7.0.Z:libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.x86_64",
+            "7ComputeNode-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.i686",
+            "7ComputeNode-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.ppc",
+            "7ComputeNode-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.ppc64",
+            "7ComputeNode-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.s390",
+            "7ComputeNode-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.s390x",
+            "7ComputeNode-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.x86_64",
+            "7ComputeNode-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.i686",
+            "7ComputeNode-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.ppc",
+            "7ComputeNode-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.ppc64",
+            "7ComputeNode-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.s390",
+            "7ComputeNode-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.s390x",
+            "7ComputeNode-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.x86_64",
+            "7ComputeNode-7.0.Z:libvirt-docs-0:1.1.1-29.el7_0.4.ppc64",
+            "7ComputeNode-7.0.Z:libvirt-docs-0:1.1.1-29.el7_0.4.s390x",
+            "7ComputeNode-7.0.Z:libvirt-docs-0:1.1.1-29.el7_0.4.x86_64",
+            "7ComputeNode-7.0.Z:libvirt-lock-sanlock-0:1.1.1-29.el7_0.4.x86_64",
+            "7ComputeNode-7.0.Z:libvirt-login-shell-0:1.1.1-29.el7_0.4.ppc64",
+            "7ComputeNode-7.0.Z:libvirt-login-shell-0:1.1.1-29.el7_0.4.s390x",
+            "7ComputeNode-7.0.Z:libvirt-login-shell-0:1.1.1-29.el7_0.4.x86_64",
+            "7ComputeNode-7.0.Z:libvirt-python-0:1.1.1-29.el7_0.4.ppc64",
+            "7ComputeNode-7.0.Z:libvirt-python-0:1.1.1-29.el7_0.4.s390x",
+            "7ComputeNode-7.0.Z:libvirt-python-0:1.1.1-29.el7_0.4.x86_64",
+            "7ComputeNode-optional-7.0.Z:libvirt-0:1.1.1-29.el7_0.4.ppc64",
+            "7ComputeNode-optional-7.0.Z:libvirt-0:1.1.1-29.el7_0.4.s390x",
+            "7ComputeNode-optional-7.0.Z:libvirt-0:1.1.1-29.el7_0.4.src",
+            "7ComputeNode-optional-7.0.Z:libvirt-0:1.1.1-29.el7_0.4.x86_64",
+            "7ComputeNode-optional-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.i686",
+            "7ComputeNode-optional-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.ppc",
+            "7ComputeNode-optional-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.ppc64",
+            "7ComputeNode-optional-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.s390",
+            "7ComputeNode-optional-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.s390x",
+            "7ComputeNode-optional-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.x86_64",
+            "7ComputeNode-optional-7.0.Z:libvirt-daemon-0:1.1.1-29.el7_0.4.ppc64",
+            "7ComputeNode-optional-7.0.Z:libvirt-daemon-0:1.1.1-29.el7_0.4.s390x",
+            "7ComputeNode-optional-7.0.Z:libvirt-daemon-0:1.1.1-29.el7_0.4.x86_64",
+            "7ComputeNode-optional-7.0.Z:libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.ppc64",
+            "7ComputeNode-optional-7.0.Z:libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.s390x",
+            "7ComputeNode-optional-7.0.Z:libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.x86_64",
+            "7ComputeNode-optional-7.0.Z:libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.ppc64",
+            "7ComputeNode-optional-7.0.Z:libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.s390x",
+            "7ComputeNode-optional-7.0.Z:libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.x86_64",
+            "7ComputeNode-optional-7.0.Z:libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.ppc64",
+            "7ComputeNode-optional-7.0.Z:libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.s390x",
+            "7ComputeNode-optional-7.0.Z:libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.x86_64",
+            "7ComputeNode-optional-7.0.Z:libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.ppc64",
+            "7ComputeNode-optional-7.0.Z:libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.s390x",
+            "7ComputeNode-optional-7.0.Z:libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.x86_64",
+            "7ComputeNode-optional-7.0.Z:libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.ppc64",
+            "7ComputeNode-optional-7.0.Z:libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.s390x",
+            "7ComputeNode-optional-7.0.Z:libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.x86_64",
+            "7ComputeNode-optional-7.0.Z:libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.ppc64",
+            "7ComputeNode-optional-7.0.Z:libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.s390x",
+            "7ComputeNode-optional-7.0.Z:libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.x86_64",
+            "7ComputeNode-optional-7.0.Z:libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.ppc64",
+            "7ComputeNode-optional-7.0.Z:libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.s390x",
+            "7ComputeNode-optional-7.0.Z:libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.x86_64",
+            "7ComputeNode-optional-7.0.Z:libvirt-daemon-driver-qemu-0:1.1.1-29.el7_0.4.x86_64",
+            "7ComputeNode-optional-7.0.Z:libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.ppc64",
+            "7ComputeNode-optional-7.0.Z:libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.s390x",
+            "7ComputeNode-optional-7.0.Z:libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.x86_64",
+            "7ComputeNode-optional-7.0.Z:libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.ppc64",
+            "7ComputeNode-optional-7.0.Z:libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.s390x",
+            "7ComputeNode-optional-7.0.Z:libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.x86_64",
+            "7ComputeNode-optional-7.0.Z:libvirt-daemon-kvm-0:1.1.1-29.el7_0.4.x86_64",
+            "7ComputeNode-optional-7.0.Z:libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.ppc64",
+            "7ComputeNode-optional-7.0.Z:libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.s390x",
+            "7ComputeNode-optional-7.0.Z:libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.x86_64",
+            "7ComputeNode-optional-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.i686",
+            "7ComputeNode-optional-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.ppc",
+            "7ComputeNode-optional-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.ppc64",
+            "7ComputeNode-optional-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.s390",
+            "7ComputeNode-optional-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.s390x",
+            "7ComputeNode-optional-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.x86_64",
+            "7ComputeNode-optional-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.i686",
+            "7ComputeNode-optional-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.ppc",
+            "7ComputeNode-optional-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.ppc64",
+            "7ComputeNode-optional-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.s390",
+            "7ComputeNode-optional-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.s390x",
+            "7ComputeNode-optional-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.x86_64",
+            "7ComputeNode-optional-7.0.Z:libvirt-docs-0:1.1.1-29.el7_0.4.ppc64",
+            "7ComputeNode-optional-7.0.Z:libvirt-docs-0:1.1.1-29.el7_0.4.s390x",
+            "7ComputeNode-optional-7.0.Z:libvirt-docs-0:1.1.1-29.el7_0.4.x86_64",
+            "7ComputeNode-optional-7.0.Z:libvirt-lock-sanlock-0:1.1.1-29.el7_0.4.x86_64",
+            "7ComputeNode-optional-7.0.Z:libvirt-login-shell-0:1.1.1-29.el7_0.4.ppc64",
+            "7ComputeNode-optional-7.0.Z:libvirt-login-shell-0:1.1.1-29.el7_0.4.s390x",
+            "7ComputeNode-optional-7.0.Z:libvirt-login-shell-0:1.1.1-29.el7_0.4.x86_64",
+            "7ComputeNode-optional-7.0.Z:libvirt-python-0:1.1.1-29.el7_0.4.ppc64",
+            "7ComputeNode-optional-7.0.Z:libvirt-python-0:1.1.1-29.el7_0.4.s390x",
+            "7ComputeNode-optional-7.0.Z:libvirt-python-0:1.1.1-29.el7_0.4.x86_64",
+            "7Server-7.0.Z:libvirt-0:1.1.1-29.el7_0.4.ppc64",
+            "7Server-7.0.Z:libvirt-0:1.1.1-29.el7_0.4.s390x",
+            "7Server-7.0.Z:libvirt-0:1.1.1-29.el7_0.4.src",
+            "7Server-7.0.Z:libvirt-0:1.1.1-29.el7_0.4.x86_64",
+            "7Server-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.i686",
+            "7Server-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.ppc",
+            "7Server-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.ppc64",
+            "7Server-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.s390",
+            "7Server-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.s390x",
+            "7Server-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.x86_64",
+            "7Server-7.0.Z:libvirt-daemon-0:1.1.1-29.el7_0.4.ppc64",
+            "7Server-7.0.Z:libvirt-daemon-0:1.1.1-29.el7_0.4.s390x",
+            "7Server-7.0.Z:libvirt-daemon-0:1.1.1-29.el7_0.4.x86_64",
+            "7Server-7.0.Z:libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.ppc64",
+            "7Server-7.0.Z:libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.s390x",
+            "7Server-7.0.Z:libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.x86_64",
+            "7Server-7.0.Z:libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.ppc64",
+            "7Server-7.0.Z:libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.s390x",
+            "7Server-7.0.Z:libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.x86_64",
+            "7Server-7.0.Z:libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.ppc64",
+            "7Server-7.0.Z:libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.s390x",
+            "7Server-7.0.Z:libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.x86_64",
+            "7Server-7.0.Z:libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.ppc64",
+            "7Server-7.0.Z:libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.s390x",
+            "7Server-7.0.Z:libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.x86_64",
+            "7Server-7.0.Z:libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.ppc64",
+            "7Server-7.0.Z:libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.s390x",
+            "7Server-7.0.Z:libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.x86_64",
+            "7Server-7.0.Z:libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.ppc64",
+            "7Server-7.0.Z:libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.s390x",
+            "7Server-7.0.Z:libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.x86_64",
+            "7Server-7.0.Z:libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.ppc64",
+            "7Server-7.0.Z:libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.s390x",
+            "7Server-7.0.Z:libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.x86_64",
+            "7Server-7.0.Z:libvirt-daemon-driver-qemu-0:1.1.1-29.el7_0.4.x86_64",
+            "7Server-7.0.Z:libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.ppc64",
+            "7Server-7.0.Z:libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.s390x",
+            "7Server-7.0.Z:libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.x86_64",
+            "7Server-7.0.Z:libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.ppc64",
+            "7Server-7.0.Z:libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.s390x",
+            "7Server-7.0.Z:libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.x86_64",
+            "7Server-7.0.Z:libvirt-daemon-kvm-0:1.1.1-29.el7_0.4.x86_64",
+            "7Server-7.0.Z:libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.ppc64",
+            "7Server-7.0.Z:libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.s390x",
+            "7Server-7.0.Z:libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.x86_64",
+            "7Server-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.i686",
+            "7Server-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.ppc",
+            "7Server-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.ppc64",
+            "7Server-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.s390",
+            "7Server-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.s390x",
+            "7Server-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.x86_64",
+            "7Server-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.i686",
+            "7Server-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.ppc",
+            "7Server-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.ppc64",
+            "7Server-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.s390",
+            "7Server-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.s390x",
+            "7Server-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.x86_64",
+            "7Server-7.0.Z:libvirt-docs-0:1.1.1-29.el7_0.4.ppc64",
+            "7Server-7.0.Z:libvirt-docs-0:1.1.1-29.el7_0.4.s390x",
+            "7Server-7.0.Z:libvirt-docs-0:1.1.1-29.el7_0.4.x86_64",
+            "7Server-7.0.Z:libvirt-lock-sanlock-0:1.1.1-29.el7_0.4.x86_64",
+            "7Server-7.0.Z:libvirt-login-shell-0:1.1.1-29.el7_0.4.ppc64",
+            "7Server-7.0.Z:libvirt-login-shell-0:1.1.1-29.el7_0.4.s390x",
+            "7Server-7.0.Z:libvirt-login-shell-0:1.1.1-29.el7_0.4.x86_64",
+            "7Server-7.0.Z:libvirt-python-0:1.1.1-29.el7_0.4.ppc64",
+            "7Server-7.0.Z:libvirt-python-0:1.1.1-29.el7_0.4.s390x",
+            "7Server-7.0.Z:libvirt-python-0:1.1.1-29.el7_0.4.x86_64",
+            "7Server-optional-7.0.Z:libvirt-0:1.1.1-29.el7_0.4.ppc64",
+            "7Server-optional-7.0.Z:libvirt-0:1.1.1-29.el7_0.4.s390x",
+            "7Server-optional-7.0.Z:libvirt-0:1.1.1-29.el7_0.4.src",
+            "7Server-optional-7.0.Z:libvirt-0:1.1.1-29.el7_0.4.x86_64",
+            "7Server-optional-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.i686",
+            "7Server-optional-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.ppc",
+            "7Server-optional-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.ppc64",
+            "7Server-optional-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.s390",
+            "7Server-optional-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.s390x",
+            "7Server-optional-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.x86_64",
+            "7Server-optional-7.0.Z:libvirt-daemon-0:1.1.1-29.el7_0.4.ppc64",
+            "7Server-optional-7.0.Z:libvirt-daemon-0:1.1.1-29.el7_0.4.s390x",
+            "7Server-optional-7.0.Z:libvirt-daemon-0:1.1.1-29.el7_0.4.x86_64",
+            "7Server-optional-7.0.Z:libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.ppc64",
+            "7Server-optional-7.0.Z:libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.s390x",
+            "7Server-optional-7.0.Z:libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.x86_64",
+            "7Server-optional-7.0.Z:libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.ppc64",
+            "7Server-optional-7.0.Z:libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.s390x",
+            "7Server-optional-7.0.Z:libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.x86_64",
+            "7Server-optional-7.0.Z:libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.ppc64",
+            "7Server-optional-7.0.Z:libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.s390x",
+            "7Server-optional-7.0.Z:libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.x86_64",
+            "7Server-optional-7.0.Z:libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.ppc64",
+            "7Server-optional-7.0.Z:libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.s390x",
+            "7Server-optional-7.0.Z:libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.x86_64",
+            "7Server-optional-7.0.Z:libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.ppc64",
+            "7Server-optional-7.0.Z:libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.s390x",
+            "7Server-optional-7.0.Z:libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.x86_64",
+            "7Server-optional-7.0.Z:libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.ppc64",
+            "7Server-optional-7.0.Z:libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.s390x",
+            "7Server-optional-7.0.Z:libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.x86_64",
+            "7Server-optional-7.0.Z:libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.ppc64",
+            "7Server-optional-7.0.Z:libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.s390x",
+            "7Server-optional-7.0.Z:libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.x86_64",
+            "7Server-optional-7.0.Z:libvirt-daemon-driver-qemu-0:1.1.1-29.el7_0.4.x86_64",
+            "7Server-optional-7.0.Z:libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.ppc64",
+            "7Server-optional-7.0.Z:libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.s390x",
+            "7Server-optional-7.0.Z:libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.x86_64",
+            "7Server-optional-7.0.Z:libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.ppc64",
+            "7Server-optional-7.0.Z:libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.s390x",
+            "7Server-optional-7.0.Z:libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.x86_64",
+            "7Server-optional-7.0.Z:libvirt-daemon-kvm-0:1.1.1-29.el7_0.4.x86_64",
+            "7Server-optional-7.0.Z:libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.ppc64",
+            "7Server-optional-7.0.Z:libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.s390x",
+            "7Server-optional-7.0.Z:libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.x86_64",
+            "7Server-optional-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.i686",
+            "7Server-optional-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.ppc",
+            "7Server-optional-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.ppc64",
+            "7Server-optional-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.s390",
+            "7Server-optional-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.s390x",
+            "7Server-optional-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.x86_64",
+            "7Server-optional-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.i686",
+            "7Server-optional-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.ppc",
+            "7Server-optional-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.ppc64",
+            "7Server-optional-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.s390",
+            "7Server-optional-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.s390x",
+            "7Server-optional-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.x86_64",
+            "7Server-optional-7.0.Z:libvirt-docs-0:1.1.1-29.el7_0.4.ppc64",
+            "7Server-optional-7.0.Z:libvirt-docs-0:1.1.1-29.el7_0.4.s390x",
+            "7Server-optional-7.0.Z:libvirt-docs-0:1.1.1-29.el7_0.4.x86_64",
+            "7Server-optional-7.0.Z:libvirt-lock-sanlock-0:1.1.1-29.el7_0.4.x86_64",
+            "7Server-optional-7.0.Z:libvirt-login-shell-0:1.1.1-29.el7_0.4.ppc64",
+            "7Server-optional-7.0.Z:libvirt-login-shell-0:1.1.1-29.el7_0.4.s390x",
+            "7Server-optional-7.0.Z:libvirt-login-shell-0:1.1.1-29.el7_0.4.x86_64",
+            "7Server-optional-7.0.Z:libvirt-python-0:1.1.1-29.el7_0.4.ppc64",
+            "7Server-optional-7.0.Z:libvirt-python-0:1.1.1-29.el7_0.4.s390x",
+            "7Server-optional-7.0.Z:libvirt-python-0:1.1.1-29.el7_0.4.x86_64",
+            "7Workstation-7.0.Z:libvirt-0:1.1.1-29.el7_0.4.ppc64",
+            "7Workstation-7.0.Z:libvirt-0:1.1.1-29.el7_0.4.s390x",
+            "7Workstation-7.0.Z:libvirt-0:1.1.1-29.el7_0.4.src",
+            "7Workstation-7.0.Z:libvirt-0:1.1.1-29.el7_0.4.x86_64",
+            "7Workstation-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.i686",
+            "7Workstation-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.ppc",
+            "7Workstation-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.ppc64",
+            "7Workstation-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.s390",
+            "7Workstation-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.s390x",
+            "7Workstation-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.x86_64",
+            "7Workstation-7.0.Z:libvirt-daemon-0:1.1.1-29.el7_0.4.ppc64",
+            "7Workstation-7.0.Z:libvirt-daemon-0:1.1.1-29.el7_0.4.s390x",
+            "7Workstation-7.0.Z:libvirt-daemon-0:1.1.1-29.el7_0.4.x86_64",
+            "7Workstation-7.0.Z:libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.ppc64",
+            "7Workstation-7.0.Z:libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.s390x",
+            "7Workstation-7.0.Z:libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.x86_64",
+            "7Workstation-7.0.Z:libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.ppc64",
+            "7Workstation-7.0.Z:libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.s390x",
+            "7Workstation-7.0.Z:libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.x86_64",
+            "7Workstation-7.0.Z:libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.ppc64",
+            "7Workstation-7.0.Z:libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.s390x",
+            "7Workstation-7.0.Z:libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.x86_64",
+            "7Workstation-7.0.Z:libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.ppc64",
+            "7Workstation-7.0.Z:libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.s390x",
+            "7Workstation-7.0.Z:libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.x86_64",
+            "7Workstation-7.0.Z:libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.ppc64",
+            "7Workstation-7.0.Z:libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.s390x",
+            "7Workstation-7.0.Z:libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.x86_64",
+            "7Workstation-7.0.Z:libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.ppc64",
+            "7Workstation-7.0.Z:libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.s390x",
+            "7Workstation-7.0.Z:libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.x86_64",
+            "7Workstation-7.0.Z:libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.ppc64",
+            "7Workstation-7.0.Z:libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.s390x",
+            "7Workstation-7.0.Z:libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.x86_64",
+            "7Workstation-7.0.Z:libvirt-daemon-driver-qemu-0:1.1.1-29.el7_0.4.x86_64",
+            "7Workstation-7.0.Z:libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.ppc64",
+            "7Workstation-7.0.Z:libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.s390x",
+            "7Workstation-7.0.Z:libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.x86_64",
+            "7Workstation-7.0.Z:libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.ppc64",
+            "7Workstation-7.0.Z:libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.s390x",
+            "7Workstation-7.0.Z:libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.x86_64",
+            "7Workstation-7.0.Z:libvirt-daemon-kvm-0:1.1.1-29.el7_0.4.x86_64",
+            "7Workstation-7.0.Z:libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.ppc64",
+            "7Workstation-7.0.Z:libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.s390x",
+            "7Workstation-7.0.Z:libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.x86_64",
+            "7Workstation-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.i686",
+            "7Workstation-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.ppc",
+            "7Workstation-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.ppc64",
+            "7Workstation-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.s390",
+            "7Workstation-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.s390x",
+            "7Workstation-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.x86_64",
+            "7Workstation-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.i686",
+            "7Workstation-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.ppc",
+            "7Workstation-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.ppc64",
+            "7Workstation-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.s390",
+            "7Workstation-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.s390x",
+            "7Workstation-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.x86_64",
+            "7Workstation-7.0.Z:libvirt-docs-0:1.1.1-29.el7_0.4.ppc64",
+            "7Workstation-7.0.Z:libvirt-docs-0:1.1.1-29.el7_0.4.s390x",
+            "7Workstation-7.0.Z:libvirt-docs-0:1.1.1-29.el7_0.4.x86_64",
+            "7Workstation-7.0.Z:libvirt-lock-sanlock-0:1.1.1-29.el7_0.4.x86_64",
+            "7Workstation-7.0.Z:libvirt-login-shell-0:1.1.1-29.el7_0.4.ppc64",
+            "7Workstation-7.0.Z:libvirt-login-shell-0:1.1.1-29.el7_0.4.s390x",
+            "7Workstation-7.0.Z:libvirt-login-shell-0:1.1.1-29.el7_0.4.x86_64",
+            "7Workstation-7.0.Z:libvirt-python-0:1.1.1-29.el7_0.4.ppc64",
+            "7Workstation-7.0.Z:libvirt-python-0:1.1.1-29.el7_0.4.s390x",
+            "7Workstation-7.0.Z:libvirt-python-0:1.1.1-29.el7_0.4.x86_64",
+            "7Workstation-optional-7.0.Z:libvirt-0:1.1.1-29.el7_0.4.ppc64",
+            "7Workstation-optional-7.0.Z:libvirt-0:1.1.1-29.el7_0.4.s390x",
+            "7Workstation-optional-7.0.Z:libvirt-0:1.1.1-29.el7_0.4.src",
+            "7Workstation-optional-7.0.Z:libvirt-0:1.1.1-29.el7_0.4.x86_64",
+            "7Workstation-optional-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.i686",
+            "7Workstation-optional-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.ppc",
+            "7Workstation-optional-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.ppc64",
+            "7Workstation-optional-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.s390",
+            "7Workstation-optional-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.s390x",
+            "7Workstation-optional-7.0.Z:libvirt-client-0:1.1.1-29.el7_0.4.x86_64",
+            "7Workstation-optional-7.0.Z:libvirt-daemon-0:1.1.1-29.el7_0.4.ppc64",
+            "7Workstation-optional-7.0.Z:libvirt-daemon-0:1.1.1-29.el7_0.4.s390x",
+            "7Workstation-optional-7.0.Z:libvirt-daemon-0:1.1.1-29.el7_0.4.x86_64",
+            "7Workstation-optional-7.0.Z:libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.ppc64",
+            "7Workstation-optional-7.0.Z:libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.s390x",
+            "7Workstation-optional-7.0.Z:libvirt-daemon-config-network-0:1.1.1-29.el7_0.4.x86_64",
+            "7Workstation-optional-7.0.Z:libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.ppc64",
+            "7Workstation-optional-7.0.Z:libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.s390x",
+            "7Workstation-optional-7.0.Z:libvirt-daemon-config-nwfilter-0:1.1.1-29.el7_0.4.x86_64",
+            "7Workstation-optional-7.0.Z:libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.ppc64",
+            "7Workstation-optional-7.0.Z:libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.s390x",
+            "7Workstation-optional-7.0.Z:libvirt-daemon-driver-interface-0:1.1.1-29.el7_0.4.x86_64",
+            "7Workstation-optional-7.0.Z:libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.ppc64",
+            "7Workstation-optional-7.0.Z:libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.s390x",
+            "7Workstation-optional-7.0.Z:libvirt-daemon-driver-lxc-0:1.1.1-29.el7_0.4.x86_64",
+            "7Workstation-optional-7.0.Z:libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.ppc64",
+            "7Workstation-optional-7.0.Z:libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.s390x",
+            "7Workstation-optional-7.0.Z:libvirt-daemon-driver-network-0:1.1.1-29.el7_0.4.x86_64",
+            "7Workstation-optional-7.0.Z:libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.ppc64",
+            "7Workstation-optional-7.0.Z:libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.s390x",
+            "7Workstation-optional-7.0.Z:libvirt-daemon-driver-nodedev-0:1.1.1-29.el7_0.4.x86_64",
+            "7Workstation-optional-7.0.Z:libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.ppc64",
+            "7Workstation-optional-7.0.Z:libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.s390x",
+            "7Workstation-optional-7.0.Z:libvirt-daemon-driver-nwfilter-0:1.1.1-29.el7_0.4.x86_64",
+            "7Workstation-optional-7.0.Z:libvirt-daemon-driver-qemu-0:1.1.1-29.el7_0.4.x86_64",
+            "7Workstation-optional-7.0.Z:libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.ppc64",
+            "7Workstation-optional-7.0.Z:libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.s390x",
+            "7Workstation-optional-7.0.Z:libvirt-daemon-driver-secret-0:1.1.1-29.el7_0.4.x86_64",
+            "7Workstation-optional-7.0.Z:libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.ppc64",
+            "7Workstation-optional-7.0.Z:libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.s390x",
+            "7Workstation-optional-7.0.Z:libvirt-daemon-driver-storage-0:1.1.1-29.el7_0.4.x86_64",
+            "7Workstation-optional-7.0.Z:libvirt-daemon-kvm-0:1.1.1-29.el7_0.4.x86_64",
+            "7Workstation-optional-7.0.Z:libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.ppc64",
+            "7Workstation-optional-7.0.Z:libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.s390x",
+            "7Workstation-optional-7.0.Z:libvirt-daemon-lxc-0:1.1.1-29.el7_0.4.x86_64",
+            "7Workstation-optional-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.i686",
+            "7Workstation-optional-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.ppc",
+            "7Workstation-optional-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.ppc64",
+            "7Workstation-optional-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.s390",
+            "7Workstation-optional-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.s390x",
+            "7Workstation-optional-7.0.Z:libvirt-debuginfo-0:1.1.1-29.el7_0.4.x86_64",
+            "7Workstation-optional-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.i686",
+            "7Workstation-optional-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.ppc",
+            "7Workstation-optional-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.ppc64",
+            "7Workstation-optional-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.s390",
+            "7Workstation-optional-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.s390x",
+            "7Workstation-optional-7.0.Z:libvirt-devel-0:1.1.1-29.el7_0.4.x86_64",
+            "7Workstation-optional-7.0.Z:libvirt-docs-0:1.1.1-29.el7_0.4.ppc64",
+            "7Workstation-optional-7.0.Z:libvirt-docs-0:1.1.1-29.el7_0.4.s390x",
+            "7Workstation-optional-7.0.Z:libvirt-docs-0:1.1.1-29.el7_0.4.x86_64",
+            "7Workstation-optional-7.0.Z:libvirt-lock-sanlock-0:1.1.1-29.el7_0.4.x86_64",
+            "7Workstation-optional-7.0.Z:libvirt-login-shell-0:1.1.1-29.el7_0.4.ppc64",
+            "7Workstation-optional-7.0.Z:libvirt-login-shell-0:1.1.1-29.el7_0.4.s390x",
+            "7Workstation-optional-7.0.Z:libvirt-login-shell-0:1.1.1-29.el7_0.4.x86_64",
+            "7Workstation-optional-7.0.Z:libvirt-python-0:1.1.1-29.el7_0.4.ppc64",
+            "7Workstation-optional-7.0.Z:libvirt-python-0:1.1.1-29.el7_0.4.s390x",
+            "7Workstation-optional-7.0.Z:libvirt-python-0:1.1.1-29.el7_0.4.x86_64"
+          ]
+        }
+      ],
+      "threats": [
+        {
+          "category": "impact",
+          "details": "Low"
+        }
+      ],
+      "title": "libvirt: dumpxml: information leak with migratable flag"
+    }
+  ]
+}

--- a/tools/redhat/testdata/rhsa-2024_4546.json
+++ b/tools/redhat/testdata/rhsa-2024_4546.json
@@ -1,0 +1,570 @@
+{
+  "document": {
+    "aggregate_severity": {
+      "namespace": "https://access.redhat.com/security/updates/classification/",
+      "text": "Important"
+    },
+    "category": "csaf_vex",
+    "csaf_version": "2.0",
+    "distribution": {
+      "text": "Copyright © Red Hat, Inc. All rights reserved.",
+      "tlp": {
+        "label": "WHITE",
+        "url": "https://www.first.org/tlp/"
+      }
+    },
+    "lang": "en",
+    "notes": [
+      {
+        "category": "summary",
+        "text": "An update for git-lfs is now available for Red Hat Enterprise Linux 8.6 Advanced Mission Critical Update Support, Red Hat Enterprise Linux 8.6 Update Services for SAP Solutions, and Red Hat Enterprise Linux 8.6 Telecommunications Update Service.\n\nRed Hat Product Security has rated this update as having a security impact of Important. A Common Vulnerability Scoring System (CVSS) base score, which gives a detailed severity rating, is available for each vulnerability from the CVE link(s) in the References section.",
+        "title": "Topic"
+      },
+      {
+        "category": "general",
+        "text": "Git Large File Storage (LFS) replaces large files such as audio samples, videos, datasets, and graphics with text pointers inside Git, while storing the file contents on a remote server.\n\nSecurity Fix(es):\n\n* golang: net/http, x/net/http2: unlimited number of CONTINUATION frames causes DoS (CVE-2023-45288,VU#421644.3)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+        "title": "Details"
+      },
+      {
+        "category": "legal_disclaimer",
+        "text": "This content is licensed under the Creative Commons Attribution 4.0 International License (https://creativecommons.org/licenses/by/4.0/). If you distribute this content, or a modified version of it, you must provide attribution to Red Hat Inc. and provide a link to the original.",
+        "title": "Terms of Use"
+      }
+    ],
+    "publisher": {
+      "category": "vendor",
+      "contact_details": "https://access.redhat.com/security/team/contact/",
+      "issuing_authority": "Red Hat Product Security is responsible for vulnerability handling across all Red Hat offerings.",
+      "name": "Red Hat Product Security",
+      "namespace": "https://www.redhat.com"
+    },
+    "references": [
+      {
+        "category": "self",
+        "summary": "https://access.redhat.com/errata/RHSA-2024:4546",
+        "url": "https://access.redhat.com/errata/RHSA-2024:4546"
+      },
+      {
+        "category": "external",
+        "summary": "https://access.redhat.com/security/updates/classification/#important",
+        "url": "https://access.redhat.com/security/updates/classification/#important"
+      },
+      {
+        "category": "external",
+        "summary": "2268273",
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=2268273"
+      },
+      {
+        "category": "self",
+        "summary": "Canonical URL",
+        "url": "https://access.redhat.com/security/data/csaf/v2/advisories/2024/rhsa-2024_4546.json"
+      }
+    ],
+    "title": "Red Hat Security Advisory: git-lfs security update",
+    "tracking": {
+      "current_release_date": "2024-07-16T13:38:03+00:00",
+      "generator": {
+        "date": "2024-07-16T13:38:03+00:00",
+        "engine": {
+          "name": "Red Hat SDEngine",
+          "version": "3.30.3"
+        }
+      },
+      "id": "RHSA-2024:4546",
+      "initial_release_date": "2024-07-15T16:12:25+00:00",
+      "revision_history": [
+        {
+          "date": "2024-07-15T16:12:25+00:00",
+          "number": "1",
+          "summary": "Initial version"
+        },
+        {
+          "date": "2024-07-15T16:12:25+00:00",
+          "number": "2",
+          "summary": "Last updated version"
+        },
+        {
+          "date": "2024-07-16T13:38:03+00:00",
+          "number": "3",
+          "summary": "Last generated version"
+        }
+      ],
+      "status": "final",
+      "version": "3"
+    }
+  },
+  "product_tree": {
+    "branches": [
+      {
+        "branches": [
+          {
+            "branches": [
+              {
+                "category": "product_name",
+                "name": "Red Hat Enterprise Linux AppStream AUS (v.8.6)",
+                "product": {
+                  "name": "Red Hat Enterprise Linux AppStream AUS (v.8.6)",
+                  "product_id": "AppStream-8.6.0.Z.AUS",
+                  "product_identification_helper": {
+                    "cpe": "cpe:/a:redhat:rhel_aus:8.6::appstream"
+                  }
+                }
+              },
+              {
+                "category": "product_name",
+                "name": "Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+                "product": {
+                  "name": "Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+                  "product_id": "AppStream-8.6.0.Z.E4S",
+                  "product_identification_helper": {
+                    "cpe": "cpe:/a:redhat:rhel_e4s:8.6::appstream"
+                  }
+                }
+              },
+              {
+                "category": "product_name",
+                "name": "Red Hat Enterprise Linux AppStream TUS (v.8.6)",
+                "product": {
+                  "name": "Red Hat Enterprise Linux AppStream TUS (v.8.6)",
+                  "product_id": "AppStream-8.6.0.Z.TUS",
+                  "product_identification_helper": {
+                    "cpe": "cpe:/a:redhat:rhel_tus:8.6::appstream"
+                  }
+                }
+              }
+            ],
+            "category": "product_family",
+            "name": "Red Hat Enterprise Linux"
+          },
+          {
+            "branches": [
+              {
+                "category": "product_version",
+                "name": "git-lfs-0:2.13.3-3.el8_6.1.src",
+                "product": {
+                  "name": "git-lfs-0:2.13.3-3.el8_6.1.src",
+                  "product_id": "git-lfs-0:2.13.3-3.el8_6.1.src",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/git-lfs@2.13.3-3.el8_6.1?arch=src"
+                  }
+                }
+              }
+            ],
+            "category": "architecture",
+            "name": "src"
+          },
+          {
+            "branches": [
+              {
+                "category": "product_version",
+                "name": "git-lfs-0:2.13.3-3.el8_6.1.x86_64",
+                "product": {
+                  "name": "git-lfs-0:2.13.3-3.el8_6.1.x86_64",
+                  "product_id": "git-lfs-0:2.13.3-3.el8_6.1.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/git-lfs@2.13.3-3.el8_6.1?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "git-lfs-debugsource-0:2.13.3-3.el8_6.1.x86_64",
+                "product": {
+                  "name": "git-lfs-debugsource-0:2.13.3-3.el8_6.1.x86_64",
+                  "product_id": "git-lfs-debugsource-0:2.13.3-3.el8_6.1.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/git-lfs-debugsource@2.13.3-3.el8_6.1?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "git-lfs-debuginfo-0:2.13.3-3.el8_6.1.x86_64",
+                "product": {
+                  "name": "git-lfs-debuginfo-0:2.13.3-3.el8_6.1.x86_64",
+                  "product_id": "git-lfs-debuginfo-0:2.13.3-3.el8_6.1.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/git-lfs-debuginfo@2.13.3-3.el8_6.1?arch=x86_64"
+                  }
+                }
+              }
+            ],
+            "category": "architecture",
+            "name": "x86_64"
+          },
+          {
+            "branches": [
+              {
+                "category": "product_version",
+                "name": "git-lfs-0:2.13.3-3.el8_6.1.ppc64le",
+                "product": {
+                  "name": "git-lfs-0:2.13.3-3.el8_6.1.ppc64le",
+                  "product_id": "git-lfs-0:2.13.3-3.el8_6.1.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/git-lfs@2.13.3-3.el8_6.1?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "git-lfs-debugsource-0:2.13.3-3.el8_6.1.ppc64le",
+                "product": {
+                  "name": "git-lfs-debugsource-0:2.13.3-3.el8_6.1.ppc64le",
+                  "product_id": "git-lfs-debugsource-0:2.13.3-3.el8_6.1.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/git-lfs-debugsource@2.13.3-3.el8_6.1?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "git-lfs-debuginfo-0:2.13.3-3.el8_6.1.ppc64le",
+                "product": {
+                  "name": "git-lfs-debuginfo-0:2.13.3-3.el8_6.1.ppc64le",
+                  "product_id": "git-lfs-debuginfo-0:2.13.3-3.el8_6.1.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/git-lfs-debuginfo@2.13.3-3.el8_6.1?arch=ppc64le"
+                  }
+                }
+              }
+            ],
+            "category": "architecture",
+            "name": "ppc64le"
+          }
+        ],
+        "category": "vendor",
+        "name": "Red Hat"
+      }
+    ],
+    "relationships": [
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "git-lfs-0:2.13.3-3.el8_6.1.src as a component of Red Hat Enterprise Linux AppStream AUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.AUS:git-lfs-0:2.13.3-3.el8_6.1.src"
+        },
+        "product_reference": "git-lfs-0:2.13.3-3.el8_6.1.src",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.AUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "git-lfs-0:2.13.3-3.el8_6.1.x86_64 as a component of Red Hat Enterprise Linux AppStream AUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.AUS:git-lfs-0:2.13.3-3.el8_6.1.x86_64"
+        },
+        "product_reference": "git-lfs-0:2.13.3-3.el8_6.1.x86_64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.AUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "git-lfs-debuginfo-0:2.13.3-3.el8_6.1.x86_64 as a component of Red Hat Enterprise Linux AppStream AUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.AUS:git-lfs-debuginfo-0:2.13.3-3.el8_6.1.x86_64"
+        },
+        "product_reference": "git-lfs-debuginfo-0:2.13.3-3.el8_6.1.x86_64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.AUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "git-lfs-debugsource-0:2.13.3-3.el8_6.1.x86_64 as a component of Red Hat Enterprise Linux AppStream AUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.AUS:git-lfs-debugsource-0:2.13.3-3.el8_6.1.x86_64"
+        },
+        "product_reference": "git-lfs-debugsource-0:2.13.3-3.el8_6.1.x86_64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.AUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "git-lfs-0:2.13.3-3.el8_6.1.ppc64le as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:git-lfs-0:2.13.3-3.el8_6.1.ppc64le"
+        },
+        "product_reference": "git-lfs-0:2.13.3-3.el8_6.1.ppc64le",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "git-lfs-0:2.13.3-3.el8_6.1.src as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:git-lfs-0:2.13.3-3.el8_6.1.src"
+        },
+        "product_reference": "git-lfs-0:2.13.3-3.el8_6.1.src",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "git-lfs-0:2.13.3-3.el8_6.1.x86_64 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:git-lfs-0:2.13.3-3.el8_6.1.x86_64"
+        },
+        "product_reference": "git-lfs-0:2.13.3-3.el8_6.1.x86_64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "git-lfs-debuginfo-0:2.13.3-3.el8_6.1.ppc64le as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:git-lfs-debuginfo-0:2.13.3-3.el8_6.1.ppc64le"
+        },
+        "product_reference": "git-lfs-debuginfo-0:2.13.3-3.el8_6.1.ppc64le",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "git-lfs-debuginfo-0:2.13.3-3.el8_6.1.x86_64 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:git-lfs-debuginfo-0:2.13.3-3.el8_6.1.x86_64"
+        },
+        "product_reference": "git-lfs-debuginfo-0:2.13.3-3.el8_6.1.x86_64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "git-lfs-debugsource-0:2.13.3-3.el8_6.1.ppc64le as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:git-lfs-debugsource-0:2.13.3-3.el8_6.1.ppc64le"
+        },
+        "product_reference": "git-lfs-debugsource-0:2.13.3-3.el8_6.1.ppc64le",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "git-lfs-debugsource-0:2.13.3-3.el8_6.1.x86_64 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:git-lfs-debugsource-0:2.13.3-3.el8_6.1.x86_64"
+        },
+        "product_reference": "git-lfs-debugsource-0:2.13.3-3.el8_6.1.x86_64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "git-lfs-0:2.13.3-3.el8_6.1.src as a component of Red Hat Enterprise Linux AppStream TUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.TUS:git-lfs-0:2.13.3-3.el8_6.1.src"
+        },
+        "product_reference": "git-lfs-0:2.13.3-3.el8_6.1.src",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.TUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "git-lfs-0:2.13.3-3.el8_6.1.x86_64 as a component of Red Hat Enterprise Linux AppStream TUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.TUS:git-lfs-0:2.13.3-3.el8_6.1.x86_64"
+        },
+        "product_reference": "git-lfs-0:2.13.3-3.el8_6.1.x86_64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.TUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "git-lfs-debuginfo-0:2.13.3-3.el8_6.1.x86_64 as a component of Red Hat Enterprise Linux AppStream TUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.TUS:git-lfs-debuginfo-0:2.13.3-3.el8_6.1.x86_64"
+        },
+        "product_reference": "git-lfs-debuginfo-0:2.13.3-3.el8_6.1.x86_64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.TUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "git-lfs-debugsource-0:2.13.3-3.el8_6.1.x86_64 as a component of Red Hat Enterprise Linux AppStream TUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.TUS:git-lfs-debugsource-0:2.13.3-3.el8_6.1.x86_64"
+        },
+        "product_reference": "git-lfs-debugsource-0:2.13.3-3.el8_6.1.x86_64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.TUS"
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "acknowledgments": [
+        {
+          "names": [
+            "Bartek Nowotarski"
+          ],
+          "organization": "nowotarski.info"
+        }
+      ],
+      "cve": "CVE-2023-45288",
+      "cwe": {
+        "id": "CWE-400",
+        "name": "Uncontrolled Resource Consumption"
+      },
+      "discovery_date": "2024-03-06T00:00:00+00:00",
+      "ids": [
+        {
+          "system_name": "Red Hat Bugzilla ID",
+          "text": "2268273"
+        }
+      ],
+      "notes": [
+        {
+          "category": "description",
+          "text": "A vulnerability was discovered with the implementation of the HTTP/2 protocol in the Go programming language. There were insufficient limitations on the amount of CONTINUATION frames sent within a single stream. An attacker could potentially exploit this to cause a Denial of Service (DoS) attack.",
+          "title": "Vulnerability description"
+        },
+        {
+          "category": "summary",
+          "text": "golang: net/http, x/net/http2: unlimited number of CONTINUATION frames causes DoS",
+          "title": "Vulnerability summary"
+        },
+        {
+          "category": "other",
+          "text": "Red Hat rates the security impact of this vulnerability as Important due to the worst case scenario resulting in a denial of service. It is simple to exploit, could significantly impact availability, and there is not a suitable mitigation for all use cases. Once an attack has ended, the system should return to normal operations on its own.\n\nThis vulnerability only impacts servers which have HTTP/2 enabled. It stems from an imperfect definition of the protocol. As the Go programming language is widely utilized across nearly every major Red Hat offering, a full listing of impacted packages will not be provided. Therefore, the “Affected Packages and Issued Red Hat Security Errata” section contains a simplified list of what offerings need to remediate this vulnerability. Every impacted offering has at least one representative component listed, but potentially not all of them. Rest assured that Red Hat is committed to remediating this vulnerability across our entire portfolio.\n\nWithin the Red Hat OpenShift Container Platform, the majority of vulnerable components are not externally accessible. This means an attacker must already have access to a container within your environment to exploit this vulnerability. However, the ose-hyperkube (openshift-enterprise-hyperkube) container is externally accessible, so there are less barriers to exploitation. Fixes for this specific container are already available.\n\nWithin Red Hat Ansible Automation Platform, the impacted component is Receptor. The impact has been reduced to Low as the vulnerable code is present, but not utilized. There are three potential exposures within this component:\n* Receptor utilizes QUIC a UDP based protocol which does not run over HTTP/2\n* Receptor utilizes the x/net/ipv4 and ipv6 packages, both of which are not affected",
+          "title": "Statement"
+        },
+        {
+          "category": "general",
+          "text": "The CVSS score(s) listed for this vulnerability do not reflect the associated product's status, and are included for informational purposes to better understand the severity of this vulnerability.",
+          "title": "CVSS score applicability"
+        }
+      ],
+      "product_status": {
+        "fixed": [
+          "AppStream-8.6.0.Z.AUS:git-lfs-0:2.13.3-3.el8_6.1.src",
+          "AppStream-8.6.0.Z.AUS:git-lfs-0:2.13.3-3.el8_6.1.x86_64",
+          "AppStream-8.6.0.Z.AUS:git-lfs-debuginfo-0:2.13.3-3.el8_6.1.x86_64",
+          "AppStream-8.6.0.Z.AUS:git-lfs-debugsource-0:2.13.3-3.el8_6.1.x86_64",
+          "AppStream-8.6.0.Z.E4S:git-lfs-0:2.13.3-3.el8_6.1.ppc64le",
+          "AppStream-8.6.0.Z.E4S:git-lfs-0:2.13.3-3.el8_6.1.src",
+          "AppStream-8.6.0.Z.E4S:git-lfs-0:2.13.3-3.el8_6.1.x86_64",
+          "AppStream-8.6.0.Z.E4S:git-lfs-debuginfo-0:2.13.3-3.el8_6.1.ppc64le",
+          "AppStream-8.6.0.Z.E4S:git-lfs-debuginfo-0:2.13.3-3.el8_6.1.x86_64",
+          "AppStream-8.6.0.Z.E4S:git-lfs-debugsource-0:2.13.3-3.el8_6.1.ppc64le",
+          "AppStream-8.6.0.Z.E4S:git-lfs-debugsource-0:2.13.3-3.el8_6.1.x86_64",
+          "AppStream-8.6.0.Z.TUS:git-lfs-0:2.13.3-3.el8_6.1.src",
+          "AppStream-8.6.0.Z.TUS:git-lfs-0:2.13.3-3.el8_6.1.x86_64",
+          "AppStream-8.6.0.Z.TUS:git-lfs-debuginfo-0:2.13.3-3.el8_6.1.x86_64",
+          "AppStream-8.6.0.Z.TUS:git-lfs-debugsource-0:2.13.3-3.el8_6.1.x86_64"
+        ]
+      },
+      "references": [
+        {
+          "category": "self",
+          "summary": "Canonical URL",
+          "url": "https://access.redhat.com/security/cve/CVE-2023-45288"
+        },
+        {
+          "category": "external",
+          "summary": "RHBZ#2268273",
+          "url": "https://bugzilla.redhat.com/show_bug.cgi?id=2268273"
+        },
+        {
+          "category": "external",
+          "summary": "https://www.cve.org/CVERecord?id=CVE-2023-45288",
+          "url": "https://www.cve.org/CVERecord?id=CVE-2023-45288"
+        },
+        {
+          "category": "external",
+          "summary": "https://nvd.nist.gov/vuln/detail/CVE-2023-45288",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-45288"
+        },
+        {
+          "category": "external",
+          "summary": "https://nowotarski.info/http2-continuation-flood/",
+          "url": "https://nowotarski.info/http2-continuation-flood/"
+        },
+        {
+          "category": "external",
+          "summary": "https://pkg.go.dev/vuln/GO-2024-2687",
+          "url": "https://pkg.go.dev/vuln/GO-2024-2687"
+        },
+        {
+          "category": "external",
+          "summary": "https://www.kb.cert.org/vuls/id/421644",
+          "url": "https://www.kb.cert.org/vuls/id/421644"
+        }
+      ],
+      "release_date": "2024-04-03T00:00:00+00:00",
+      "remediations": [
+        {
+          "category": "vendor_fix",
+          "details": "For details on how to apply this update, which includes the changes described in this advisory, refer to:\n\nhttps://access.redhat.com/articles/11258",
+          "product_ids": [
+            "AppStream-8.6.0.Z.AUS:git-lfs-0:2.13.3-3.el8_6.1.src",
+            "AppStream-8.6.0.Z.AUS:git-lfs-0:2.13.3-3.el8_6.1.x86_64",
+            "AppStream-8.6.0.Z.AUS:git-lfs-debuginfo-0:2.13.3-3.el8_6.1.x86_64",
+            "AppStream-8.6.0.Z.AUS:git-lfs-debugsource-0:2.13.3-3.el8_6.1.x86_64",
+            "AppStream-8.6.0.Z.E4S:git-lfs-0:2.13.3-3.el8_6.1.ppc64le",
+            "AppStream-8.6.0.Z.E4S:git-lfs-0:2.13.3-3.el8_6.1.src",
+            "AppStream-8.6.0.Z.E4S:git-lfs-0:2.13.3-3.el8_6.1.x86_64",
+            "AppStream-8.6.0.Z.E4S:git-lfs-debuginfo-0:2.13.3-3.el8_6.1.ppc64le",
+            "AppStream-8.6.0.Z.E4S:git-lfs-debuginfo-0:2.13.3-3.el8_6.1.x86_64",
+            "AppStream-8.6.0.Z.E4S:git-lfs-debugsource-0:2.13.3-3.el8_6.1.ppc64le",
+            "AppStream-8.6.0.Z.E4S:git-lfs-debugsource-0:2.13.3-3.el8_6.1.x86_64",
+            "AppStream-8.6.0.Z.TUS:git-lfs-0:2.13.3-3.el8_6.1.src",
+            "AppStream-8.6.0.Z.TUS:git-lfs-0:2.13.3-3.el8_6.1.x86_64",
+            "AppStream-8.6.0.Z.TUS:git-lfs-debuginfo-0:2.13.3-3.el8_6.1.x86_64",
+            "AppStream-8.6.0.Z.TUS:git-lfs-debugsource-0:2.13.3-3.el8_6.1.x86_64"
+          ],
+          "restart_required": {
+            "category": "none"
+          },
+          "url": "https://access.redhat.com/errata/RHSA-2024:4546"
+        },
+        {
+          "category": "workaround",
+          "details": "In some environments where http/2 support is not required, it may be possible to disable this feature to reduce risk.",
+          "product_ids": [
+            "AppStream-8.6.0.Z.AUS:git-lfs-0:2.13.3-3.el8_6.1.src",
+            "AppStream-8.6.0.Z.AUS:git-lfs-0:2.13.3-3.el8_6.1.x86_64",
+            "AppStream-8.6.0.Z.AUS:git-lfs-debuginfo-0:2.13.3-3.el8_6.1.x86_64",
+            "AppStream-8.6.0.Z.AUS:git-lfs-debugsource-0:2.13.3-3.el8_6.1.x86_64",
+            "AppStream-8.6.0.Z.E4S:git-lfs-0:2.13.3-3.el8_6.1.ppc64le",
+            "AppStream-8.6.0.Z.E4S:git-lfs-0:2.13.3-3.el8_6.1.src",
+            "AppStream-8.6.0.Z.E4S:git-lfs-0:2.13.3-3.el8_6.1.x86_64",
+            "AppStream-8.6.0.Z.E4S:git-lfs-debuginfo-0:2.13.3-3.el8_6.1.ppc64le",
+            "AppStream-8.6.0.Z.E4S:git-lfs-debuginfo-0:2.13.3-3.el8_6.1.x86_64",
+            "AppStream-8.6.0.Z.E4S:git-lfs-debugsource-0:2.13.3-3.el8_6.1.ppc64le",
+            "AppStream-8.6.0.Z.E4S:git-lfs-debugsource-0:2.13.3-3.el8_6.1.x86_64",
+            "AppStream-8.6.0.Z.TUS:git-lfs-0:2.13.3-3.el8_6.1.src",
+            "AppStream-8.6.0.Z.TUS:git-lfs-0:2.13.3-3.el8_6.1.x86_64",
+            "AppStream-8.6.0.Z.TUS:git-lfs-debuginfo-0:2.13.3-3.el8_6.1.x86_64",
+            "AppStream-8.6.0.Z.TUS:git-lfs-debugsource-0:2.13.3-3.el8_6.1.x86_64"
+          ]
+        }
+      ],
+      "scores": [
+        {
+          "cvss_v3": {
+            "attackComplexity": "LOW",
+            "attackVector": "NETWORK",
+            "availabilityImpact": "HIGH",
+            "baseScore": 7.5,
+            "baseSeverity": "HIGH",
+            "confidentialityImpact": "NONE",
+            "integrityImpact": "NONE",
+            "privilegesRequired": "NONE",
+            "scope": "UNCHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+            "version": "3.1"
+          },
+          "products": [
+            "AppStream-8.6.0.Z.AUS:git-lfs-0:2.13.3-3.el8_6.1.src",
+            "AppStream-8.6.0.Z.AUS:git-lfs-0:2.13.3-3.el8_6.1.x86_64",
+            "AppStream-8.6.0.Z.AUS:git-lfs-debuginfo-0:2.13.3-3.el8_6.1.x86_64",
+            "AppStream-8.6.0.Z.AUS:git-lfs-debugsource-0:2.13.3-3.el8_6.1.x86_64",
+            "AppStream-8.6.0.Z.E4S:git-lfs-0:2.13.3-3.el8_6.1.ppc64le",
+            "AppStream-8.6.0.Z.E4S:git-lfs-0:2.13.3-3.el8_6.1.src",
+            "AppStream-8.6.0.Z.E4S:git-lfs-0:2.13.3-3.el8_6.1.x86_64",
+            "AppStream-8.6.0.Z.E4S:git-lfs-debuginfo-0:2.13.3-3.el8_6.1.ppc64le",
+            "AppStream-8.6.0.Z.E4S:git-lfs-debuginfo-0:2.13.3-3.el8_6.1.x86_64",
+            "AppStream-8.6.0.Z.E4S:git-lfs-debugsource-0:2.13.3-3.el8_6.1.ppc64le",
+            "AppStream-8.6.0.Z.E4S:git-lfs-debugsource-0:2.13.3-3.el8_6.1.x86_64",
+            "AppStream-8.6.0.Z.TUS:git-lfs-0:2.13.3-3.el8_6.1.src",
+            "AppStream-8.6.0.Z.TUS:git-lfs-0:2.13.3-3.el8_6.1.x86_64",
+            "AppStream-8.6.0.Z.TUS:git-lfs-debuginfo-0:2.13.3-3.el8_6.1.x86_64",
+            "AppStream-8.6.0.Z.TUS:git-lfs-debugsource-0:2.13.3-3.el8_6.1.x86_64"
+          ]
+        }
+      ],
+      "threats": [
+        {
+          "category": "impact",
+          "details": "Important"
+        }
+      ],
+      "title": "golang: net/http, x/net/http2: unlimited number of CONTINUATION frames causes DoS"
+    }
+  ]
+}


### PR DESCRIPTION
Add a Red Hat CSAF to OSV converter tool used by Red Hat to produce the Red Hat OSV data to be hosted at https://security.access.redhat.com/data/osv

This is slightly modified version of the sample code originally review at https://github.com/andrewpollock/rhcsaf2osv