### PR TITLE
chore: add `.editorconfig` file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+# EditorConfig helps developers define and maintain consistent
+# coding styles between different editors and IDEs
+# editorconfig.org
+
+root = true
+
+[*]
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+
+[*.go]
+indent_style = tab


### PR DESCRIPTION
Among other things, this should help ensure that editors use the same indenting - note that currently a lot of the Python files in particular are formatted with 4 spaces instead of 2, which will be taken care of at a later date