### PR TITLE
strip arch from version and deduplicate arch agnostic packages

### DIFF
--- a/tools/redhat/testdata/RHSA-2024_4546.json
+++ b/tools/redhat/testdata/RHSA-2024_4546.json
@@ -29,27 +29,7 @@
               "introduced": "0"
             },
             {
-              "fixed": "0:2.13.3-3.el8_6.1.src"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "package": {
-        "name": "git-lfs",
-        "ecosystem": "Red Hat:rhel_aus:8.6::appstream",
-        "purl": "pkg:rpm/redhat/git-lfs"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "0"
-            },
-            {
-              "fixed": "0:2.13.3-3.el8_6.1.x86_64"
+              "fixed": "0:2.13.3-3.el8_6.1"
             }
           ]
         }
@@ -69,7 +49,7 @@
               "introduced": "0"
             },
             {
-              "fixed": "0:2.13.3-3.el8_6.1.x86_64"
+              "fixed": "0:2.13.3-3.el8_6.1"
             }
           ]
         }
@@ -89,7 +69,7 @@
               "introduced": "0"
             },
             {
-              "fixed": "0:2.13.3-3.el8_6.1.x86_64"
+              "fixed": "0:2.13.3-3.el8_6.1"
             }
           ]
         }
@@ -109,47 +89,7 @@
               "introduced": "0"
             },
             {
-              "fixed": "0:2.13.3-3.el8_6.1.ppc64le"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "package": {
-        "name": "git-lfs",
-        "ecosystem": "Red Hat:rhel_e4s:8.6::appstream",
-        "purl": "pkg:rpm/redhat/git-lfs"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "0"
-            },
-            {
-              "fixed": "0:2.13.3-3.el8_6.1.src"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "package": {
-        "name": "git-lfs",
-        "ecosystem": "Red Hat:rhel_e4s:8.6::appstream",
-        "purl": "pkg:rpm/redhat/git-lfs"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "0"
-            },
-            {
-              "fixed": "0:2.13.3-3.el8_6.1.x86_64"
+              "fixed": "0:2.13.3-3.el8_6.1"
             }
           ]
         }
@@ -169,27 +109,7 @@
               "introduced": "0"
             },
             {
-              "fixed": "0:2.13.3-3.el8_6.1.ppc64le"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "package": {
-        "name": "git-lfs-debuginfo",
-        "ecosystem": "Red Hat:rhel_e4s:8.6::appstream",
-        "purl": "pkg:rpm/redhat/git-lfs-debuginfo"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "0"
-            },
-            {
-              "fixed": "0:2.13.3-3.el8_6.1.x86_64"
+              "fixed": "0:2.13.3-3.el8_6.1"
             }
           ]
         }
@@ -209,27 +129,7 @@
               "introduced": "0"
             },
             {
-              "fixed": "0:2.13.3-3.el8_6.1.ppc64le"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "package": {
-        "name": "git-lfs-debugsource",
-        "ecosystem": "Red Hat:rhel_e4s:8.6::appstream",
-        "purl": "pkg:rpm/redhat/git-lfs-debugsource"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "0"
-            },
-            {
-              "fixed": "0:2.13.3-3.el8_6.1.x86_64"
+              "fixed": "0:2.13.3-3.el8_6.1"
             }
           ]
         }
@@ -249,27 +149,7 @@
               "introduced": "0"
             },
             {
-              "fixed": "0:2.13.3-3.el8_6.1.src"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "package": {
-        "name": "git-lfs",
-        "ecosystem": "Red Hat:rhel_tus:8.6::appstream",
-        "purl": "pkg:rpm/redhat/git-lfs"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "0"
-            },
-            {
-              "fixed": "0:2.13.3-3.el8_6.1.x86_64"
+              "fixed": "0:2.13.3-3.el8_6.1"
             }
           ]
         }
@@ -289,7 +169,7 @@
               "introduced": "0"
             },
             {
-              "fixed": "0:2.13.3-3.el8_6.1.x86_64"
+              "fixed": "0:2.13.3-3.el8_6.1"
             }
           ]
         }
@@ -309,7 +189,7 @@
               "introduced": "0"
             },
             {
-              "fixed": "0:2.13.3-3.el8_6.1.x86_64"
+              "fixed": "0:2.13.3-3.el8_6.1"
             }
           ]
         }


### PR DESCRIPTION
Including the arch suffix in a fixed version can cause false positives if the wrong arch range is used to scan a system.

For example

`0:7.3.0-427.28.1.el9_4.aarch64` < `0:7.3.0-427.28.1.el9_4.ppc64le`

So `0:7.3.0-427.28.1.el9_4.aarch64` would match the `0..0:7.3.0-427.28.1.el9_4.ppc64le` range and be considered vulnerable