### PR TITLE
adjust schema docs to have correct Red Hat IDs

### DIFF
--- a/docs/schema.md
+++ b/docs/schema.md
@@ -366,7 +366,7 @@ The defined database prefixes and their "home" databases are:
       </td>
     </tr>
     <tr>
-      <td><code>Red Hat</code></td>
+      <td><code>RHSA</code>/<code>RHBA</code>/<code>RHEA</code></td>
       <td><a href="https://security.access.redhat.com/data">Red Hat Security Data</a></td>
       <td>
         <ul>


### PR DESCRIPTION
Adjust Red Hat IDs to be correct per what's [validated by the schema](https://github.com/ossf/osv-schema/blob/0cef5d4bb1d6d76b7d8392b192f6e160c569e6e4/validation/schema.json#L309)