### PR TITLE
Clarify PURL requirements.

### DIFF
--- a/docs/schema.md
+++ b/docs/schema.md
@@ -667,7 +667,8 @@ within its ecosystem. The two fields must both be present, because the
 
 The `purl` field is a string following the
  [Package URL specification](https://github.com/package-url/purl-spec) that
-identifies the package. This field is optional but recommended.
+identifies the package, without the `@version` component.
+This field is optional but recommended. 
 
 Different ecosystems can define the same names; they identify different
 packages. For example, these denote different libraries with different sets of


### PR DESCRIPTION
PURLs should not include the `@version` component when used in OSV. 

`affected[].ranges[]`  should be used for this purpose.