### PR TITLE
feat(osv-schema): Add missing LINUX prefix

### DIFF
--- a/validation/schema.json
+++ b/validation/schema.json
@@ -300,13 +300,13 @@
       "type": "string",
       "title": "Currently supported ecosystems",
       "description": "These ecosystems are also documented at https://ossf.github.io/osv-schema/#affectedpackage-field",
-      "pattern": "^(AlmaLinux|Alpine|Android|Bioconductor|Bitnami|Chainguard|ConanCenter|CRAN|crates.io|Debian|GHC|GitHub Actions|GIT|Go|Hackage|Hex|Linux|Maven|npm|NuGet|openSUSE|OSS-Fuzz|Packagist|Photon OS|Pub|PyPI|Red Hat|Rocky Linux|RubyGems|SUSE|SwiftURL|Ubuntu|wolfi)(:[0-9]+)?"
+      "pattern": "^(AlmaLinux|Alpine|Android|Bioconductor|Bitnami|Chainguard|ConanCenter|CRAN|crates.io|Debian|GHC|GitHub Actions|GIT|Go|Hackage|Hex|Linux|Maven|npm|NuGet|openSUSE|OSS-Fuzz|Packagist|Photon OS|Pub|PyPI|Red Hat|Rocky Linux|RubyGems|SUSE|SwiftURL|Ubuntu|Wolfi)(:[0-9]+)?"
     },
     "prefix": {
       "type": "string",
       "title": "Currently supported home database identifier prefixes",
       "description": "These home databases are also documented at https://ossf.github.io/osv-schema/#id-modified-fields",
-      "pattern": "^(ASB-A|PUB-A|ALSA|ALBA|ALEA|BIT|CGA|CURL|CVE|DSA|DLA|ELA|DTSA|GHSA|GO|GSD|HSEC|LBSEC|MAL|OSV|openSUSE-SU|PHSA|PSF|PYSEC|RHBA|RHEA|RHSA|RLSA|RXSA|RSEC|RUSTSEC|SUSE-[SRFO]U|UBUNTU|USN)-"
+      "pattern": "^(ASB-A|PUB-A|ALSA|ALBA|ALEA|BIT|CGA|CURL|CVE|DSA|DLA|ELA|DTSA|GHSA|GO|GSD|HSEC|LBSEC|LINUX|MAL|OSV|openSUSE-SU|PHSA|PSF|PYSEC|RHBA|RHEA|RHSA|RLSA|RXSA|RSEC|RUSTSEC|SUSE-[SRFO]U|UBUNTU|USN)-"
     },
     "severity": {
       "type": [


### PR DESCRIPTION
Not currently in production use, but [OSV.dev has a test case](https://github.com/google/osv.dev/blob/3dd07d08451a9be3cf4eaf95e3fa0e0d8f3e8a9f/docker/worker/worker_test.py#L1303) using it.

Missed when generating the regex because it's absent from https://ossf.github.io/osv-schema/#id-modified-fields (should it be?)

(This made me go and research how the [Linux Kernel CVEs are generated](https://git.kernel.org/pub/scm/linux/security/vulns.git/tree/HOWTO))