### PR TITLE
refactor(osv-linter): further tidy up output

### DIFF
--- a/tools/osv-linter/cmd/osv/main.go
+++ b/tools/osv-linter/cmd/osv/main.go
@@ -30,9 +30,14 @@ func main() {
 								Usage: "check collection to use (use 'list' to see)",
 							},
 							&cli.StringSliceFlag{
-								Name:  "check",
+								Name:  "checks",
 								Value: &cli.StringSlice{},
 								Usage: "explicitly run a specific check (use 'list' to see)",
+							},
+							&cli.StringSliceFlag{
+								Name:  "ecosystems",
+								Value: &cli.StringSlice{},
+								Usage: "the ecosystems to constrain package checks to (use 'list' to see)",
 							},
 						},
 						Aliases: []string{"check"},

--- a/tools/osv-linter/internal/checks/checks.go
+++ b/tools/osv-linter/internal/checks/checks.go
@@ -40,6 +40,7 @@ type CheckDef struct {
 // Config defines the configuration for a check.
 type Config struct {
 	Verbose bool
+	Ecosystems []string
 }
 
 // Check defines how to run the check.

--- a/tools/osv-linter/internal/checks/ranges_test.go
+++ b/tools/osv-linter/internal/checks/ranges_test.go
@@ -45,7 +45,7 @@ func TestRangeHasIntroducedEvent(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotFindings := RangeHasIntroducedEvent(tt.args.json)
+			gotFindings := RangeHasIntroducedEvent(tt.args.json, &Config{Verbose: true})
 			if diff := cmp.Diff(tt.wantFindings, gotFindings, cmpopts.EquateErrors()); diff != "" {
 				t.Errorf("RangeHasIntroducedEvent() mismatch (-want +got):\n%s", diff)
 			}

--- a/tools/osv-linter/internal/linter.go
+++ b/tools/osv-linter/internal/linter.go
@@ -17,6 +17,7 @@ import (
 	"github.com/urfave/cli/v2"
 
 	"github.com/ossf/osv-schema/linter/internal/checks"
+	"github.com/ossf/osv-schema/linter/internal/pkgchecker"
 )
 
 type Content struct {
@@ -24,11 +25,13 @@ type Content struct {
 	bytes    []byte
 }
 
-type LintConfig struct {
-	verbose bool
+type Config struct {
+	checks     []*checks.CheckDef
+	ecosystems []string
+	verbose    bool
 }
 
-func lint(content *Content, checksDefined []*checks.CheckDef, config *LintConfig) (findings []checks.CheckError) {
+func lint(content *Content, config *Config) (findings []checks.CheckError) {
 	// Parse file into JSON
 	if !gjson.ValidBytes(content.bytes) {
 		log.Printf("%q: invalid JSON", content.filename)
@@ -36,11 +39,11 @@ func lint(content *Content, checksDefined []*checks.CheckDef, config *LintConfig
 
 	record := gjson.ParseBytes(content.bytes)
 
-	for _, check := range checksDefined {
+	for _, check := range config.checks {
 		if config.verbose {
 			fmt.Printf("Running %q check on %q\n", check.Name, content.filename)
 		}
-		checkConfig := checks.Config{Verbose: config.verbose}
+		checkConfig := checks.Config{Verbose: config.verbose, Ecosystems: config.ecosystems}
 		checkFindings := check.Run(&record, &checkConfig)
 		if checkFindings != nil && config.verbose {
 			log.Printf("%q: %q: %#v", content.filename, check.Name, checkFindings)
@@ -64,10 +67,19 @@ func LintCommand(cCtx *cli.Context) error {
 	}
 
 	// List all available checks.
-	if slices.Contains(cCtx.StringSlice("check"), "list") {
+	if slices.Contains(cCtx.StringSlice("checks"), "list") {
 		fmt.Printf("Available checks:\n\n")
 		for _, check := range checks.CollectionFromName("ALL").Checks {
 			fmt.Printf("%s: (%s): %s\n", check.Code, check.Name, check.Description)
+		}
+		return nil
+	}
+
+	// List all supported ecosystems.
+	if slices.Contains(cCtx.StringSlice("ecosystems"), "list") {
+		fmt.Printf("Supported ecosystems:\n\n")
+		for _, ecosystem := range pkgchecker.SupportedEcosystems {
+			fmt.Printf("%s\n", ecosystem)
 		}
 		return nil
 	}
@@ -80,11 +92,11 @@ func LintCommand(cCtx *cli.Context) error {
 	var checksToBeRun []*checks.CheckDef
 
 	// Run just individual checks.
-	for _, checkRequested := range cCtx.StringSlice("check") {
+	for _, checkRequested := range cCtx.StringSlice("checks") {
 		// Check the requested check exists.
 		check := checks.FromCode(checkRequested)
 		if check == nil {
-			return fmt.Errorf("%q is not a valid check", checkRequested)
+			return fmt.Errorf("%q is not a valid check (use \"list\" to see all available checks)", checkRequested)
 		}
 		checksToBeRun = append(checksToBeRun, check)
 	}
@@ -93,7 +105,7 @@ func LintCommand(cCtx *cli.Context) error {
 	if checksToBeRun == nil && cCtx.String("collection") != "" {
 		if cCtx.Bool("verbose") {
 			if cCtx.Args().Present() {
-				fmt.Printf("Running %q check collection on %q\n", cCtx.String("collection"), cCtx.Args())
+				fmt.Printf("Running %q check collection on %q\n", cCtx.String("collection"), cCtx.Args().Slice())
 			} else {
 				fmt.Printf("Running %q check collection on <stdin>\n", cCtx.String("collection"))
 			}
@@ -171,7 +183,7 @@ func LintCommand(cCtx *cli.Context) error {
 			log.Printf("%v, skipping", err)
 			continue
 		}
-		findings := lint(&Content{filename: fileToCheck, bytes: recordBytes}, checksToBeRun, &LintConfig{verbose: cCtx.Bool("verbose")})
+		findings := lint(&Content{filename: fileToCheck, bytes: recordBytes}, &Config{verbose: cCtx.Bool("verbose"), checks: checksToBeRun, ecosystems: cCtx.StringSlice("ecosystems")})
 		if findings != nil {
 			perFileFindings[fileToCheck] = findings
 		}

--- a/tools/osv-linter/internal/pkgchecker/ecosystems_test.go
+++ b/tools/osv-linter/internal/pkgchecker/ecosystems_test.go
@@ -1,0 +1,39 @@
+package pkgchecker
+
+import "testing"
+
+func Test_versionsExistInGo(t *testing.T) {
+	type args struct {
+		pkg      string
+		versions []string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "an unreleased package",
+			args: args{
+				pkg:      "github.com/nanobox-io/golang-nanoauth",
+				versions: nil,
+			},
+			wantErr: false,
+		},
+		{
+			name: "a released package",
+			args: args{
+				pkg:      "github.com/oauth2-proxy/oauth2-proxy",
+				versions: []string{"1.1.1"},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := versionsExistInGo(tt.args.pkg, tt.args.versions); (err != nil) != tt.wantErr {
+				t.Errorf("versionsExistInGo() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
- Use a structured error for package version findings
- tidy up the passing around of configurations
- add support for only checking specific ecosystems
Signed-off-by: Andrew Pollock <apollock@google.com>