### PR TITLE
feat: create dedicated ecosystem name enum with all ecosystems

### DIFF
--- a/validation/schema.json
+++ b/validation/schema.json
@@ -56,7 +56,7 @@
             "type": "object",
             "properties": {
               "ecosystem": {
-                "$ref": "#/$defs/ecosystem"
+                "$ref": "#/$defs/ecosystemWithSuffix"
               },
               "name": {
                 "type": "string"
@@ -296,11 +296,55 @@
     "modified"
   ],
   "$defs": {
-    "ecosystem": {
+    "ecosystemName": {
       "type": "string",
       "title": "Currently supported ecosystems",
       "description": "These ecosystems are also documented at https://ossf.github.io/osv-schema/#affectedpackage-field",
-      "pattern": "^(AlmaLinux|Alpine|Android|Bioconductor|Bitnami|Chainguard|ConanCenter|CRAN|crates.io|Debian|GHC|GitHub Actions|GIT|Go|Hackage|Hex|Linux|Maven|npm|NuGet|openSUSE|OSS-Fuzz|Packagist|Photon OS|Pub|PyPI|Red Hat|Rocky Linux|RubyGems|SUSE|SwiftURL|Ubuntu|Wolfi)(:[0-9]+)?"
+      "enum": [
+        "AlmaLinux",
+        "Alpine",
+        "Android",
+        "Bioconductor",
+        "Bitnami",
+        "Chainguard",
+        "ConanCenter",
+        "CRAN",
+        "crates.io",
+        "Debian",
+        "GHC",
+        "GitHub Actions",
+        "Go",
+        "Hackage",
+        "Hex",
+        "Linux",
+        "Mageia",
+        "Maven",
+        "npm",
+        "NuGet",
+        "OSS-Fuzz",
+        "openSUSE",
+        "Packagist",
+        "Photon OS",
+        "Pub",
+        "PyPI",
+        "Red Hat",
+        "Rocky Linux",
+        "RubyGems",
+        "SUSE",
+        "SwiftURL",
+        "Ubuntu",
+        "Wolfi"
+      ]
+    },
+    "ecosystemSuffix": {
+      "type": "string",
+      "pattern": ":.+"
+    },
+    "ecosystemWithSuffix": {
+      "type": "string",
+      "title": "Currently supported ecosystems",
+      "description": "These ecosystems are also documented at https://ossf.github.io/osv-schema/#affectedpackage-field",
+      "pattern": "^(AlmaLinux|Alpine|Android|Bioconductor|Bitnami|Chainguard|ConanCenter|CRAN|crates\\.io|Debian|GHC|GitHub Actions|Go|Hackage|Hex|Linux|Mageia|Maven|npm|NuGet|OSS-Fuzz|openSUSE|Packagist|Photon OS|Pub|PyPI|Red Hat|Rocky Linux|RubyGems|SUSE|SwiftURL|Ubuntu|Wolfi|GIT)(:.+)?$"
     },
     "prefix": {
       "type": "string",


### PR DESCRIPTION
This introduces new dedicated types for the name of an ecosystem (which is an enum) and an ecosystem suffix (which is a string starting with `:`), along with renaming the existing `ecosystem` type to `ecosystemWithSuffix` (+ adding it).

While these types are not actually used in the schema due to JSONSchema currently does not have a way of specifying that a string is made up of two types, having them defined enables a lot of automation as the current `pattern` based type cannot be used to get a finite list of all possible ecosystems defined by the spec.

As an example, here's a [TypeScript playground](https://www.typescriptlang.org/play/?#code/C4TwDgpgBAogxgewM4icCBbKBeKByOAJwEN0kA6ASwTygB98BxG+-AWWIDcIA7PAWABQQ0JFiIUaTAHVKwABYAFQhABmlAB45xyVOiwMABgBIA3vF1SMAXwBcZtIUo8A5tYfAnr64YDcQoQATCDgAG2IVKFUAVx44YGoeKJ4ACg1bHUl9WQVlNU0ASgzOBEpA-2FBVVSCEjIqBFsARgAmPAKhapTa0ggKanbOmqJe-sbByud0QlViOGhFCKQIQIsszChTISgoEMt9DLW9TAqdpGjVdXSoR2cXCusgA) showcasing how you could use the types that would be automatically generated from this new schema structure using [`json-schema-to-typescript`](https://www.npmjs.com/package/json-schema-to-typescript) (with a manually defined `EcosystemSuffix` type, though we can later introduce that for TypeScript specifically by adding a `tsType` property).

Notably, landing this will unblock me adding automation to ensure that all lists of the ecosystem name are in sync (notably, the table in the docs, the enum + pattern here, and soon the constants being added in #292)