### PR TITLE
skip modules but keep their rpms

### DIFF
--- a/tools/redhat/redhat_osv/convert_redhat_test.py
+++ b/tools/redhat/redhat_osv/convert_redhat_test.py
@@ -8,25 +8,29 @@ from redhat_osv.osv import DATE_FORMAT, RedHatConverter
 class TestRedHatConverter(unittest.TestCase):
     """Test end-to-end convertion from RedHAt CSAF to OSV format"""
 
+    test_advisories = ["2024_4546", "2024_6220"]
+
     def test_convert_redhat(self):
-        """ Test a single demo CSAF file """
-        modified_time = datetime.strptime("2024-09-02T14:30:00",
-                                          "%Y-%m-%dT%H:%M:%S")
-        csaf_file = "testdata/rhsa-2024_4546.json"
-        expected_file = "testdata/RHSA-2024_4546.json"
+        for test_advisory in self.test_advisories:
+            """ Test a single demo CSAF file """
+            modified_time = datetime.strptime("2024-09-02T14:30:00",
+                                              "%Y-%m-%dT%H:%M:%S")
+            csaf_file = f"testdata/rhsa-{test_advisory}.json"
+            expected_file = f"testdata/RHSA-{test_advisory}.json"
 
-        with open(csaf_file, "r", encoding="utf-8") as fp:
-            csaf_data = fp.read()
-        converter = RedHatConverter()
-        osv_data = converter.convert(csaf_data,
-                                     modified_time.strftime(DATE_FORMAT))
+            with open(csaf_file, "r", encoding="utf-8") as fp:
+                csaf_data = fp.read()
+            converter = RedHatConverter()
+            osv_data = converter.convert(csaf_data,
+                                         modified_time.strftime(DATE_FORMAT))
 
-        assert osv_data[0] == "RHSA-2024:4546"
-        result_data = json.loads(osv_data[1])
+            advisory_id = test_advisory.replace("_", ":")
+            assert osv_data[0] == f"RHSA-{advisory_id}"
+            result_data = json.loads(osv_data[1])
 
-        with open(expected_file, "r", encoding="utf-8") as fp:
-            expected_data = json.load(fp)
-        assert expected_data == result_data
+            with open(expected_file, "r", encoding="utf-8") as fp:
+                expected_data = json.load(fp)
+            assert expected_data == result_data
 
 
 if __name__ == '__main__':

--- a/tools/redhat/testdata/RHSA-2024_6220.json
+++ b/tools/redhat/testdata/RHSA-2024_6220.json
@@ -1,0 +1,4616 @@
+{
+  "schema_version": "1.6.7",
+  "id": "RHSA-2024:6220",
+  "related": [
+    "CVE-2024-6345"
+  ],
+  "published": "2024-09-02T14:30:00Z",
+  "modified": "2024-09-02T14:30:00Z",
+  "summary": "Red Hat Security Advisory: python39:3.9 security update",
+  "severity": [
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H"
+    }
+  ],
+  "affected": [
+    {
+      "package": {
+        "name": "PyYAML",
+        "ecosystem": "Red Hat:rhel_aus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/PyYAML"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:5.4.1-1.module+el8.5.0+10613+59a13ec4"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "PyYAML-debugsource",
+        "ecosystem": "Red Hat:rhel_aus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/PyYAML-debugsource"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:5.4.1-1.module+el8.5.0+10613+59a13ec4"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "mod_wsgi",
+        "ecosystem": "Red Hat:rhel_aus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/mod_wsgi"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:4.7.1-4.module+el8.4.0+9822+20bf1249"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "numpy",
+        "ecosystem": "Red Hat:rhel_aus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/numpy"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:1.19.4-3.module+el8.5.0+12204+54860423"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "numpy-debugsource",
+        "ecosystem": "Red Hat:rhel_aus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/numpy-debugsource"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:1.19.4-3.module+el8.5.0+12204+54860423"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python-PyMySQL",
+        "ecosystem": "Red Hat:rhel_aus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python-PyMySQL"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:0.10.1-2.module+el8.4.0+9822+20bf1249"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python-cffi",
+        "ecosystem": "Red Hat:rhel_aus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python-cffi"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:1.14.3-2.module+el8.4.0+9822+20bf1249"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python-cffi-debugsource",
+        "ecosystem": "Red Hat:rhel_aus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python-cffi-debugsource"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:1.14.3-2.module+el8.4.0+9822+20bf1249"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python-chardet",
+        "ecosystem": "Red Hat:rhel_aus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python-chardet"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:3.0.4-19.module+el8.4.0+9822+20bf1249"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python-cryptography",
+        "ecosystem": "Red Hat:rhel_aus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python-cryptography"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:3.3.1-2.module+el8.4.0+9822+20bf1249"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python-cryptography-debugsource",
+        "ecosystem": "Red Hat:rhel_aus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python-cryptography-debugsource"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:3.3.1-2.module+el8.4.0+9822+20bf1249"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python-idna",
+        "ecosystem": "Red Hat:rhel_aus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python-idna"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:2.10-3.module+el8.4.0+9822+20bf1249"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python-lxml",
+        "ecosystem": "Red Hat:rhel_aus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python-lxml"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:4.6.5-1.module+el8.6.0+13933+9cf0c87c"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python-lxml-debugsource",
+        "ecosystem": "Red Hat:rhel_aus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python-lxml-debugsource"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:4.6.5-1.module+el8.6.0+13933+9cf0c87c"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python-ply",
+        "ecosystem": "Red Hat:rhel_aus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python-ply"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:3.11-10.module+el8.4.0+9822+20bf1249"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python-psutil",
+        "ecosystem": "Red Hat:rhel_aus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python-psutil"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:5.8.0-4.module+el8.4.0+9822+20bf1249"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python-psutil-debugsource",
+        "ecosystem": "Red Hat:rhel_aus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python-psutil-debugsource"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:5.8.0-4.module+el8.4.0+9822+20bf1249"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python-psycopg2",
+        "ecosystem": "Red Hat:rhel_aus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python-psycopg2"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:2.8.6-2.module+el8.4.0+9822+20bf1249"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python-psycopg2-debugsource",
+        "ecosystem": "Red Hat:rhel_aus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python-psycopg2-debugsource"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:2.8.6-2.module+el8.4.0+9822+20bf1249"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python-pycparser",
+        "ecosystem": "Red Hat:rhel_aus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python-pycparser"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:2.20-3.module+el8.4.0+9822+20bf1249"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python-pysocks",
+        "ecosystem": "Red Hat:rhel_aus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python-pysocks"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:1.7.1-4.module+el8.4.0+9822+20bf1249"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python-requests",
+        "ecosystem": "Red Hat:rhel_aus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python-requests"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:2.25.0-2.module+el8.4.0+9822+20bf1249"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python-toml",
+        "ecosystem": "Red Hat:rhel_aus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python-toml"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:0.10.1-5.module+el8.4.0+9822+20bf1249"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python-urllib3",
+        "ecosystem": "Red Hat:rhel_aus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python-urllib3"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:1.25.10-4.module+el8.5.0+11712+ea2d2be1"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python-wheel",
+        "ecosystem": "Red Hat:rhel_aus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python-wheel"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1:0.35.1-4.module+el8.5.0+12204+54860423"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python39",
+        "ecosystem": "Red Hat:rhel_aus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python39"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:3.9.7-2.module+el8.6.0+20026+579726f4.2"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python39-PyMySQL",
+        "ecosystem": "Red Hat:rhel_aus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python39-PyMySQL"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:0.10.1-2.module+el8.4.0+9822+20bf1249"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python39-cffi",
+        "ecosystem": "Red Hat:rhel_aus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python39-cffi"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:1.14.3-2.module+el8.4.0+9822+20bf1249"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python39-cffi-debuginfo",
+        "ecosystem": "Red Hat:rhel_aus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python39-cffi-debuginfo"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:1.14.3-2.module+el8.4.0+9822+20bf1249"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python39-chardet",
+        "ecosystem": "Red Hat:rhel_aus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python39-chardet"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:3.0.4-19.module+el8.4.0+9822+20bf1249"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python39-cryptography",
+        "ecosystem": "Red Hat:rhel_aus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python39-cryptography"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:3.3.1-2.module+el8.4.0+9822+20bf1249"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python39-cryptography-debuginfo",
+        "ecosystem": "Red Hat:rhel_aus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python39-cryptography-debuginfo"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:3.3.1-2.module+el8.4.0+9822+20bf1249"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python39-debuginfo",
+        "ecosystem": "Red Hat:rhel_aus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python39-debuginfo"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:3.9.7-2.module+el8.6.0+20026+579726f4.2"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python39-debugsource",
+        "ecosystem": "Red Hat:rhel_aus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python39-debugsource"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:3.9.7-2.module+el8.6.0+20026+579726f4.2"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python39-devel",
+        "ecosystem": "Red Hat:rhel_aus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python39-devel"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:3.9.7-2.module+el8.6.0+20026+579726f4.2"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python39-idle",
+        "ecosystem": "Red Hat:rhel_aus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python39-idle"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:3.9.7-2.module+el8.6.0+20026+579726f4.2"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python39-idna",
+        "ecosystem": "Red Hat:rhel_aus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python39-idna"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:2.10-3.module+el8.4.0+9822+20bf1249"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python39-libs",
+        "ecosystem": "Red Hat:rhel_aus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python39-libs"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:3.9.7-2.module+el8.6.0+20026+579726f4.2"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python39-lxml",
+        "ecosystem": "Red Hat:rhel_aus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python39-lxml"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:4.6.5-1.module+el8.6.0+13933+9cf0c87c"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python39-lxml-debuginfo",
+        "ecosystem": "Red Hat:rhel_aus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python39-lxml-debuginfo"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:4.6.5-1.module+el8.6.0+13933+9cf0c87c"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python39-mod_wsgi",
+        "ecosystem": "Red Hat:rhel_aus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python39-mod_wsgi"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:4.7.1-4.module+el8.4.0+9822+20bf1249"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python39-numpy",
+        "ecosystem": "Red Hat:rhel_aus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python39-numpy"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:1.19.4-3.module+el8.5.0+12204+54860423"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python39-numpy-debuginfo",
+        "ecosystem": "Red Hat:rhel_aus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python39-numpy-debuginfo"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:1.19.4-3.module+el8.5.0+12204+54860423"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python39-numpy-doc",
+        "ecosystem": "Red Hat:rhel_aus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python39-numpy-doc"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:1.19.4-3.module+el8.5.0+12204+54860423"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python39-numpy-f2py",
+        "ecosystem": "Red Hat:rhel_aus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python39-numpy-f2py"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:1.19.4-3.module+el8.5.0+12204+54860423"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python39-pip",
+        "ecosystem": "Red Hat:rhel_aus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python39-pip"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:20.2.4-7.module+el8.6.0+13003+6bb2c488"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python39-pip-wheel",
+        "ecosystem": "Red Hat:rhel_aus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python39-pip-wheel"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:20.2.4-7.module+el8.6.0+13003+6bb2c488"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python39-ply",
+        "ecosystem": "Red Hat:rhel_aus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python39-ply"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:3.11-10.module+el8.4.0+9822+20bf1249"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python39-psutil",
+        "ecosystem": "Red Hat:rhel_aus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python39-psutil"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:5.8.0-4.module+el8.4.0+9822+20bf1249"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python39-psutil-debuginfo",
+        "ecosystem": "Red Hat:rhel_aus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python39-psutil-debuginfo"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:5.8.0-4.module+el8.4.0+9822+20bf1249"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python39-psycopg2",
+        "ecosystem": "Red Hat:rhel_aus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python39-psycopg2"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:2.8.6-2.module+el8.4.0+9822+20bf1249"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python39-psycopg2-debuginfo",
+        "ecosystem": "Red Hat:rhel_aus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python39-psycopg2-debuginfo"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:2.8.6-2.module+el8.4.0+9822+20bf1249"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python39-psycopg2-doc",
+        "ecosystem": "Red Hat:rhel_aus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python39-psycopg2-doc"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:2.8.6-2.module+el8.4.0+9822+20bf1249"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python39-psycopg2-tests",
+        "ecosystem": "Red Hat:rhel_aus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python39-psycopg2-tests"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:2.8.6-2.module+el8.4.0+9822+20bf1249"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python39-pycparser",
+        "ecosystem": "Red Hat:rhel_aus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python39-pycparser"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:2.20-3.module+el8.4.0+9822+20bf1249"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python39-pysocks",
+        "ecosystem": "Red Hat:rhel_aus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python39-pysocks"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:1.7.1-4.module+el8.4.0+9822+20bf1249"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python39-pyyaml",
+        "ecosystem": "Red Hat:rhel_aus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python39-pyyaml"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:5.4.1-1.module+el8.5.0+10613+59a13ec4"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python39-pyyaml-debuginfo",
+        "ecosystem": "Red Hat:rhel_aus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python39-pyyaml-debuginfo"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:5.4.1-1.module+el8.5.0+10613+59a13ec4"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python39-requests",
+        "ecosystem": "Red Hat:rhel_aus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python39-requests"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:2.25.0-2.module+el8.4.0+9822+20bf1249"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python39-rpm-macros",
+        "ecosystem": "Red Hat:rhel_aus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python39-rpm-macros"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:3.9.7-2.module+el8.6.0+20026+579726f4.2"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python39-scipy",
+        "ecosystem": "Red Hat:rhel_aus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python39-scipy"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:1.5.4-3.module+el8.4.0+9822+20bf1249"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python39-scipy-debuginfo",
+        "ecosystem": "Red Hat:rhel_aus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python39-scipy-debuginfo"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:1.5.4-3.module+el8.4.0+9822+20bf1249"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python39-setuptools",
+        "ecosystem": "Red Hat:rhel_aus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python39-setuptools"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:50.3.2-6.module+el8.6.0+22162+859a69ec"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python39-setuptools-wheel",
+        "ecosystem": "Red Hat:rhel_aus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python39-setuptools-wheel"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:50.3.2-6.module+el8.6.0+22162+859a69ec"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python39-six",
+        "ecosystem": "Red Hat:rhel_aus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python39-six"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:1.15.0-3.module+el8.4.0+9822+20bf1249"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python39-test",
+        "ecosystem": "Red Hat:rhel_aus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python39-test"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:3.9.7-2.module+el8.6.0+20026+579726f4.2"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python39-tkinter",
+        "ecosystem": "Red Hat:rhel_aus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python39-tkinter"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:3.9.7-2.module+el8.6.0+20026+579726f4.2"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python39-toml",
+        "ecosystem": "Red Hat:rhel_aus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python39-toml"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:0.10.1-5.module+el8.4.0+9822+20bf1249"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python39-urllib3",
+        "ecosystem": "Red Hat:rhel_aus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python39-urllib3"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:1.25.10-4.module+el8.5.0+11712+ea2d2be1"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python39-wheel",
+        "ecosystem": "Red Hat:rhel_aus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python39-wheel"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1:0.35.1-4.module+el8.5.0+12204+54860423"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python39-wheel-wheel",
+        "ecosystem": "Red Hat:rhel_aus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python39-wheel-wheel"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1:0.35.1-4.module+el8.5.0+12204+54860423"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python3x-pip",
+        "ecosystem": "Red Hat:rhel_aus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python3x-pip"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:20.2.4-7.module+el8.6.0+13003+6bb2c488"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python3x-setuptools",
+        "ecosystem": "Red Hat:rhel_aus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python3x-setuptools"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:50.3.2-6.module+el8.6.0+22162+859a69ec"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python3x-six",
+        "ecosystem": "Red Hat:rhel_aus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python3x-six"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:1.15.0-3.module+el8.4.0+9822+20bf1249"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "scipy",
+        "ecosystem": "Red Hat:rhel_aus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/scipy"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:1.5.4-3.module+el8.4.0+9822+20bf1249"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "scipy-debugsource",
+        "ecosystem": "Red Hat:rhel_aus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/scipy-debugsource"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:1.5.4-3.module+el8.4.0+9822+20bf1249"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "PyYAML",
+        "ecosystem": "Red Hat:rhel_e4s:8.6::appstream",
+        "purl": "pkg:rpm/redhat/PyYAML"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:5.4.1-1.module+el8.5.0+10613+59a13ec4"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "PyYAML-debugsource",
+        "ecosystem": "Red Hat:rhel_e4s:8.6::appstream",
+        "purl": "pkg:rpm/redhat/PyYAML-debugsource"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:5.4.1-1.module+el8.5.0+10613+59a13ec4"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "mod_wsgi",
+        "ecosystem": "Red Hat:rhel_e4s:8.6::appstream",
+        "purl": "pkg:rpm/redhat/mod_wsgi"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:4.7.1-4.module+el8.4.0+9822+20bf1249"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "numpy",
+        "ecosystem": "Red Hat:rhel_e4s:8.6::appstream",
+        "purl": "pkg:rpm/redhat/numpy"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:1.19.4-3.module+el8.5.0+12204+54860423"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "numpy-debugsource",
+        "ecosystem": "Red Hat:rhel_e4s:8.6::appstream",
+        "purl": "pkg:rpm/redhat/numpy-debugsource"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:1.19.4-3.module+el8.5.0+12204+54860423"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python-PyMySQL",
+        "ecosystem": "Red Hat:rhel_e4s:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python-PyMySQL"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:0.10.1-2.module+el8.4.0+9822+20bf1249"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python-cffi",
+        "ecosystem": "Red Hat:rhel_e4s:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python-cffi"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:1.14.3-2.module+el8.4.0+9822+20bf1249"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python-cffi-debugsource",
+        "ecosystem": "Red Hat:rhel_e4s:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python-cffi-debugsource"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:1.14.3-2.module+el8.4.0+9822+20bf1249"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python-chardet",
+        "ecosystem": "Red Hat:rhel_e4s:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python-chardet"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:3.0.4-19.module+el8.4.0+9822+20bf1249"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python-cryptography",
+        "ecosystem": "Red Hat:rhel_e4s:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python-cryptography"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:3.3.1-2.module+el8.4.0+9822+20bf1249"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python-cryptography-debugsource",
+        "ecosystem": "Red Hat:rhel_e4s:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python-cryptography-debugsource"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:3.3.1-2.module+el8.4.0+9822+20bf1249"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python-idna",
+        "ecosystem": "Red Hat:rhel_e4s:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python-idna"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:2.10-3.module+el8.4.0+9822+20bf1249"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python-lxml",
+        "ecosystem": "Red Hat:rhel_e4s:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python-lxml"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:4.6.5-1.module+el8.6.0+13933+9cf0c87c"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python-lxml-debugsource",
+        "ecosystem": "Red Hat:rhel_e4s:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python-lxml-debugsource"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:4.6.5-1.module+el8.6.0+13933+9cf0c87c"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python-ply",
+        "ecosystem": "Red Hat:rhel_e4s:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python-ply"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:3.11-10.module+el8.4.0+9822+20bf1249"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python-psutil",
+        "ecosystem": "Red Hat:rhel_e4s:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python-psutil"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:5.8.0-4.module+el8.4.0+9822+20bf1249"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python-psutil-debugsource",
+        "ecosystem": "Red Hat:rhel_e4s:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python-psutil-debugsource"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:5.8.0-4.module+el8.4.0+9822+20bf1249"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python-psycopg2",
+        "ecosystem": "Red Hat:rhel_e4s:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python-psycopg2"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:2.8.6-2.module+el8.4.0+9822+20bf1249"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python-psycopg2-debugsource",
+        "ecosystem": "Red Hat:rhel_e4s:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python-psycopg2-debugsource"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:2.8.6-2.module+el8.4.0+9822+20bf1249"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python-pycparser",
+        "ecosystem": "Red Hat:rhel_e4s:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python-pycparser"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:2.20-3.module+el8.4.0+9822+20bf1249"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python-pysocks",
+        "ecosystem": "Red Hat:rhel_e4s:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python-pysocks"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:1.7.1-4.module+el8.4.0+9822+20bf1249"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python-requests",
+        "ecosystem": "Red Hat:rhel_e4s:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python-requests"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:2.25.0-2.module+el8.4.0+9822+20bf1249"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python-toml",
+        "ecosystem": "Red Hat:rhel_e4s:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python-toml"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:0.10.1-5.module+el8.4.0+9822+20bf1249"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python-urllib3",
+        "ecosystem": "Red Hat:rhel_e4s:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python-urllib3"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:1.25.10-4.module+el8.5.0+11712+ea2d2be1"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python-wheel",
+        "ecosystem": "Red Hat:rhel_e4s:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python-wheel"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1:0.35.1-4.module+el8.5.0+12204+54860423"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python39",
+        "ecosystem": "Red Hat:rhel_e4s:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python39"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:3.9.7-2.module+el8.6.0+20026+579726f4.2"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python39-PyMySQL",
+        "ecosystem": "Red Hat:rhel_e4s:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python39-PyMySQL"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:0.10.1-2.module+el8.4.0+9822+20bf1249"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python39-cffi",
+        "ecosystem": "Red Hat:rhel_e4s:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python39-cffi"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:1.14.3-2.module+el8.4.0+9822+20bf1249"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python39-cffi-debuginfo",
+        "ecosystem": "Red Hat:rhel_e4s:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python39-cffi-debuginfo"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:1.14.3-2.module+el8.4.0+9822+20bf1249"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python39-chardet",
+        "ecosystem": "Red Hat:rhel_e4s:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python39-chardet"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:3.0.4-19.module+el8.4.0+9822+20bf1249"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python39-cryptography",
+        "ecosystem": "Red Hat:rhel_e4s:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python39-cryptography"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:3.3.1-2.module+el8.4.0+9822+20bf1249"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python39-cryptography-debuginfo",
+        "ecosystem": "Red Hat:rhel_e4s:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python39-cryptography-debuginfo"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:3.3.1-2.module+el8.4.0+9822+20bf1249"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python39-debuginfo",
+        "ecosystem": "Red Hat:rhel_e4s:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python39-debuginfo"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:3.9.7-2.module+el8.6.0+20026+579726f4.2"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python39-debugsource",
+        "ecosystem": "Red Hat:rhel_e4s:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python39-debugsource"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:3.9.7-2.module+el8.6.0+20026+579726f4.2"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python39-devel",
+        "ecosystem": "Red Hat:rhel_e4s:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python39-devel"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:3.9.7-2.module+el8.6.0+20026+579726f4.2"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python39-idle",
+        "ecosystem": "Red Hat:rhel_e4s:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python39-idle"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:3.9.7-2.module+el8.6.0+20026+579726f4.2"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python39-idna",
+        "ecosystem": "Red Hat:rhel_e4s:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python39-idna"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:2.10-3.module+el8.4.0+9822+20bf1249"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python39-libs",
+        "ecosystem": "Red Hat:rhel_e4s:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python39-libs"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:3.9.7-2.module+el8.6.0+20026+579726f4.2"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python39-lxml",
+        "ecosystem": "Red Hat:rhel_e4s:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python39-lxml"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:4.6.5-1.module+el8.6.0+13933+9cf0c87c"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python39-lxml-debuginfo",
+        "ecosystem": "Red Hat:rhel_e4s:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python39-lxml-debuginfo"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:4.6.5-1.module+el8.6.0+13933+9cf0c87c"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python39-mod_wsgi",
+        "ecosystem": "Red Hat:rhel_e4s:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python39-mod_wsgi"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:4.7.1-4.module+el8.4.0+9822+20bf1249"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python39-numpy",
+        "ecosystem": "Red Hat:rhel_e4s:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python39-numpy"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:1.19.4-3.module+el8.5.0+12204+54860423"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python39-numpy-debuginfo",
+        "ecosystem": "Red Hat:rhel_e4s:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python39-numpy-debuginfo"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:1.19.4-3.module+el8.5.0+12204+54860423"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python39-numpy-doc",
+        "ecosystem": "Red Hat:rhel_e4s:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python39-numpy-doc"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:1.19.4-3.module+el8.5.0+12204+54860423"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python39-numpy-f2py",
+        "ecosystem": "Red Hat:rhel_e4s:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python39-numpy-f2py"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:1.19.4-3.module+el8.5.0+12204+54860423"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python39-pip",
+        "ecosystem": "Red Hat:rhel_e4s:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python39-pip"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:20.2.4-7.module+el8.6.0+13003+6bb2c488"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python39-pip-wheel",
+        "ecosystem": "Red Hat:rhel_e4s:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python39-pip-wheel"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:20.2.4-7.module+el8.6.0+13003+6bb2c488"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python39-ply",
+        "ecosystem": "Red Hat:rhel_e4s:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python39-ply"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:3.11-10.module+el8.4.0+9822+20bf1249"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python39-psutil",
+        "ecosystem": "Red Hat:rhel_e4s:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python39-psutil"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:5.8.0-4.module+el8.4.0+9822+20bf1249"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python39-psutil-debuginfo",
+        "ecosystem": "Red Hat:rhel_e4s:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python39-psutil-debuginfo"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:5.8.0-4.module+el8.4.0+9822+20bf1249"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python39-psycopg2",
+        "ecosystem": "Red Hat:rhel_e4s:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python39-psycopg2"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:2.8.6-2.module+el8.4.0+9822+20bf1249"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python39-psycopg2-debuginfo",
+        "ecosystem": "Red Hat:rhel_e4s:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python39-psycopg2-debuginfo"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:2.8.6-2.module+el8.4.0+9822+20bf1249"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python39-psycopg2-doc",
+        "ecosystem": "Red Hat:rhel_e4s:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python39-psycopg2-doc"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:2.8.6-2.module+el8.4.0+9822+20bf1249"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python39-psycopg2-tests",
+        "ecosystem": "Red Hat:rhel_e4s:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python39-psycopg2-tests"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:2.8.6-2.module+el8.4.0+9822+20bf1249"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python39-pycparser",
+        "ecosystem": "Red Hat:rhel_e4s:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python39-pycparser"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:2.20-3.module+el8.4.0+9822+20bf1249"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python39-pysocks",
+        "ecosystem": "Red Hat:rhel_e4s:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python39-pysocks"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:1.7.1-4.module+el8.4.0+9822+20bf1249"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python39-pyyaml",
+        "ecosystem": "Red Hat:rhel_e4s:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python39-pyyaml"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:5.4.1-1.module+el8.5.0+10613+59a13ec4"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python39-pyyaml-debuginfo",
+        "ecosystem": "Red Hat:rhel_e4s:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python39-pyyaml-debuginfo"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:5.4.1-1.module+el8.5.0+10613+59a13ec4"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python39-requests",
+        "ecosystem": "Red Hat:rhel_e4s:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python39-requests"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:2.25.0-2.module+el8.4.0+9822+20bf1249"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python39-rpm-macros",
+        "ecosystem": "Red Hat:rhel_e4s:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python39-rpm-macros"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:3.9.7-2.module+el8.6.0+20026+579726f4.2"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python39-scipy",
+        "ecosystem": "Red Hat:rhel_e4s:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python39-scipy"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:1.5.4-3.module+el8.4.0+9822+20bf1249"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python39-scipy-debuginfo",
+        "ecosystem": "Red Hat:rhel_e4s:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python39-scipy-debuginfo"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:1.5.4-3.module+el8.4.0+9822+20bf1249"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python39-setuptools",
+        "ecosystem": "Red Hat:rhel_e4s:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python39-setuptools"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:50.3.2-6.module+el8.6.0+22162+859a69ec"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python39-setuptools-wheel",
+        "ecosystem": "Red Hat:rhel_e4s:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python39-setuptools-wheel"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:50.3.2-6.module+el8.6.0+22162+859a69ec"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python39-six",
+        "ecosystem": "Red Hat:rhel_e4s:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python39-six"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:1.15.0-3.module+el8.4.0+9822+20bf1249"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python39-test",
+        "ecosystem": "Red Hat:rhel_e4s:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python39-test"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:3.9.7-2.module+el8.6.0+20026+579726f4.2"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python39-tkinter",
+        "ecosystem": "Red Hat:rhel_e4s:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python39-tkinter"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:3.9.7-2.module+el8.6.0+20026+579726f4.2"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python39-toml",
+        "ecosystem": "Red Hat:rhel_e4s:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python39-toml"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:0.10.1-5.module+el8.4.0+9822+20bf1249"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python39-urllib3",
+        "ecosystem": "Red Hat:rhel_e4s:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python39-urllib3"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:1.25.10-4.module+el8.5.0+11712+ea2d2be1"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python39-wheel",
+        "ecosystem": "Red Hat:rhel_e4s:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python39-wheel"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1:0.35.1-4.module+el8.5.0+12204+54860423"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python39-wheel-wheel",
+        "ecosystem": "Red Hat:rhel_e4s:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python39-wheel-wheel"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1:0.35.1-4.module+el8.5.0+12204+54860423"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python3x-pip",
+        "ecosystem": "Red Hat:rhel_e4s:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python3x-pip"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:20.2.4-7.module+el8.6.0+13003+6bb2c488"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python3x-setuptools",
+        "ecosystem": "Red Hat:rhel_e4s:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python3x-setuptools"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:50.3.2-6.module+el8.6.0+22162+859a69ec"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python3x-six",
+        "ecosystem": "Red Hat:rhel_e4s:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python3x-six"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:1.15.0-3.module+el8.4.0+9822+20bf1249"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "scipy",
+        "ecosystem": "Red Hat:rhel_e4s:8.6::appstream",
+        "purl": "pkg:rpm/redhat/scipy"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:1.5.4-3.module+el8.4.0+9822+20bf1249"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "scipy-debugsource",
+        "ecosystem": "Red Hat:rhel_e4s:8.6::appstream",
+        "purl": "pkg:rpm/redhat/scipy-debugsource"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:1.5.4-3.module+el8.4.0+9822+20bf1249"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "PyYAML",
+        "ecosystem": "Red Hat:rhel_tus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/PyYAML"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:5.4.1-1.module+el8.5.0+10613+59a13ec4"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "PyYAML-debugsource",
+        "ecosystem": "Red Hat:rhel_tus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/PyYAML-debugsource"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:5.4.1-1.module+el8.5.0+10613+59a13ec4"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "mod_wsgi",
+        "ecosystem": "Red Hat:rhel_tus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/mod_wsgi"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:4.7.1-4.module+el8.4.0+9822+20bf1249"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "numpy",
+        "ecosystem": "Red Hat:rhel_tus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/numpy"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:1.19.4-3.module+el8.5.0+12204+54860423"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "numpy-debugsource",
+        "ecosystem": "Red Hat:rhel_tus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/numpy-debugsource"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:1.19.4-3.module+el8.5.0+12204+54860423"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python-PyMySQL",
+        "ecosystem": "Red Hat:rhel_tus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python-PyMySQL"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:0.10.1-2.module+el8.4.0+9822+20bf1249"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python-cffi",
+        "ecosystem": "Red Hat:rhel_tus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python-cffi"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:1.14.3-2.module+el8.4.0+9822+20bf1249"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python-cffi-debugsource",
+        "ecosystem": "Red Hat:rhel_tus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python-cffi-debugsource"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:1.14.3-2.module+el8.4.0+9822+20bf1249"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python-chardet",
+        "ecosystem": "Red Hat:rhel_tus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python-chardet"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:3.0.4-19.module+el8.4.0+9822+20bf1249"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python-cryptography",
+        "ecosystem": "Red Hat:rhel_tus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python-cryptography"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:3.3.1-2.module+el8.4.0+9822+20bf1249"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python-cryptography-debugsource",
+        "ecosystem": "Red Hat:rhel_tus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python-cryptography-debugsource"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:3.3.1-2.module+el8.4.0+9822+20bf1249"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python-idna",
+        "ecosystem": "Red Hat:rhel_tus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python-idna"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:2.10-3.module+el8.4.0+9822+20bf1249"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python-lxml",
+        "ecosystem": "Red Hat:rhel_tus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python-lxml"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:4.6.5-1.module+el8.6.0+13933+9cf0c87c"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python-lxml-debugsource",
+        "ecosystem": "Red Hat:rhel_tus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python-lxml-debugsource"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:4.6.5-1.module+el8.6.0+13933+9cf0c87c"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python-ply",
+        "ecosystem": "Red Hat:rhel_tus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python-ply"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:3.11-10.module+el8.4.0+9822+20bf1249"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python-psutil",
+        "ecosystem": "Red Hat:rhel_tus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python-psutil"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:5.8.0-4.module+el8.4.0+9822+20bf1249"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python-psutil-debugsource",
+        "ecosystem": "Red Hat:rhel_tus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python-psutil-debugsource"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:5.8.0-4.module+el8.4.0+9822+20bf1249"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python-psycopg2",
+        "ecosystem": "Red Hat:rhel_tus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python-psycopg2"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:2.8.6-2.module+el8.4.0+9822+20bf1249"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python-psycopg2-debugsource",
+        "ecosystem": "Red Hat:rhel_tus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python-psycopg2-debugsource"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:2.8.6-2.module+el8.4.0+9822+20bf1249"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python-pycparser",
+        "ecosystem": "Red Hat:rhel_tus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python-pycparser"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:2.20-3.module+el8.4.0+9822+20bf1249"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python-pysocks",
+        "ecosystem": "Red Hat:rhel_tus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python-pysocks"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:1.7.1-4.module+el8.4.0+9822+20bf1249"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python-requests",
+        "ecosystem": "Red Hat:rhel_tus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python-requests"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:2.25.0-2.module+el8.4.0+9822+20bf1249"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python-toml",
+        "ecosystem": "Red Hat:rhel_tus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python-toml"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:0.10.1-5.module+el8.4.0+9822+20bf1249"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python-urllib3",
+        "ecosystem": "Red Hat:rhel_tus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python-urllib3"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:1.25.10-4.module+el8.5.0+11712+ea2d2be1"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python-wheel",
+        "ecosystem": "Red Hat:rhel_tus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python-wheel"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1:0.35.1-4.module+el8.5.0+12204+54860423"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python39",
+        "ecosystem": "Red Hat:rhel_tus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python39"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:3.9.7-2.module+el8.6.0+20026+579726f4.2"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python39-PyMySQL",
+        "ecosystem": "Red Hat:rhel_tus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python39-PyMySQL"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:0.10.1-2.module+el8.4.0+9822+20bf1249"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python39-cffi",
+        "ecosystem": "Red Hat:rhel_tus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python39-cffi"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:1.14.3-2.module+el8.4.0+9822+20bf1249"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python39-cffi-debuginfo",
+        "ecosystem": "Red Hat:rhel_tus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python39-cffi-debuginfo"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:1.14.3-2.module+el8.4.0+9822+20bf1249"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python39-chardet",
+        "ecosystem": "Red Hat:rhel_tus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python39-chardet"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:3.0.4-19.module+el8.4.0+9822+20bf1249"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python39-cryptography",
+        "ecosystem": "Red Hat:rhel_tus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python39-cryptography"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:3.3.1-2.module+el8.4.0+9822+20bf1249"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python39-cryptography-debuginfo",
+        "ecosystem": "Red Hat:rhel_tus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python39-cryptography-debuginfo"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:3.3.1-2.module+el8.4.0+9822+20bf1249"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python39-debuginfo",
+        "ecosystem": "Red Hat:rhel_tus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python39-debuginfo"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:3.9.7-2.module+el8.6.0+20026+579726f4.2"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python39-debugsource",
+        "ecosystem": "Red Hat:rhel_tus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python39-debugsource"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:3.9.7-2.module+el8.6.0+20026+579726f4.2"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python39-devel",
+        "ecosystem": "Red Hat:rhel_tus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python39-devel"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:3.9.7-2.module+el8.6.0+20026+579726f4.2"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python39-idle",
+        "ecosystem": "Red Hat:rhel_tus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python39-idle"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:3.9.7-2.module+el8.6.0+20026+579726f4.2"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python39-idna",
+        "ecosystem": "Red Hat:rhel_tus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python39-idna"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:2.10-3.module+el8.4.0+9822+20bf1249"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python39-libs",
+        "ecosystem": "Red Hat:rhel_tus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python39-libs"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:3.9.7-2.module+el8.6.0+20026+579726f4.2"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python39-lxml",
+        "ecosystem": "Red Hat:rhel_tus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python39-lxml"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:4.6.5-1.module+el8.6.0+13933+9cf0c87c"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python39-lxml-debuginfo",
+        "ecosystem": "Red Hat:rhel_tus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python39-lxml-debuginfo"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:4.6.5-1.module+el8.6.0+13933+9cf0c87c"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python39-mod_wsgi",
+        "ecosystem": "Red Hat:rhel_tus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python39-mod_wsgi"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:4.7.1-4.module+el8.4.0+9822+20bf1249"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python39-numpy",
+        "ecosystem": "Red Hat:rhel_tus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python39-numpy"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:1.19.4-3.module+el8.5.0+12204+54860423"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python39-numpy-debuginfo",
+        "ecosystem": "Red Hat:rhel_tus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python39-numpy-debuginfo"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:1.19.4-3.module+el8.5.0+12204+54860423"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python39-numpy-doc",
+        "ecosystem": "Red Hat:rhel_tus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python39-numpy-doc"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:1.19.4-3.module+el8.5.0+12204+54860423"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python39-numpy-f2py",
+        "ecosystem": "Red Hat:rhel_tus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python39-numpy-f2py"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:1.19.4-3.module+el8.5.0+12204+54860423"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python39-pip",
+        "ecosystem": "Red Hat:rhel_tus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python39-pip"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:20.2.4-7.module+el8.6.0+13003+6bb2c488"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python39-pip-wheel",
+        "ecosystem": "Red Hat:rhel_tus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python39-pip-wheel"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:20.2.4-7.module+el8.6.0+13003+6bb2c488"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python39-ply",
+        "ecosystem": "Red Hat:rhel_tus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python39-ply"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:3.11-10.module+el8.4.0+9822+20bf1249"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python39-psutil",
+        "ecosystem": "Red Hat:rhel_tus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python39-psutil"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:5.8.0-4.module+el8.4.0+9822+20bf1249"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python39-psutil-debuginfo",
+        "ecosystem": "Red Hat:rhel_tus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python39-psutil-debuginfo"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:5.8.0-4.module+el8.4.0+9822+20bf1249"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python39-psycopg2",
+        "ecosystem": "Red Hat:rhel_tus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python39-psycopg2"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:2.8.6-2.module+el8.4.0+9822+20bf1249"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python39-psycopg2-debuginfo",
+        "ecosystem": "Red Hat:rhel_tus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python39-psycopg2-debuginfo"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:2.8.6-2.module+el8.4.0+9822+20bf1249"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python39-psycopg2-doc",
+        "ecosystem": "Red Hat:rhel_tus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python39-psycopg2-doc"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:2.8.6-2.module+el8.4.0+9822+20bf1249"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python39-psycopg2-tests",
+        "ecosystem": "Red Hat:rhel_tus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python39-psycopg2-tests"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:2.8.6-2.module+el8.4.0+9822+20bf1249"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python39-pycparser",
+        "ecosystem": "Red Hat:rhel_tus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python39-pycparser"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:2.20-3.module+el8.4.0+9822+20bf1249"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python39-pysocks",
+        "ecosystem": "Red Hat:rhel_tus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python39-pysocks"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:1.7.1-4.module+el8.4.0+9822+20bf1249"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python39-pyyaml",
+        "ecosystem": "Red Hat:rhel_tus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python39-pyyaml"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:5.4.1-1.module+el8.5.0+10613+59a13ec4"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python39-pyyaml-debuginfo",
+        "ecosystem": "Red Hat:rhel_tus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python39-pyyaml-debuginfo"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:5.4.1-1.module+el8.5.0+10613+59a13ec4"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python39-requests",
+        "ecosystem": "Red Hat:rhel_tus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python39-requests"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:2.25.0-2.module+el8.4.0+9822+20bf1249"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python39-rpm-macros",
+        "ecosystem": "Red Hat:rhel_tus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python39-rpm-macros"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:3.9.7-2.module+el8.6.0+20026+579726f4.2"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python39-scipy",
+        "ecosystem": "Red Hat:rhel_tus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python39-scipy"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:1.5.4-3.module+el8.4.0+9822+20bf1249"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python39-scipy-debuginfo",
+        "ecosystem": "Red Hat:rhel_tus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python39-scipy-debuginfo"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:1.5.4-3.module+el8.4.0+9822+20bf1249"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python39-setuptools",
+        "ecosystem": "Red Hat:rhel_tus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python39-setuptools"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:50.3.2-6.module+el8.6.0+22162+859a69ec"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python39-setuptools-wheel",
+        "ecosystem": "Red Hat:rhel_tus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python39-setuptools-wheel"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:50.3.2-6.module+el8.6.0+22162+859a69ec"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python39-six",
+        "ecosystem": "Red Hat:rhel_tus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python39-six"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:1.15.0-3.module+el8.4.0+9822+20bf1249"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python39-test",
+        "ecosystem": "Red Hat:rhel_tus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python39-test"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:3.9.7-2.module+el8.6.0+20026+579726f4.2"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python39-tkinter",
+        "ecosystem": "Red Hat:rhel_tus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python39-tkinter"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:3.9.7-2.module+el8.6.0+20026+579726f4.2"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python39-toml",
+        "ecosystem": "Red Hat:rhel_tus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python39-toml"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:0.10.1-5.module+el8.4.0+9822+20bf1249"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python39-urllib3",
+        "ecosystem": "Red Hat:rhel_tus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python39-urllib3"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:1.25.10-4.module+el8.5.0+11712+ea2d2be1"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python39-wheel",
+        "ecosystem": "Red Hat:rhel_tus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python39-wheel"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1:0.35.1-4.module+el8.5.0+12204+54860423"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python39-wheel-wheel",
+        "ecosystem": "Red Hat:rhel_tus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python39-wheel-wheel"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1:0.35.1-4.module+el8.5.0+12204+54860423"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python3x-pip",
+        "ecosystem": "Red Hat:rhel_tus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python3x-pip"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:20.2.4-7.module+el8.6.0+13003+6bb2c488"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python3x-setuptools",
+        "ecosystem": "Red Hat:rhel_tus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python3x-setuptools"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:50.3.2-6.module+el8.6.0+22162+859a69ec"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "python3x-six",
+        "ecosystem": "Red Hat:rhel_tus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/python3x-six"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:1.15.0-3.module+el8.4.0+9822+20bf1249"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "scipy",
+        "ecosystem": "Red Hat:rhel_tus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/scipy"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:1.5.4-3.module+el8.4.0+9822+20bf1249"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    },
+    {
+      "package": {
+        "name": "scipy-debugsource",
+        "ecosystem": "Red Hat:rhel_tus:8.6::appstream",
+        "purl": "pkg:rpm/redhat/scipy-debugsource"
+      },
+      "ranges": [
+        {
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "0:1.5.4-3.module+el8.4.0+9822+20bf1249"
+            }
+          ],
+          "type": "ECOSYSTEM"
+        }
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "ADVISORY",
+      "url": "https://access.redhat.com/errata/RHSA-2024:6220"
+    },
+    {
+      "type": "ARTICLE",
+      "url": "https://access.redhat.com/security/updates/classification/#important"
+    },
+    {
+      "type": "REPORT",
+      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=2297771"
+    },
+    {
+      "type": "ADVISORY",
+      "url": "https://security.access.redhat.com/data/csaf/v2/advisories/2024/rhsa-2024_6220.json"
+    },
+    {
+      "type": "REPORT",
+      "url": "https://access.redhat.com/security/cve/CVE-2024-6345"
+    },
+    {
+      "type": "ADVISORY",
+      "url": "https://www.cve.org/CVERecord?id=CVE-2024-6345"
+    },
+    {
+      "type": "ADVISORY",
+      "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-6345"
+    },
+    {
+      "type": "ARTICLE",
+      "url": "https://github.com/pypa/setuptools/commit/88807c7062788254f654ea8c03427adc859321f0"
+    },
+    {
+      "type": "ARTICLE",
+      "url": "https://huntr.com/bounties/d6362117-ad57-4e83-951f-b8141c6e7ca5"
+    }
+  ]
+}

--- a/tools/redhat/testdata/rhsa-2024_6220.json
+++ b/tools/redhat/testdata/rhsa-2024_6220.json
@@ -1,0 +1,6795 @@
+{
+  "document": {
+    "aggregate_severity": {
+      "namespace": "https://access.redhat.com/security/updates/classification/",
+      "text": "Important"
+    },
+    "category": "csaf_vex",
+    "csaf_version": "2.0",
+    "distribution": {
+      "text": "Copyright © Red Hat, Inc. All rights reserved.",
+      "tlp": {
+        "label": "WHITE",
+        "url": "https://www.first.org/tlp/"
+      }
+    },
+    "lang": "en",
+    "notes": [
+      {
+        "category": "summary",
+        "text": "An update for the python39:3.9 module is now available for Red Hat Enterprise Linux 8.6 Advanced Mission Critical Update Support, Red Hat Enterprise Linux 8.6 Update Services for SAP Solutions, and Red Hat Enterprise Linux 8.6 Telecommunications Update Service.\n\nRed Hat Product Security has rated this update as having a security impact of Important. A Common Vulnerability Scoring System (CVSS) base score, which gives a detailed severity rating, is available for each vulnerability from the CVE link(s) in the References section.",
+        "title": "Topic"
+      },
+      {
+        "category": "general",
+        "text": "Python is an interpreted, interactive, object-oriented programming language, which includes modules, classes, exceptions, very high level dynamic data types and dynamic typing. Python supports interfaces to many system calls and libraries, as well as to various windowing systems.\n\nSecurity Fix(es):\n\n* pypa/setuptools: Remote code execution via download functions in the package_index module in pypa/setuptools (CVE-2024-6345)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+        "title": "Details"
+      },
+      {
+        "category": "legal_disclaimer",
+        "text": "This content is licensed under the Creative Commons Attribution 4.0 International License (https://creativecommons.org/licenses/by/4.0/). If you distribute this content, or a modified version of it, you must provide attribution to Red Hat Inc. and provide a link to the original.",
+        "title": "Terms of Use"
+      }
+    ],
+    "publisher": {
+      "category": "vendor",
+      "contact_details": "https://access.redhat.com/security/team/contact/",
+      "issuing_authority": "Red Hat Product Security is responsible for vulnerability handling across all Red Hat offerings.",
+      "name": "Red Hat Product Security",
+      "namespace": "https://www.redhat.com"
+    },
+    "references": [
+      {
+        "category": "self",
+        "summary": "https://access.redhat.com/errata/RHSA-2024:6220",
+        "url": "https://access.redhat.com/errata/RHSA-2024:6220"
+      },
+      {
+        "category": "external",
+        "summary": "https://access.redhat.com/security/updates/classification/#important",
+        "url": "https://access.redhat.com/security/updates/classification/#important"
+      },
+      {
+        "category": "external",
+        "summary": "2297771",
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=2297771"
+      },
+      {
+        "category": "self",
+        "summary": "Canonical URL",
+        "url": "https://security.access.redhat.com/data/csaf/v2/advisories/2024/rhsa-2024_6220.json"
+      }
+    ],
+    "title": "Red Hat Security Advisory: python39:3.9 security update",
+    "tracking": {
+      "current_release_date": "2024-10-21T13:39:14+00:00",
+      "generator": {
+        "date": "2024-10-21T13:39:14+00:00",
+        "engine": {
+          "name": "Red Hat SDEngine",
+          "version": "4.0.1"
+        }
+      },
+      "id": "RHSA-2024:6220",
+      "initial_release_date": "2024-09-03T12:48:09+00:00",
+      "revision_history": [
+        {
+          "date": "2024-09-03T12:48:09+00:00",
+          "number": "1",
+          "summary": "Initial version"
+        },
+        {
+          "date": "2024-09-03T12:48:09+00:00",
+          "number": "2",
+          "summary": "Last updated version"
+        },
+        {
+          "date": "2024-10-21T13:39:14+00:00",
+          "number": "3",
+          "summary": "Last generated version"
+        }
+      ],
+      "status": "final",
+      "version": "3"
+    }
+  },
+  "product_tree": {
+    "branches": [
+      {
+        "branches": [
+          {
+            "branches": [
+              {
+                "category": "product_name",
+                "name": "Red Hat Enterprise Linux AppStream AUS (v.8.6)",
+                "product": {
+                  "name": "Red Hat Enterprise Linux AppStream AUS (v.8.6)",
+                  "product_id": "AppStream-8.6.0.Z.AUS",
+                  "product_identification_helper": {
+                    "cpe": "cpe:/a:redhat:rhel_aus:8.6::appstream"
+                  }
+                }
+              },
+              {
+                "category": "product_name",
+                "name": "Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+                "product": {
+                  "name": "Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+                  "product_id": "AppStream-8.6.0.Z.E4S",
+                  "product_identification_helper": {
+                    "cpe": "cpe:/a:redhat:rhel_e4s:8.6::appstream"
+                  }
+                }
+              },
+              {
+                "category": "product_name",
+                "name": "Red Hat Enterprise Linux AppStream TUS (v.8.6)",
+                "product": {
+                  "name": "Red Hat Enterprise Linux AppStream TUS (v.8.6)",
+                  "product_id": "AppStream-8.6.0.Z.TUS",
+                  "product_identification_helper": {
+                    "cpe": "cpe:/a:redhat:rhel_tus:8.6::appstream"
+                  }
+                }
+              }
+            ],
+            "category": "product_family",
+            "name": "Red Hat Enterprise Linux"
+          },
+          {
+            "branches": [
+              {
+                "category": "product_version",
+                "name": "python39:3.9:8060020240801142753:6a631399",
+                "product": {
+                  "name": "python39:3.9:8060020240801142753:6a631399",
+                  "product_id": "python39:3.9:8060020240801142753:6a631399",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpmmod/redhat/python39@3.9:8060020240801142753:6a631399"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python39-PyMySQL-0:0.10.1-2.module+el8.4.0+9822+20bf1249.noarch",
+                "product": {
+                  "name": "python39-PyMySQL-0:0.10.1-2.module+el8.4.0+9822+20bf1249.noarch",
+                  "product_id": "python39-PyMySQL-0:0.10.1-2.module+el8.4.0+9822+20bf1249.noarch",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python39-PyMySQL@0.10.1-2.module%2Bel8.4.0%2B9822%2B20bf1249?arch=noarch"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python39-chardet-0:3.0.4-19.module+el8.4.0+9822+20bf1249.noarch",
+                "product": {
+                  "name": "python39-chardet-0:3.0.4-19.module+el8.4.0+9822+20bf1249.noarch",
+                  "product_id": "python39-chardet-0:3.0.4-19.module+el8.4.0+9822+20bf1249.noarch",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python39-chardet@3.0.4-19.module%2Bel8.4.0%2B9822%2B20bf1249?arch=noarch"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python39-idna-0:2.10-3.module+el8.4.0+9822+20bf1249.noarch",
+                "product": {
+                  "name": "python39-idna-0:2.10-3.module+el8.4.0+9822+20bf1249.noarch",
+                  "product_id": "python39-idna-0:2.10-3.module+el8.4.0+9822+20bf1249.noarch",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python39-idna@2.10-3.module%2Bel8.4.0%2B9822%2B20bf1249?arch=noarch"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python39-numpy-doc-0:1.19.4-3.module+el8.5.0+12204+54860423.noarch",
+                "product": {
+                  "name": "python39-numpy-doc-0:1.19.4-3.module+el8.5.0+12204+54860423.noarch",
+                  "product_id": "python39-numpy-doc-0:1.19.4-3.module+el8.5.0+12204+54860423.noarch",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python39-numpy-doc@1.19.4-3.module%2Bel8.5.0%2B12204%2B54860423?arch=noarch"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python39-pip-0:20.2.4-7.module+el8.6.0+13003+6bb2c488.noarch",
+                "product": {
+                  "name": "python39-pip-0:20.2.4-7.module+el8.6.0+13003+6bb2c488.noarch",
+                  "product_id": "python39-pip-0:20.2.4-7.module+el8.6.0+13003+6bb2c488.noarch",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python39-pip@20.2.4-7.module%2Bel8.6.0%2B13003%2B6bb2c488?arch=noarch"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python39-pip-wheel-0:20.2.4-7.module+el8.6.0+13003+6bb2c488.noarch",
+                "product": {
+                  "name": "python39-pip-wheel-0:20.2.4-7.module+el8.6.0+13003+6bb2c488.noarch",
+                  "product_id": "python39-pip-wheel-0:20.2.4-7.module+el8.6.0+13003+6bb2c488.noarch",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python39-pip-wheel@20.2.4-7.module%2Bel8.6.0%2B13003%2B6bb2c488?arch=noarch"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python39-ply-0:3.11-10.module+el8.4.0+9822+20bf1249.noarch",
+                "product": {
+                  "name": "python39-ply-0:3.11-10.module+el8.4.0+9822+20bf1249.noarch",
+                  "product_id": "python39-ply-0:3.11-10.module+el8.4.0+9822+20bf1249.noarch",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python39-ply@3.11-10.module%2Bel8.4.0%2B9822%2B20bf1249?arch=noarch"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python39-pycparser-0:2.20-3.module+el8.4.0+9822+20bf1249.noarch",
+                "product": {
+                  "name": "python39-pycparser-0:2.20-3.module+el8.4.0+9822+20bf1249.noarch",
+                  "product_id": "python39-pycparser-0:2.20-3.module+el8.4.0+9822+20bf1249.noarch",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python39-pycparser@2.20-3.module%2Bel8.4.0%2B9822%2B20bf1249?arch=noarch"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python39-pysocks-0:1.7.1-4.module+el8.4.0+9822+20bf1249.noarch",
+                "product": {
+                  "name": "python39-pysocks-0:1.7.1-4.module+el8.4.0+9822+20bf1249.noarch",
+                  "product_id": "python39-pysocks-0:1.7.1-4.module+el8.4.0+9822+20bf1249.noarch",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python39-pysocks@1.7.1-4.module%2Bel8.4.0%2B9822%2B20bf1249?arch=noarch"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python39-requests-0:2.25.0-2.module+el8.4.0+9822+20bf1249.noarch",
+                "product": {
+                  "name": "python39-requests-0:2.25.0-2.module+el8.4.0+9822+20bf1249.noarch",
+                  "product_id": "python39-requests-0:2.25.0-2.module+el8.4.0+9822+20bf1249.noarch",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python39-requests@2.25.0-2.module%2Bel8.4.0%2B9822%2B20bf1249?arch=noarch"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python39-rpm-macros-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.noarch",
+                "product": {
+                  "name": "python39-rpm-macros-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.noarch",
+                  "product_id": "python39-rpm-macros-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.noarch",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python39-rpm-macros@3.9.7-2.module%2Bel8.6.0%2B20026%2B579726f4.2?arch=noarch"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python39-setuptools-0:50.3.2-6.module+el8.6.0+22162+859a69ec.noarch",
+                "product": {
+                  "name": "python39-setuptools-0:50.3.2-6.module+el8.6.0+22162+859a69ec.noarch",
+                  "product_id": "python39-setuptools-0:50.3.2-6.module+el8.6.0+22162+859a69ec.noarch",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python39-setuptools@50.3.2-6.module%2Bel8.6.0%2B22162%2B859a69ec?arch=noarch"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python39-setuptools-wheel-0:50.3.2-6.module+el8.6.0+22162+859a69ec.noarch",
+                "product": {
+                  "name": "python39-setuptools-wheel-0:50.3.2-6.module+el8.6.0+22162+859a69ec.noarch",
+                  "product_id": "python39-setuptools-wheel-0:50.3.2-6.module+el8.6.0+22162+859a69ec.noarch",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python39-setuptools-wheel@50.3.2-6.module%2Bel8.6.0%2B22162%2B859a69ec?arch=noarch"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python39-six-0:1.15.0-3.module+el8.4.0+9822+20bf1249.noarch",
+                "product": {
+                  "name": "python39-six-0:1.15.0-3.module+el8.4.0+9822+20bf1249.noarch",
+                  "product_id": "python39-six-0:1.15.0-3.module+el8.4.0+9822+20bf1249.noarch",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python39-six@1.15.0-3.module%2Bel8.4.0%2B9822%2B20bf1249?arch=noarch"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python39-toml-0:0.10.1-5.module+el8.4.0+9822+20bf1249.noarch",
+                "product": {
+                  "name": "python39-toml-0:0.10.1-5.module+el8.4.0+9822+20bf1249.noarch",
+                  "product_id": "python39-toml-0:0.10.1-5.module+el8.4.0+9822+20bf1249.noarch",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python39-toml@0.10.1-5.module%2Bel8.4.0%2B9822%2B20bf1249?arch=noarch"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python39-urllib3-0:1.25.10-4.module+el8.5.0+11712+ea2d2be1.noarch",
+                "product": {
+                  "name": "python39-urllib3-0:1.25.10-4.module+el8.5.0+11712+ea2d2be1.noarch",
+                  "product_id": "python39-urllib3-0:1.25.10-4.module+el8.5.0+11712+ea2d2be1.noarch",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python39-urllib3@1.25.10-4.module%2Bel8.5.0%2B11712%2Bea2d2be1?arch=noarch"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python39-wheel-1:0.35.1-4.module+el8.5.0+12204+54860423.noarch",
+                "product": {
+                  "name": "python39-wheel-1:0.35.1-4.module+el8.5.0+12204+54860423.noarch",
+                  "product_id": "python39-wheel-1:0.35.1-4.module+el8.5.0+12204+54860423.noarch",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python39-wheel@0.35.1-4.module%2Bel8.5.0%2B12204%2B54860423?arch=noarch&epoch=1"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python39-wheel-wheel-1:0.35.1-4.module+el8.5.0+12204+54860423.noarch",
+                "product": {
+                  "name": "python39-wheel-wheel-1:0.35.1-4.module+el8.5.0+12204+54860423.noarch",
+                  "product_id": "python39-wheel-wheel-1:0.35.1-4.module+el8.5.0+12204+54860423.noarch",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python39-wheel-wheel@0.35.1-4.module%2Bel8.5.0%2B12204%2B54860423?arch=noarch&epoch=1"
+                  }
+                }
+              }
+            ],
+            "category": "architecture",
+            "name": "noarch"
+          },
+          {
+            "branches": [
+              {
+                "category": "product_version",
+                "name": "PyYAML-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.src",
+                "product": {
+                  "name": "PyYAML-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.src",
+                  "product_id": "PyYAML-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.src",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/PyYAML@5.4.1-1.module%2Bel8.5.0%2B10613%2B59a13ec4?arch=src"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "mod_wsgi-0:4.7.1-4.module+el8.4.0+9822+20bf1249.src",
+                "product": {
+                  "name": "mod_wsgi-0:4.7.1-4.module+el8.4.0+9822+20bf1249.src",
+                  "product_id": "mod_wsgi-0:4.7.1-4.module+el8.4.0+9822+20bf1249.src",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/mod_wsgi@4.7.1-4.module%2Bel8.4.0%2B9822%2B20bf1249?arch=src"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "numpy-0:1.19.4-3.module+el8.5.0+12204+54860423.src",
+                "product": {
+                  "name": "numpy-0:1.19.4-3.module+el8.5.0+12204+54860423.src",
+                  "product_id": "numpy-0:1.19.4-3.module+el8.5.0+12204+54860423.src",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/numpy@1.19.4-3.module%2Bel8.5.0%2B12204%2B54860423?arch=src"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python-PyMySQL-0:0.10.1-2.module+el8.4.0+9822+20bf1249.src",
+                "product": {
+                  "name": "python-PyMySQL-0:0.10.1-2.module+el8.4.0+9822+20bf1249.src",
+                  "product_id": "python-PyMySQL-0:0.10.1-2.module+el8.4.0+9822+20bf1249.src",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python-PyMySQL@0.10.1-2.module%2Bel8.4.0%2B9822%2B20bf1249?arch=src"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python-cffi-0:1.14.3-2.module+el8.4.0+9822+20bf1249.src",
+                "product": {
+                  "name": "python-cffi-0:1.14.3-2.module+el8.4.0+9822+20bf1249.src",
+                  "product_id": "python-cffi-0:1.14.3-2.module+el8.4.0+9822+20bf1249.src",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python-cffi@1.14.3-2.module%2Bel8.4.0%2B9822%2B20bf1249?arch=src"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python-chardet-0:3.0.4-19.module+el8.4.0+9822+20bf1249.src",
+                "product": {
+                  "name": "python-chardet-0:3.0.4-19.module+el8.4.0+9822+20bf1249.src",
+                  "product_id": "python-chardet-0:3.0.4-19.module+el8.4.0+9822+20bf1249.src",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python-chardet@3.0.4-19.module%2Bel8.4.0%2B9822%2B20bf1249?arch=src"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python-cryptography-0:3.3.1-2.module+el8.4.0+9822+20bf1249.src",
+                "product": {
+                  "name": "python-cryptography-0:3.3.1-2.module+el8.4.0+9822+20bf1249.src",
+                  "product_id": "python-cryptography-0:3.3.1-2.module+el8.4.0+9822+20bf1249.src",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python-cryptography@3.3.1-2.module%2Bel8.4.0%2B9822%2B20bf1249?arch=src"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python-idna-0:2.10-3.module+el8.4.0+9822+20bf1249.src",
+                "product": {
+                  "name": "python-idna-0:2.10-3.module+el8.4.0+9822+20bf1249.src",
+                  "product_id": "python-idna-0:2.10-3.module+el8.4.0+9822+20bf1249.src",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python-idna@2.10-3.module%2Bel8.4.0%2B9822%2B20bf1249?arch=src"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python-lxml-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.src",
+                "product": {
+                  "name": "python-lxml-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.src",
+                  "product_id": "python-lxml-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.src",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python-lxml@4.6.5-1.module%2Bel8.6.0%2B13933%2B9cf0c87c?arch=src"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python-ply-0:3.11-10.module+el8.4.0+9822+20bf1249.src",
+                "product": {
+                  "name": "python-ply-0:3.11-10.module+el8.4.0+9822+20bf1249.src",
+                  "product_id": "python-ply-0:3.11-10.module+el8.4.0+9822+20bf1249.src",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python-ply@3.11-10.module%2Bel8.4.0%2B9822%2B20bf1249?arch=src"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python-psutil-0:5.8.0-4.module+el8.4.0+9822+20bf1249.src",
+                "product": {
+                  "name": "python-psutil-0:5.8.0-4.module+el8.4.0+9822+20bf1249.src",
+                  "product_id": "python-psutil-0:5.8.0-4.module+el8.4.0+9822+20bf1249.src",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python-psutil@5.8.0-4.module%2Bel8.4.0%2B9822%2B20bf1249?arch=src"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python-psycopg2-0:2.8.6-2.module+el8.4.0+9822+20bf1249.src",
+                "product": {
+                  "name": "python-psycopg2-0:2.8.6-2.module+el8.4.0+9822+20bf1249.src",
+                  "product_id": "python-psycopg2-0:2.8.6-2.module+el8.4.0+9822+20bf1249.src",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python-psycopg2@2.8.6-2.module%2Bel8.4.0%2B9822%2B20bf1249?arch=src"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python-pycparser-0:2.20-3.module+el8.4.0+9822+20bf1249.src",
+                "product": {
+                  "name": "python-pycparser-0:2.20-3.module+el8.4.0+9822+20bf1249.src",
+                  "product_id": "python-pycparser-0:2.20-3.module+el8.4.0+9822+20bf1249.src",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python-pycparser@2.20-3.module%2Bel8.4.0%2B9822%2B20bf1249?arch=src"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python-pysocks-0:1.7.1-4.module+el8.4.0+9822+20bf1249.src",
+                "product": {
+                  "name": "python-pysocks-0:1.7.1-4.module+el8.4.0+9822+20bf1249.src",
+                  "product_id": "python-pysocks-0:1.7.1-4.module+el8.4.0+9822+20bf1249.src",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python-pysocks@1.7.1-4.module%2Bel8.4.0%2B9822%2B20bf1249?arch=src"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python-requests-0:2.25.0-2.module+el8.4.0+9822+20bf1249.src",
+                "product": {
+                  "name": "python-requests-0:2.25.0-2.module+el8.4.0+9822+20bf1249.src",
+                  "product_id": "python-requests-0:2.25.0-2.module+el8.4.0+9822+20bf1249.src",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python-requests@2.25.0-2.module%2Bel8.4.0%2B9822%2B20bf1249?arch=src"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python-toml-0:0.10.1-5.module+el8.4.0+9822+20bf1249.src",
+                "product": {
+                  "name": "python-toml-0:0.10.1-5.module+el8.4.0+9822+20bf1249.src",
+                  "product_id": "python-toml-0:0.10.1-5.module+el8.4.0+9822+20bf1249.src",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python-toml@0.10.1-5.module%2Bel8.4.0%2B9822%2B20bf1249?arch=src"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python-urllib3-0:1.25.10-4.module+el8.5.0+11712+ea2d2be1.src",
+                "product": {
+                  "name": "python-urllib3-0:1.25.10-4.module+el8.5.0+11712+ea2d2be1.src",
+                  "product_id": "python-urllib3-0:1.25.10-4.module+el8.5.0+11712+ea2d2be1.src",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python-urllib3@1.25.10-4.module%2Bel8.5.0%2B11712%2Bea2d2be1?arch=src"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python-wheel-1:0.35.1-4.module+el8.5.0+12204+54860423.src",
+                "product": {
+                  "name": "python-wheel-1:0.35.1-4.module+el8.5.0+12204+54860423.src",
+                  "product_id": "python-wheel-1:0.35.1-4.module+el8.5.0+12204+54860423.src",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python-wheel@0.35.1-4.module%2Bel8.5.0%2B12204%2B54860423?arch=src&epoch=1"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python39-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.src",
+                "product": {
+                  "name": "python39-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.src",
+                  "product_id": "python39-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.src",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python39@3.9.7-2.module%2Bel8.6.0%2B20026%2B579726f4.2?arch=src"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python3x-pip-0:20.2.4-7.module+el8.6.0+13003+6bb2c488.src",
+                "product": {
+                  "name": "python3x-pip-0:20.2.4-7.module+el8.6.0+13003+6bb2c488.src",
+                  "product_id": "python3x-pip-0:20.2.4-7.module+el8.6.0+13003+6bb2c488.src",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python3x-pip@20.2.4-7.module%2Bel8.6.0%2B13003%2B6bb2c488?arch=src"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python3x-setuptools-0:50.3.2-6.module+el8.6.0+22162+859a69ec.src",
+                "product": {
+                  "name": "python3x-setuptools-0:50.3.2-6.module+el8.6.0+22162+859a69ec.src",
+                  "product_id": "python3x-setuptools-0:50.3.2-6.module+el8.6.0+22162+859a69ec.src",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python3x-setuptools@50.3.2-6.module%2Bel8.6.0%2B22162%2B859a69ec?arch=src"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python3x-six-0:1.15.0-3.module+el8.4.0+9822+20bf1249.src",
+                "product": {
+                  "name": "python3x-six-0:1.15.0-3.module+el8.4.0+9822+20bf1249.src",
+                  "product_id": "python3x-six-0:1.15.0-3.module+el8.4.0+9822+20bf1249.src",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python3x-six@1.15.0-3.module%2Bel8.4.0%2B9822%2B20bf1249?arch=src"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "scipy-0:1.5.4-3.module+el8.4.0+9822+20bf1249.src",
+                "product": {
+                  "name": "scipy-0:1.5.4-3.module+el8.4.0+9822+20bf1249.src",
+                  "product_id": "scipy-0:1.5.4-3.module+el8.4.0+9822+20bf1249.src",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/scipy@1.5.4-3.module%2Bel8.4.0%2B9822%2B20bf1249?arch=src"
+                  }
+                }
+              }
+            ],
+            "category": "architecture",
+            "name": "src"
+          },
+          {
+            "branches": [
+              {
+                "category": "product_version",
+                "name": "PyYAML-debugsource-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.x86_64",
+                "product": {
+                  "name": "PyYAML-debugsource-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.x86_64",
+                  "product_id": "PyYAML-debugsource-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/PyYAML-debugsource@5.4.1-1.module%2Bel8.5.0%2B10613%2B59a13ec4?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "numpy-debugsource-0:1.19.4-3.module+el8.5.0+12204+54860423.x86_64",
+                "product": {
+                  "name": "numpy-debugsource-0:1.19.4-3.module+el8.5.0+12204+54860423.x86_64",
+                  "product_id": "numpy-debugsource-0:1.19.4-3.module+el8.5.0+12204+54860423.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/numpy-debugsource@1.19.4-3.module%2Bel8.5.0%2B12204%2B54860423?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python-cffi-debugsource-0:1.14.3-2.module+el8.4.0+9822+20bf1249.x86_64",
+                "product": {
+                  "name": "python-cffi-debugsource-0:1.14.3-2.module+el8.4.0+9822+20bf1249.x86_64",
+                  "product_id": "python-cffi-debugsource-0:1.14.3-2.module+el8.4.0+9822+20bf1249.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python-cffi-debugsource@1.14.3-2.module%2Bel8.4.0%2B9822%2B20bf1249?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python-cryptography-debugsource-0:3.3.1-2.module+el8.4.0+9822+20bf1249.x86_64",
+                "product": {
+                  "name": "python-cryptography-debugsource-0:3.3.1-2.module+el8.4.0+9822+20bf1249.x86_64",
+                  "product_id": "python-cryptography-debugsource-0:3.3.1-2.module+el8.4.0+9822+20bf1249.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python-cryptography-debugsource@3.3.1-2.module%2Bel8.4.0%2B9822%2B20bf1249?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python-lxml-debugsource-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.x86_64",
+                "product": {
+                  "name": "python-lxml-debugsource-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.x86_64",
+                  "product_id": "python-lxml-debugsource-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python-lxml-debugsource@4.6.5-1.module%2Bel8.6.0%2B13933%2B9cf0c87c?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python-psutil-debugsource-0:5.8.0-4.module+el8.4.0+9822+20bf1249.x86_64",
+                "product": {
+                  "name": "python-psutil-debugsource-0:5.8.0-4.module+el8.4.0+9822+20bf1249.x86_64",
+                  "product_id": "python-psutil-debugsource-0:5.8.0-4.module+el8.4.0+9822+20bf1249.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python-psutil-debugsource@5.8.0-4.module%2Bel8.4.0%2B9822%2B20bf1249?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python-psycopg2-debugsource-0:2.8.6-2.module+el8.4.0+9822+20bf1249.x86_64",
+                "product": {
+                  "name": "python-psycopg2-debugsource-0:2.8.6-2.module+el8.4.0+9822+20bf1249.x86_64",
+                  "product_id": "python-psycopg2-debugsource-0:2.8.6-2.module+el8.4.0+9822+20bf1249.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python-psycopg2-debugsource@2.8.6-2.module%2Bel8.4.0%2B9822%2B20bf1249?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python39-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+                "product": {
+                  "name": "python39-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+                  "product_id": "python39-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python39@3.9.7-2.module%2Bel8.6.0%2B20026%2B579726f4.2?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python39-cffi-0:1.14.3-2.module+el8.4.0+9822+20bf1249.x86_64",
+                "product": {
+                  "name": "python39-cffi-0:1.14.3-2.module+el8.4.0+9822+20bf1249.x86_64",
+                  "product_id": "python39-cffi-0:1.14.3-2.module+el8.4.0+9822+20bf1249.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python39-cffi@1.14.3-2.module%2Bel8.4.0%2B9822%2B20bf1249?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python39-cffi-debuginfo-0:1.14.3-2.module+el8.4.0+9822+20bf1249.x86_64",
+                "product": {
+                  "name": "python39-cffi-debuginfo-0:1.14.3-2.module+el8.4.0+9822+20bf1249.x86_64",
+                  "product_id": "python39-cffi-debuginfo-0:1.14.3-2.module+el8.4.0+9822+20bf1249.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python39-cffi-debuginfo@1.14.3-2.module%2Bel8.4.0%2B9822%2B20bf1249?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python39-cryptography-0:3.3.1-2.module+el8.4.0+9822+20bf1249.x86_64",
+                "product": {
+                  "name": "python39-cryptography-0:3.3.1-2.module+el8.4.0+9822+20bf1249.x86_64",
+                  "product_id": "python39-cryptography-0:3.3.1-2.module+el8.4.0+9822+20bf1249.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python39-cryptography@3.3.1-2.module%2Bel8.4.0%2B9822%2B20bf1249?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python39-cryptography-debuginfo-0:3.3.1-2.module+el8.4.0+9822+20bf1249.x86_64",
+                "product": {
+                  "name": "python39-cryptography-debuginfo-0:3.3.1-2.module+el8.4.0+9822+20bf1249.x86_64",
+                  "product_id": "python39-cryptography-debuginfo-0:3.3.1-2.module+el8.4.0+9822+20bf1249.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python39-cryptography-debuginfo@3.3.1-2.module%2Bel8.4.0%2B9822%2B20bf1249?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python39-debuginfo-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+                "product": {
+                  "name": "python39-debuginfo-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+                  "product_id": "python39-debuginfo-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python39-debuginfo@3.9.7-2.module%2Bel8.6.0%2B20026%2B579726f4.2?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python39-debugsource-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+                "product": {
+                  "name": "python39-debugsource-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+                  "product_id": "python39-debugsource-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python39-debugsource@3.9.7-2.module%2Bel8.6.0%2B20026%2B579726f4.2?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python39-devel-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+                "product": {
+                  "name": "python39-devel-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+                  "product_id": "python39-devel-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python39-devel@3.9.7-2.module%2Bel8.6.0%2B20026%2B579726f4.2?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python39-idle-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+                "product": {
+                  "name": "python39-idle-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+                  "product_id": "python39-idle-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python39-idle@3.9.7-2.module%2Bel8.6.0%2B20026%2B579726f4.2?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python39-libs-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+                "product": {
+                  "name": "python39-libs-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+                  "product_id": "python39-libs-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python39-libs@3.9.7-2.module%2Bel8.6.0%2B20026%2B579726f4.2?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python39-lxml-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.x86_64",
+                "product": {
+                  "name": "python39-lxml-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.x86_64",
+                  "product_id": "python39-lxml-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python39-lxml@4.6.5-1.module%2Bel8.6.0%2B13933%2B9cf0c87c?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python39-lxml-debuginfo-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.x86_64",
+                "product": {
+                  "name": "python39-lxml-debuginfo-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.x86_64",
+                  "product_id": "python39-lxml-debuginfo-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python39-lxml-debuginfo@4.6.5-1.module%2Bel8.6.0%2B13933%2B9cf0c87c?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python39-mod_wsgi-0:4.7.1-4.module+el8.4.0+9822+20bf1249.x86_64",
+                "product": {
+                  "name": "python39-mod_wsgi-0:4.7.1-4.module+el8.4.0+9822+20bf1249.x86_64",
+                  "product_id": "python39-mod_wsgi-0:4.7.1-4.module+el8.4.0+9822+20bf1249.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python39-mod_wsgi@4.7.1-4.module%2Bel8.4.0%2B9822%2B20bf1249?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python39-numpy-0:1.19.4-3.module+el8.5.0+12204+54860423.x86_64",
+                "product": {
+                  "name": "python39-numpy-0:1.19.4-3.module+el8.5.0+12204+54860423.x86_64",
+                  "product_id": "python39-numpy-0:1.19.4-3.module+el8.5.0+12204+54860423.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python39-numpy@1.19.4-3.module%2Bel8.5.0%2B12204%2B54860423?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python39-numpy-debuginfo-0:1.19.4-3.module+el8.5.0+12204+54860423.x86_64",
+                "product": {
+                  "name": "python39-numpy-debuginfo-0:1.19.4-3.module+el8.5.0+12204+54860423.x86_64",
+                  "product_id": "python39-numpy-debuginfo-0:1.19.4-3.module+el8.5.0+12204+54860423.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python39-numpy-debuginfo@1.19.4-3.module%2Bel8.5.0%2B12204%2B54860423?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python39-numpy-f2py-0:1.19.4-3.module+el8.5.0+12204+54860423.x86_64",
+                "product": {
+                  "name": "python39-numpy-f2py-0:1.19.4-3.module+el8.5.0+12204+54860423.x86_64",
+                  "product_id": "python39-numpy-f2py-0:1.19.4-3.module+el8.5.0+12204+54860423.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python39-numpy-f2py@1.19.4-3.module%2Bel8.5.0%2B12204%2B54860423?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python39-psutil-0:5.8.0-4.module+el8.4.0+9822+20bf1249.x86_64",
+                "product": {
+                  "name": "python39-psutil-0:5.8.0-4.module+el8.4.0+9822+20bf1249.x86_64",
+                  "product_id": "python39-psutil-0:5.8.0-4.module+el8.4.0+9822+20bf1249.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python39-psutil@5.8.0-4.module%2Bel8.4.0%2B9822%2B20bf1249?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python39-psutil-debuginfo-0:5.8.0-4.module+el8.4.0+9822+20bf1249.x86_64",
+                "product": {
+                  "name": "python39-psutil-debuginfo-0:5.8.0-4.module+el8.4.0+9822+20bf1249.x86_64",
+                  "product_id": "python39-psutil-debuginfo-0:5.8.0-4.module+el8.4.0+9822+20bf1249.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python39-psutil-debuginfo@5.8.0-4.module%2Bel8.4.0%2B9822%2B20bf1249?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python39-psycopg2-0:2.8.6-2.module+el8.4.0+9822+20bf1249.x86_64",
+                "product": {
+                  "name": "python39-psycopg2-0:2.8.6-2.module+el8.4.0+9822+20bf1249.x86_64",
+                  "product_id": "python39-psycopg2-0:2.8.6-2.module+el8.4.0+9822+20bf1249.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python39-psycopg2@2.8.6-2.module%2Bel8.4.0%2B9822%2B20bf1249?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python39-psycopg2-debuginfo-0:2.8.6-2.module+el8.4.0+9822+20bf1249.x86_64",
+                "product": {
+                  "name": "python39-psycopg2-debuginfo-0:2.8.6-2.module+el8.4.0+9822+20bf1249.x86_64",
+                  "product_id": "python39-psycopg2-debuginfo-0:2.8.6-2.module+el8.4.0+9822+20bf1249.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python39-psycopg2-debuginfo@2.8.6-2.module%2Bel8.4.0%2B9822%2B20bf1249?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python39-psycopg2-doc-0:2.8.6-2.module+el8.4.0+9822+20bf1249.x86_64",
+                "product": {
+                  "name": "python39-psycopg2-doc-0:2.8.6-2.module+el8.4.0+9822+20bf1249.x86_64",
+                  "product_id": "python39-psycopg2-doc-0:2.8.6-2.module+el8.4.0+9822+20bf1249.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python39-psycopg2-doc@2.8.6-2.module%2Bel8.4.0%2B9822%2B20bf1249?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python39-psycopg2-tests-0:2.8.6-2.module+el8.4.0+9822+20bf1249.x86_64",
+                "product": {
+                  "name": "python39-psycopg2-tests-0:2.8.6-2.module+el8.4.0+9822+20bf1249.x86_64",
+                  "product_id": "python39-psycopg2-tests-0:2.8.6-2.module+el8.4.0+9822+20bf1249.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python39-psycopg2-tests@2.8.6-2.module%2Bel8.4.0%2B9822%2B20bf1249?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python39-pyyaml-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.x86_64",
+                "product": {
+                  "name": "python39-pyyaml-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.x86_64",
+                  "product_id": "python39-pyyaml-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python39-pyyaml@5.4.1-1.module%2Bel8.5.0%2B10613%2B59a13ec4?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python39-pyyaml-debuginfo-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.x86_64",
+                "product": {
+                  "name": "python39-pyyaml-debuginfo-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.x86_64",
+                  "product_id": "python39-pyyaml-debuginfo-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python39-pyyaml-debuginfo@5.4.1-1.module%2Bel8.5.0%2B10613%2B59a13ec4?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python39-scipy-0:1.5.4-3.module+el8.4.0+9822+20bf1249.x86_64",
+                "product": {
+                  "name": "python39-scipy-0:1.5.4-3.module+el8.4.0+9822+20bf1249.x86_64",
+                  "product_id": "python39-scipy-0:1.5.4-3.module+el8.4.0+9822+20bf1249.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python39-scipy@1.5.4-3.module%2Bel8.4.0%2B9822%2B20bf1249?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python39-scipy-debuginfo-0:1.5.4-3.module+el8.4.0+9822+20bf1249.x86_64",
+                "product": {
+                  "name": "python39-scipy-debuginfo-0:1.5.4-3.module+el8.4.0+9822+20bf1249.x86_64",
+                  "product_id": "python39-scipy-debuginfo-0:1.5.4-3.module+el8.4.0+9822+20bf1249.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python39-scipy-debuginfo@1.5.4-3.module%2Bel8.4.0%2B9822%2B20bf1249?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python39-test-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+                "product": {
+                  "name": "python39-test-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+                  "product_id": "python39-test-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python39-test@3.9.7-2.module%2Bel8.6.0%2B20026%2B579726f4.2?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python39-tkinter-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+                "product": {
+                  "name": "python39-tkinter-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+                  "product_id": "python39-tkinter-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python39-tkinter@3.9.7-2.module%2Bel8.6.0%2B20026%2B579726f4.2?arch=x86_64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "scipy-debugsource-0:1.5.4-3.module+el8.4.0+9822+20bf1249.x86_64",
+                "product": {
+                  "name": "scipy-debugsource-0:1.5.4-3.module+el8.4.0+9822+20bf1249.x86_64",
+                  "product_id": "scipy-debugsource-0:1.5.4-3.module+el8.4.0+9822+20bf1249.x86_64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/scipy-debugsource@1.5.4-3.module%2Bel8.4.0%2B9822%2B20bf1249?arch=x86_64"
+                  }
+                }
+              }
+            ],
+            "category": "architecture",
+            "name": "x86_64"
+          },
+          {
+            "branches": [
+              {
+                "category": "product_version",
+                "name": "PyYAML-debugsource-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.aarch64",
+                "product": {
+                  "name": "PyYAML-debugsource-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.aarch64",
+                  "product_id": "PyYAML-debugsource-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/PyYAML-debugsource@5.4.1-1.module%2Bel8.5.0%2B10613%2B59a13ec4?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "numpy-debugsource-0:1.19.4-3.module+el8.5.0+12204+54860423.aarch64",
+                "product": {
+                  "name": "numpy-debugsource-0:1.19.4-3.module+el8.5.0+12204+54860423.aarch64",
+                  "product_id": "numpy-debugsource-0:1.19.4-3.module+el8.5.0+12204+54860423.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/numpy-debugsource@1.19.4-3.module%2Bel8.5.0%2B12204%2B54860423?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python-cffi-debugsource-0:1.14.3-2.module+el8.4.0+9822+20bf1249.aarch64",
+                "product": {
+                  "name": "python-cffi-debugsource-0:1.14.3-2.module+el8.4.0+9822+20bf1249.aarch64",
+                  "product_id": "python-cffi-debugsource-0:1.14.3-2.module+el8.4.0+9822+20bf1249.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python-cffi-debugsource@1.14.3-2.module%2Bel8.4.0%2B9822%2B20bf1249?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python-cryptography-debugsource-0:3.3.1-2.module+el8.4.0+9822+20bf1249.aarch64",
+                "product": {
+                  "name": "python-cryptography-debugsource-0:3.3.1-2.module+el8.4.0+9822+20bf1249.aarch64",
+                  "product_id": "python-cryptography-debugsource-0:3.3.1-2.module+el8.4.0+9822+20bf1249.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python-cryptography-debugsource@3.3.1-2.module%2Bel8.4.0%2B9822%2B20bf1249?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python-lxml-debugsource-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.aarch64",
+                "product": {
+                  "name": "python-lxml-debugsource-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.aarch64",
+                  "product_id": "python-lxml-debugsource-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python-lxml-debugsource@4.6.5-1.module%2Bel8.6.0%2B13933%2B9cf0c87c?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python-psutil-debugsource-0:5.8.0-4.module+el8.4.0+9822+20bf1249.aarch64",
+                "product": {
+                  "name": "python-psutil-debugsource-0:5.8.0-4.module+el8.4.0+9822+20bf1249.aarch64",
+                  "product_id": "python-psutil-debugsource-0:5.8.0-4.module+el8.4.0+9822+20bf1249.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python-psutil-debugsource@5.8.0-4.module%2Bel8.4.0%2B9822%2B20bf1249?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python-psycopg2-debugsource-0:2.8.6-2.module+el8.4.0+9822+20bf1249.aarch64",
+                "product": {
+                  "name": "python-psycopg2-debugsource-0:2.8.6-2.module+el8.4.0+9822+20bf1249.aarch64",
+                  "product_id": "python-psycopg2-debugsource-0:2.8.6-2.module+el8.4.0+9822+20bf1249.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python-psycopg2-debugsource@2.8.6-2.module%2Bel8.4.0%2B9822%2B20bf1249?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python39-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.aarch64",
+                "product": {
+                  "name": "python39-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.aarch64",
+                  "product_id": "python39-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python39@3.9.7-2.module%2Bel8.6.0%2B20026%2B579726f4.2?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python39-cffi-0:1.14.3-2.module+el8.4.0+9822+20bf1249.aarch64",
+                "product": {
+                  "name": "python39-cffi-0:1.14.3-2.module+el8.4.0+9822+20bf1249.aarch64",
+                  "product_id": "python39-cffi-0:1.14.3-2.module+el8.4.0+9822+20bf1249.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python39-cffi@1.14.3-2.module%2Bel8.4.0%2B9822%2B20bf1249?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python39-cffi-debuginfo-0:1.14.3-2.module+el8.4.0+9822+20bf1249.aarch64",
+                "product": {
+                  "name": "python39-cffi-debuginfo-0:1.14.3-2.module+el8.4.0+9822+20bf1249.aarch64",
+                  "product_id": "python39-cffi-debuginfo-0:1.14.3-2.module+el8.4.0+9822+20bf1249.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python39-cffi-debuginfo@1.14.3-2.module%2Bel8.4.0%2B9822%2B20bf1249?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python39-cryptography-0:3.3.1-2.module+el8.4.0+9822+20bf1249.aarch64",
+                "product": {
+                  "name": "python39-cryptography-0:3.3.1-2.module+el8.4.0+9822+20bf1249.aarch64",
+                  "product_id": "python39-cryptography-0:3.3.1-2.module+el8.4.0+9822+20bf1249.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python39-cryptography@3.3.1-2.module%2Bel8.4.0%2B9822%2B20bf1249?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python39-cryptography-debuginfo-0:3.3.1-2.module+el8.4.0+9822+20bf1249.aarch64",
+                "product": {
+                  "name": "python39-cryptography-debuginfo-0:3.3.1-2.module+el8.4.0+9822+20bf1249.aarch64",
+                  "product_id": "python39-cryptography-debuginfo-0:3.3.1-2.module+el8.4.0+9822+20bf1249.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python39-cryptography-debuginfo@3.3.1-2.module%2Bel8.4.0%2B9822%2B20bf1249?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python39-debuginfo-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.aarch64",
+                "product": {
+                  "name": "python39-debuginfo-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.aarch64",
+                  "product_id": "python39-debuginfo-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python39-debuginfo@3.9.7-2.module%2Bel8.6.0%2B20026%2B579726f4.2?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python39-debugsource-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.aarch64",
+                "product": {
+                  "name": "python39-debugsource-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.aarch64",
+                  "product_id": "python39-debugsource-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python39-debugsource@3.9.7-2.module%2Bel8.6.0%2B20026%2B579726f4.2?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python39-devel-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.aarch64",
+                "product": {
+                  "name": "python39-devel-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.aarch64",
+                  "product_id": "python39-devel-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python39-devel@3.9.7-2.module%2Bel8.6.0%2B20026%2B579726f4.2?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python39-idle-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.aarch64",
+                "product": {
+                  "name": "python39-idle-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.aarch64",
+                  "product_id": "python39-idle-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python39-idle@3.9.7-2.module%2Bel8.6.0%2B20026%2B579726f4.2?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python39-libs-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.aarch64",
+                "product": {
+                  "name": "python39-libs-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.aarch64",
+                  "product_id": "python39-libs-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python39-libs@3.9.7-2.module%2Bel8.6.0%2B20026%2B579726f4.2?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python39-lxml-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.aarch64",
+                "product": {
+                  "name": "python39-lxml-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.aarch64",
+                  "product_id": "python39-lxml-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python39-lxml@4.6.5-1.module%2Bel8.6.0%2B13933%2B9cf0c87c?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python39-lxml-debuginfo-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.aarch64",
+                "product": {
+                  "name": "python39-lxml-debuginfo-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.aarch64",
+                  "product_id": "python39-lxml-debuginfo-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python39-lxml-debuginfo@4.6.5-1.module%2Bel8.6.0%2B13933%2B9cf0c87c?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python39-mod_wsgi-0:4.7.1-4.module+el8.4.0+9822+20bf1249.aarch64",
+                "product": {
+                  "name": "python39-mod_wsgi-0:4.7.1-4.module+el8.4.0+9822+20bf1249.aarch64",
+                  "product_id": "python39-mod_wsgi-0:4.7.1-4.module+el8.4.0+9822+20bf1249.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python39-mod_wsgi@4.7.1-4.module%2Bel8.4.0%2B9822%2B20bf1249?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python39-numpy-0:1.19.4-3.module+el8.5.0+12204+54860423.aarch64",
+                "product": {
+                  "name": "python39-numpy-0:1.19.4-3.module+el8.5.0+12204+54860423.aarch64",
+                  "product_id": "python39-numpy-0:1.19.4-3.module+el8.5.0+12204+54860423.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python39-numpy@1.19.4-3.module%2Bel8.5.0%2B12204%2B54860423?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python39-numpy-debuginfo-0:1.19.4-3.module+el8.5.0+12204+54860423.aarch64",
+                "product": {
+                  "name": "python39-numpy-debuginfo-0:1.19.4-3.module+el8.5.0+12204+54860423.aarch64",
+                  "product_id": "python39-numpy-debuginfo-0:1.19.4-3.module+el8.5.0+12204+54860423.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python39-numpy-debuginfo@1.19.4-3.module%2Bel8.5.0%2B12204%2B54860423?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python39-numpy-f2py-0:1.19.4-3.module+el8.5.0+12204+54860423.aarch64",
+                "product": {
+                  "name": "python39-numpy-f2py-0:1.19.4-3.module+el8.5.0+12204+54860423.aarch64",
+                  "product_id": "python39-numpy-f2py-0:1.19.4-3.module+el8.5.0+12204+54860423.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python39-numpy-f2py@1.19.4-3.module%2Bel8.5.0%2B12204%2B54860423?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python39-psutil-0:5.8.0-4.module+el8.4.0+9822+20bf1249.aarch64",
+                "product": {
+                  "name": "python39-psutil-0:5.8.0-4.module+el8.4.0+9822+20bf1249.aarch64",
+                  "product_id": "python39-psutil-0:5.8.0-4.module+el8.4.0+9822+20bf1249.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python39-psutil@5.8.0-4.module%2Bel8.4.0%2B9822%2B20bf1249?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python39-psutil-debuginfo-0:5.8.0-4.module+el8.4.0+9822+20bf1249.aarch64",
+                "product": {
+                  "name": "python39-psutil-debuginfo-0:5.8.0-4.module+el8.4.0+9822+20bf1249.aarch64",
+                  "product_id": "python39-psutil-debuginfo-0:5.8.0-4.module+el8.4.0+9822+20bf1249.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python39-psutil-debuginfo@5.8.0-4.module%2Bel8.4.0%2B9822%2B20bf1249?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python39-psycopg2-0:2.8.6-2.module+el8.4.0+9822+20bf1249.aarch64",
+                "product": {
+                  "name": "python39-psycopg2-0:2.8.6-2.module+el8.4.0+9822+20bf1249.aarch64",
+                  "product_id": "python39-psycopg2-0:2.8.6-2.module+el8.4.0+9822+20bf1249.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python39-psycopg2@2.8.6-2.module%2Bel8.4.0%2B9822%2B20bf1249?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python39-psycopg2-debuginfo-0:2.8.6-2.module+el8.4.0+9822+20bf1249.aarch64",
+                "product": {
+                  "name": "python39-psycopg2-debuginfo-0:2.8.6-2.module+el8.4.0+9822+20bf1249.aarch64",
+                  "product_id": "python39-psycopg2-debuginfo-0:2.8.6-2.module+el8.4.0+9822+20bf1249.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python39-psycopg2-debuginfo@2.8.6-2.module%2Bel8.4.0%2B9822%2B20bf1249?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python39-psycopg2-doc-0:2.8.6-2.module+el8.4.0+9822+20bf1249.aarch64",
+                "product": {
+                  "name": "python39-psycopg2-doc-0:2.8.6-2.module+el8.4.0+9822+20bf1249.aarch64",
+                  "product_id": "python39-psycopg2-doc-0:2.8.6-2.module+el8.4.0+9822+20bf1249.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python39-psycopg2-doc@2.8.6-2.module%2Bel8.4.0%2B9822%2B20bf1249?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python39-psycopg2-tests-0:2.8.6-2.module+el8.4.0+9822+20bf1249.aarch64",
+                "product": {
+                  "name": "python39-psycopg2-tests-0:2.8.6-2.module+el8.4.0+9822+20bf1249.aarch64",
+                  "product_id": "python39-psycopg2-tests-0:2.8.6-2.module+el8.4.0+9822+20bf1249.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python39-psycopg2-tests@2.8.6-2.module%2Bel8.4.0%2B9822%2B20bf1249?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python39-pyyaml-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.aarch64",
+                "product": {
+                  "name": "python39-pyyaml-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.aarch64",
+                  "product_id": "python39-pyyaml-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python39-pyyaml@5.4.1-1.module%2Bel8.5.0%2B10613%2B59a13ec4?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python39-pyyaml-debuginfo-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.aarch64",
+                "product": {
+                  "name": "python39-pyyaml-debuginfo-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.aarch64",
+                  "product_id": "python39-pyyaml-debuginfo-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python39-pyyaml-debuginfo@5.4.1-1.module%2Bel8.5.0%2B10613%2B59a13ec4?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python39-scipy-0:1.5.4-3.module+el8.4.0+9822+20bf1249.aarch64",
+                "product": {
+                  "name": "python39-scipy-0:1.5.4-3.module+el8.4.0+9822+20bf1249.aarch64",
+                  "product_id": "python39-scipy-0:1.5.4-3.module+el8.4.0+9822+20bf1249.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python39-scipy@1.5.4-3.module%2Bel8.4.0%2B9822%2B20bf1249?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python39-scipy-debuginfo-0:1.5.4-3.module+el8.4.0+9822+20bf1249.aarch64",
+                "product": {
+                  "name": "python39-scipy-debuginfo-0:1.5.4-3.module+el8.4.0+9822+20bf1249.aarch64",
+                  "product_id": "python39-scipy-debuginfo-0:1.5.4-3.module+el8.4.0+9822+20bf1249.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python39-scipy-debuginfo@1.5.4-3.module%2Bel8.4.0%2B9822%2B20bf1249?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python39-test-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.aarch64",
+                "product": {
+                  "name": "python39-test-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.aarch64",
+                  "product_id": "python39-test-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python39-test@3.9.7-2.module%2Bel8.6.0%2B20026%2B579726f4.2?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python39-tkinter-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.aarch64",
+                "product": {
+                  "name": "python39-tkinter-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.aarch64",
+                  "product_id": "python39-tkinter-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python39-tkinter@3.9.7-2.module%2Bel8.6.0%2B20026%2B579726f4.2?arch=aarch64"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "scipy-debugsource-0:1.5.4-3.module+el8.4.0+9822+20bf1249.aarch64",
+                "product": {
+                  "name": "scipy-debugsource-0:1.5.4-3.module+el8.4.0+9822+20bf1249.aarch64",
+                  "product_id": "scipy-debugsource-0:1.5.4-3.module+el8.4.0+9822+20bf1249.aarch64",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/scipy-debugsource@1.5.4-3.module%2Bel8.4.0%2B9822%2B20bf1249?arch=aarch64"
+                  }
+                }
+              }
+            ],
+            "category": "architecture",
+            "name": "aarch64"
+          },
+          {
+            "branches": [
+              {
+                "category": "product_version",
+                "name": "PyYAML-debugsource-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.ppc64le",
+                "product": {
+                  "name": "PyYAML-debugsource-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.ppc64le",
+                  "product_id": "PyYAML-debugsource-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/PyYAML-debugsource@5.4.1-1.module%2Bel8.5.0%2B10613%2B59a13ec4?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "numpy-debugsource-0:1.19.4-3.module+el8.5.0+12204+54860423.ppc64le",
+                "product": {
+                  "name": "numpy-debugsource-0:1.19.4-3.module+el8.5.0+12204+54860423.ppc64le",
+                  "product_id": "numpy-debugsource-0:1.19.4-3.module+el8.5.0+12204+54860423.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/numpy-debugsource@1.19.4-3.module%2Bel8.5.0%2B12204%2B54860423?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python-cffi-debugsource-0:1.14.3-2.module+el8.4.0+9822+20bf1249.ppc64le",
+                "product": {
+                  "name": "python-cffi-debugsource-0:1.14.3-2.module+el8.4.0+9822+20bf1249.ppc64le",
+                  "product_id": "python-cffi-debugsource-0:1.14.3-2.module+el8.4.0+9822+20bf1249.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python-cffi-debugsource@1.14.3-2.module%2Bel8.4.0%2B9822%2B20bf1249?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python-cryptography-debugsource-0:3.3.1-2.module+el8.4.0+9822+20bf1249.ppc64le",
+                "product": {
+                  "name": "python-cryptography-debugsource-0:3.3.1-2.module+el8.4.0+9822+20bf1249.ppc64le",
+                  "product_id": "python-cryptography-debugsource-0:3.3.1-2.module+el8.4.0+9822+20bf1249.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python-cryptography-debugsource@3.3.1-2.module%2Bel8.4.0%2B9822%2B20bf1249?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python-lxml-debugsource-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.ppc64le",
+                "product": {
+                  "name": "python-lxml-debugsource-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.ppc64le",
+                  "product_id": "python-lxml-debugsource-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python-lxml-debugsource@4.6.5-1.module%2Bel8.6.0%2B13933%2B9cf0c87c?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python-psutil-debugsource-0:5.8.0-4.module+el8.4.0+9822+20bf1249.ppc64le",
+                "product": {
+                  "name": "python-psutil-debugsource-0:5.8.0-4.module+el8.4.0+9822+20bf1249.ppc64le",
+                  "product_id": "python-psutil-debugsource-0:5.8.0-4.module+el8.4.0+9822+20bf1249.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python-psutil-debugsource@5.8.0-4.module%2Bel8.4.0%2B9822%2B20bf1249?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python-psycopg2-debugsource-0:2.8.6-2.module+el8.4.0+9822+20bf1249.ppc64le",
+                "product": {
+                  "name": "python-psycopg2-debugsource-0:2.8.6-2.module+el8.4.0+9822+20bf1249.ppc64le",
+                  "product_id": "python-psycopg2-debugsource-0:2.8.6-2.module+el8.4.0+9822+20bf1249.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python-psycopg2-debugsource@2.8.6-2.module%2Bel8.4.0%2B9822%2B20bf1249?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python39-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.ppc64le",
+                "product": {
+                  "name": "python39-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.ppc64le",
+                  "product_id": "python39-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python39@3.9.7-2.module%2Bel8.6.0%2B20026%2B579726f4.2?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python39-cffi-0:1.14.3-2.module+el8.4.0+9822+20bf1249.ppc64le",
+                "product": {
+                  "name": "python39-cffi-0:1.14.3-2.module+el8.4.0+9822+20bf1249.ppc64le",
+                  "product_id": "python39-cffi-0:1.14.3-2.module+el8.4.0+9822+20bf1249.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python39-cffi@1.14.3-2.module%2Bel8.4.0%2B9822%2B20bf1249?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python39-cffi-debuginfo-0:1.14.3-2.module+el8.4.0+9822+20bf1249.ppc64le",
+                "product": {
+                  "name": "python39-cffi-debuginfo-0:1.14.3-2.module+el8.4.0+9822+20bf1249.ppc64le",
+                  "product_id": "python39-cffi-debuginfo-0:1.14.3-2.module+el8.4.0+9822+20bf1249.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python39-cffi-debuginfo@1.14.3-2.module%2Bel8.4.0%2B9822%2B20bf1249?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python39-cryptography-0:3.3.1-2.module+el8.4.0+9822+20bf1249.ppc64le",
+                "product": {
+                  "name": "python39-cryptography-0:3.3.1-2.module+el8.4.0+9822+20bf1249.ppc64le",
+                  "product_id": "python39-cryptography-0:3.3.1-2.module+el8.4.0+9822+20bf1249.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python39-cryptography@3.3.1-2.module%2Bel8.4.0%2B9822%2B20bf1249?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python39-cryptography-debuginfo-0:3.3.1-2.module+el8.4.0+9822+20bf1249.ppc64le",
+                "product": {
+                  "name": "python39-cryptography-debuginfo-0:3.3.1-2.module+el8.4.0+9822+20bf1249.ppc64le",
+                  "product_id": "python39-cryptography-debuginfo-0:3.3.1-2.module+el8.4.0+9822+20bf1249.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python39-cryptography-debuginfo@3.3.1-2.module%2Bel8.4.0%2B9822%2B20bf1249?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python39-debuginfo-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.ppc64le",
+                "product": {
+                  "name": "python39-debuginfo-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.ppc64le",
+                  "product_id": "python39-debuginfo-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python39-debuginfo@3.9.7-2.module%2Bel8.6.0%2B20026%2B579726f4.2?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python39-debugsource-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.ppc64le",
+                "product": {
+                  "name": "python39-debugsource-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.ppc64le",
+                  "product_id": "python39-debugsource-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python39-debugsource@3.9.7-2.module%2Bel8.6.0%2B20026%2B579726f4.2?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python39-devel-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.ppc64le",
+                "product": {
+                  "name": "python39-devel-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.ppc64le",
+                  "product_id": "python39-devel-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python39-devel@3.9.7-2.module%2Bel8.6.0%2B20026%2B579726f4.2?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python39-idle-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.ppc64le",
+                "product": {
+                  "name": "python39-idle-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.ppc64le",
+                  "product_id": "python39-idle-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python39-idle@3.9.7-2.module%2Bel8.6.0%2B20026%2B579726f4.2?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python39-libs-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.ppc64le",
+                "product": {
+                  "name": "python39-libs-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.ppc64le",
+                  "product_id": "python39-libs-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python39-libs@3.9.7-2.module%2Bel8.6.0%2B20026%2B579726f4.2?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python39-lxml-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.ppc64le",
+                "product": {
+                  "name": "python39-lxml-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.ppc64le",
+                  "product_id": "python39-lxml-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python39-lxml@4.6.5-1.module%2Bel8.6.0%2B13933%2B9cf0c87c?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python39-lxml-debuginfo-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.ppc64le",
+                "product": {
+                  "name": "python39-lxml-debuginfo-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.ppc64le",
+                  "product_id": "python39-lxml-debuginfo-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python39-lxml-debuginfo@4.6.5-1.module%2Bel8.6.0%2B13933%2B9cf0c87c?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python39-mod_wsgi-0:4.7.1-4.module+el8.4.0+9822+20bf1249.ppc64le",
+                "product": {
+                  "name": "python39-mod_wsgi-0:4.7.1-4.module+el8.4.0+9822+20bf1249.ppc64le",
+                  "product_id": "python39-mod_wsgi-0:4.7.1-4.module+el8.4.0+9822+20bf1249.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python39-mod_wsgi@4.7.1-4.module%2Bel8.4.0%2B9822%2B20bf1249?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python39-numpy-0:1.19.4-3.module+el8.5.0+12204+54860423.ppc64le",
+                "product": {
+                  "name": "python39-numpy-0:1.19.4-3.module+el8.5.0+12204+54860423.ppc64le",
+                  "product_id": "python39-numpy-0:1.19.4-3.module+el8.5.0+12204+54860423.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python39-numpy@1.19.4-3.module%2Bel8.5.0%2B12204%2B54860423?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python39-numpy-debuginfo-0:1.19.4-3.module+el8.5.0+12204+54860423.ppc64le",
+                "product": {
+                  "name": "python39-numpy-debuginfo-0:1.19.4-3.module+el8.5.0+12204+54860423.ppc64le",
+                  "product_id": "python39-numpy-debuginfo-0:1.19.4-3.module+el8.5.0+12204+54860423.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python39-numpy-debuginfo@1.19.4-3.module%2Bel8.5.0%2B12204%2B54860423?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python39-numpy-f2py-0:1.19.4-3.module+el8.5.0+12204+54860423.ppc64le",
+                "product": {
+                  "name": "python39-numpy-f2py-0:1.19.4-3.module+el8.5.0+12204+54860423.ppc64le",
+                  "product_id": "python39-numpy-f2py-0:1.19.4-3.module+el8.5.0+12204+54860423.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python39-numpy-f2py@1.19.4-3.module%2Bel8.5.0%2B12204%2B54860423?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python39-psutil-0:5.8.0-4.module+el8.4.0+9822+20bf1249.ppc64le",
+                "product": {
+                  "name": "python39-psutil-0:5.8.0-4.module+el8.4.0+9822+20bf1249.ppc64le",
+                  "product_id": "python39-psutil-0:5.8.0-4.module+el8.4.0+9822+20bf1249.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python39-psutil@5.8.0-4.module%2Bel8.4.0%2B9822%2B20bf1249?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python39-psutil-debuginfo-0:5.8.0-4.module+el8.4.0+9822+20bf1249.ppc64le",
+                "product": {
+                  "name": "python39-psutil-debuginfo-0:5.8.0-4.module+el8.4.0+9822+20bf1249.ppc64le",
+                  "product_id": "python39-psutil-debuginfo-0:5.8.0-4.module+el8.4.0+9822+20bf1249.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python39-psutil-debuginfo@5.8.0-4.module%2Bel8.4.0%2B9822%2B20bf1249?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python39-psycopg2-0:2.8.6-2.module+el8.4.0+9822+20bf1249.ppc64le",
+                "product": {
+                  "name": "python39-psycopg2-0:2.8.6-2.module+el8.4.0+9822+20bf1249.ppc64le",
+                  "product_id": "python39-psycopg2-0:2.8.6-2.module+el8.4.0+9822+20bf1249.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python39-psycopg2@2.8.6-2.module%2Bel8.4.0%2B9822%2B20bf1249?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python39-psycopg2-debuginfo-0:2.8.6-2.module+el8.4.0+9822+20bf1249.ppc64le",
+                "product": {
+                  "name": "python39-psycopg2-debuginfo-0:2.8.6-2.module+el8.4.0+9822+20bf1249.ppc64le",
+                  "product_id": "python39-psycopg2-debuginfo-0:2.8.6-2.module+el8.4.0+9822+20bf1249.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python39-psycopg2-debuginfo@2.8.6-2.module%2Bel8.4.0%2B9822%2B20bf1249?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python39-psycopg2-doc-0:2.8.6-2.module+el8.4.0+9822+20bf1249.ppc64le",
+                "product": {
+                  "name": "python39-psycopg2-doc-0:2.8.6-2.module+el8.4.0+9822+20bf1249.ppc64le",
+                  "product_id": "python39-psycopg2-doc-0:2.8.6-2.module+el8.4.0+9822+20bf1249.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python39-psycopg2-doc@2.8.6-2.module%2Bel8.4.0%2B9822%2B20bf1249?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python39-psycopg2-tests-0:2.8.6-2.module+el8.4.0+9822+20bf1249.ppc64le",
+                "product": {
+                  "name": "python39-psycopg2-tests-0:2.8.6-2.module+el8.4.0+9822+20bf1249.ppc64le",
+                  "product_id": "python39-psycopg2-tests-0:2.8.6-2.module+el8.4.0+9822+20bf1249.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python39-psycopg2-tests@2.8.6-2.module%2Bel8.4.0%2B9822%2B20bf1249?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python39-pyyaml-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.ppc64le",
+                "product": {
+                  "name": "python39-pyyaml-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.ppc64le",
+                  "product_id": "python39-pyyaml-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python39-pyyaml@5.4.1-1.module%2Bel8.5.0%2B10613%2B59a13ec4?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python39-pyyaml-debuginfo-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.ppc64le",
+                "product": {
+                  "name": "python39-pyyaml-debuginfo-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.ppc64le",
+                  "product_id": "python39-pyyaml-debuginfo-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python39-pyyaml-debuginfo@5.4.1-1.module%2Bel8.5.0%2B10613%2B59a13ec4?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python39-scipy-0:1.5.4-3.module+el8.4.0+9822+20bf1249.ppc64le",
+                "product": {
+                  "name": "python39-scipy-0:1.5.4-3.module+el8.4.0+9822+20bf1249.ppc64le",
+                  "product_id": "python39-scipy-0:1.5.4-3.module+el8.4.0+9822+20bf1249.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python39-scipy@1.5.4-3.module%2Bel8.4.0%2B9822%2B20bf1249?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python39-scipy-debuginfo-0:1.5.4-3.module+el8.4.0+9822+20bf1249.ppc64le",
+                "product": {
+                  "name": "python39-scipy-debuginfo-0:1.5.4-3.module+el8.4.0+9822+20bf1249.ppc64le",
+                  "product_id": "python39-scipy-debuginfo-0:1.5.4-3.module+el8.4.0+9822+20bf1249.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python39-scipy-debuginfo@1.5.4-3.module%2Bel8.4.0%2B9822%2B20bf1249?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python39-test-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.ppc64le",
+                "product": {
+                  "name": "python39-test-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.ppc64le",
+                  "product_id": "python39-test-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python39-test@3.9.7-2.module%2Bel8.6.0%2B20026%2B579726f4.2?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python39-tkinter-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.ppc64le",
+                "product": {
+                  "name": "python39-tkinter-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.ppc64le",
+                  "product_id": "python39-tkinter-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python39-tkinter@3.9.7-2.module%2Bel8.6.0%2B20026%2B579726f4.2?arch=ppc64le"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "scipy-debugsource-0:1.5.4-3.module+el8.4.0+9822+20bf1249.ppc64le",
+                "product": {
+                  "name": "scipy-debugsource-0:1.5.4-3.module+el8.4.0+9822+20bf1249.ppc64le",
+                  "product_id": "scipy-debugsource-0:1.5.4-3.module+el8.4.0+9822+20bf1249.ppc64le",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/scipy-debugsource@1.5.4-3.module%2Bel8.4.0%2B9822%2B20bf1249?arch=ppc64le"
+                  }
+                }
+              }
+            ],
+            "category": "architecture",
+            "name": "ppc64le"
+          },
+          {
+            "branches": [
+              {
+                "category": "product_version",
+                "name": "PyYAML-debugsource-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.s390x",
+                "product": {
+                  "name": "PyYAML-debugsource-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.s390x",
+                  "product_id": "PyYAML-debugsource-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/PyYAML-debugsource@5.4.1-1.module%2Bel8.5.0%2B10613%2B59a13ec4?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "numpy-debugsource-0:1.19.4-3.module+el8.5.0+12204+54860423.s390x",
+                "product": {
+                  "name": "numpy-debugsource-0:1.19.4-3.module+el8.5.0+12204+54860423.s390x",
+                  "product_id": "numpy-debugsource-0:1.19.4-3.module+el8.5.0+12204+54860423.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/numpy-debugsource@1.19.4-3.module%2Bel8.5.0%2B12204%2B54860423?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python-cffi-debugsource-0:1.14.3-2.module+el8.4.0+9822+20bf1249.s390x",
+                "product": {
+                  "name": "python-cffi-debugsource-0:1.14.3-2.module+el8.4.0+9822+20bf1249.s390x",
+                  "product_id": "python-cffi-debugsource-0:1.14.3-2.module+el8.4.0+9822+20bf1249.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python-cffi-debugsource@1.14.3-2.module%2Bel8.4.0%2B9822%2B20bf1249?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python-cryptography-debugsource-0:3.3.1-2.module+el8.4.0+9822+20bf1249.s390x",
+                "product": {
+                  "name": "python-cryptography-debugsource-0:3.3.1-2.module+el8.4.0+9822+20bf1249.s390x",
+                  "product_id": "python-cryptography-debugsource-0:3.3.1-2.module+el8.4.0+9822+20bf1249.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python-cryptography-debugsource@3.3.1-2.module%2Bel8.4.0%2B9822%2B20bf1249?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python-lxml-debugsource-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.s390x",
+                "product": {
+                  "name": "python-lxml-debugsource-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.s390x",
+                  "product_id": "python-lxml-debugsource-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python-lxml-debugsource@4.6.5-1.module%2Bel8.6.0%2B13933%2B9cf0c87c?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python-psutil-debugsource-0:5.8.0-4.module+el8.4.0+9822+20bf1249.s390x",
+                "product": {
+                  "name": "python-psutil-debugsource-0:5.8.0-4.module+el8.4.0+9822+20bf1249.s390x",
+                  "product_id": "python-psutil-debugsource-0:5.8.0-4.module+el8.4.0+9822+20bf1249.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python-psutil-debugsource@5.8.0-4.module%2Bel8.4.0%2B9822%2B20bf1249?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python-psycopg2-debugsource-0:2.8.6-2.module+el8.4.0+9822+20bf1249.s390x",
+                "product": {
+                  "name": "python-psycopg2-debugsource-0:2.8.6-2.module+el8.4.0+9822+20bf1249.s390x",
+                  "product_id": "python-psycopg2-debugsource-0:2.8.6-2.module+el8.4.0+9822+20bf1249.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python-psycopg2-debugsource@2.8.6-2.module%2Bel8.4.0%2B9822%2B20bf1249?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python39-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.s390x",
+                "product": {
+                  "name": "python39-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.s390x",
+                  "product_id": "python39-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python39@3.9.7-2.module%2Bel8.6.0%2B20026%2B579726f4.2?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python39-cffi-0:1.14.3-2.module+el8.4.0+9822+20bf1249.s390x",
+                "product": {
+                  "name": "python39-cffi-0:1.14.3-2.module+el8.4.0+9822+20bf1249.s390x",
+                  "product_id": "python39-cffi-0:1.14.3-2.module+el8.4.0+9822+20bf1249.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python39-cffi@1.14.3-2.module%2Bel8.4.0%2B9822%2B20bf1249?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python39-cffi-debuginfo-0:1.14.3-2.module+el8.4.0+9822+20bf1249.s390x",
+                "product": {
+                  "name": "python39-cffi-debuginfo-0:1.14.3-2.module+el8.4.0+9822+20bf1249.s390x",
+                  "product_id": "python39-cffi-debuginfo-0:1.14.3-2.module+el8.4.0+9822+20bf1249.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python39-cffi-debuginfo@1.14.3-2.module%2Bel8.4.0%2B9822%2B20bf1249?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python39-cryptography-0:3.3.1-2.module+el8.4.0+9822+20bf1249.s390x",
+                "product": {
+                  "name": "python39-cryptography-0:3.3.1-2.module+el8.4.0+9822+20bf1249.s390x",
+                  "product_id": "python39-cryptography-0:3.3.1-2.module+el8.4.0+9822+20bf1249.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python39-cryptography@3.3.1-2.module%2Bel8.4.0%2B9822%2B20bf1249?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python39-cryptography-debuginfo-0:3.3.1-2.module+el8.4.0+9822+20bf1249.s390x",
+                "product": {
+                  "name": "python39-cryptography-debuginfo-0:3.3.1-2.module+el8.4.0+9822+20bf1249.s390x",
+                  "product_id": "python39-cryptography-debuginfo-0:3.3.1-2.module+el8.4.0+9822+20bf1249.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python39-cryptography-debuginfo@3.3.1-2.module%2Bel8.4.0%2B9822%2B20bf1249?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python39-debuginfo-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.s390x",
+                "product": {
+                  "name": "python39-debuginfo-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.s390x",
+                  "product_id": "python39-debuginfo-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python39-debuginfo@3.9.7-2.module%2Bel8.6.0%2B20026%2B579726f4.2?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python39-debugsource-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.s390x",
+                "product": {
+                  "name": "python39-debugsource-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.s390x",
+                  "product_id": "python39-debugsource-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python39-debugsource@3.9.7-2.module%2Bel8.6.0%2B20026%2B579726f4.2?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python39-devel-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.s390x",
+                "product": {
+                  "name": "python39-devel-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.s390x",
+                  "product_id": "python39-devel-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python39-devel@3.9.7-2.module%2Bel8.6.0%2B20026%2B579726f4.2?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python39-idle-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.s390x",
+                "product": {
+                  "name": "python39-idle-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.s390x",
+                  "product_id": "python39-idle-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python39-idle@3.9.7-2.module%2Bel8.6.0%2B20026%2B579726f4.2?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python39-libs-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.s390x",
+                "product": {
+                  "name": "python39-libs-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.s390x",
+                  "product_id": "python39-libs-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python39-libs@3.9.7-2.module%2Bel8.6.0%2B20026%2B579726f4.2?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python39-lxml-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.s390x",
+                "product": {
+                  "name": "python39-lxml-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.s390x",
+                  "product_id": "python39-lxml-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python39-lxml@4.6.5-1.module%2Bel8.6.0%2B13933%2B9cf0c87c?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python39-lxml-debuginfo-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.s390x",
+                "product": {
+                  "name": "python39-lxml-debuginfo-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.s390x",
+                  "product_id": "python39-lxml-debuginfo-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python39-lxml-debuginfo@4.6.5-1.module%2Bel8.6.0%2B13933%2B9cf0c87c?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python39-mod_wsgi-0:4.7.1-4.module+el8.4.0+9822+20bf1249.s390x",
+                "product": {
+                  "name": "python39-mod_wsgi-0:4.7.1-4.module+el8.4.0+9822+20bf1249.s390x",
+                  "product_id": "python39-mod_wsgi-0:4.7.1-4.module+el8.4.0+9822+20bf1249.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python39-mod_wsgi@4.7.1-4.module%2Bel8.4.0%2B9822%2B20bf1249?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python39-numpy-0:1.19.4-3.module+el8.5.0+12204+54860423.s390x",
+                "product": {
+                  "name": "python39-numpy-0:1.19.4-3.module+el8.5.0+12204+54860423.s390x",
+                  "product_id": "python39-numpy-0:1.19.4-3.module+el8.5.0+12204+54860423.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python39-numpy@1.19.4-3.module%2Bel8.5.0%2B12204%2B54860423?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python39-numpy-debuginfo-0:1.19.4-3.module+el8.5.0+12204+54860423.s390x",
+                "product": {
+                  "name": "python39-numpy-debuginfo-0:1.19.4-3.module+el8.5.0+12204+54860423.s390x",
+                  "product_id": "python39-numpy-debuginfo-0:1.19.4-3.module+el8.5.0+12204+54860423.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python39-numpy-debuginfo@1.19.4-3.module%2Bel8.5.0%2B12204%2B54860423?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python39-numpy-f2py-0:1.19.4-3.module+el8.5.0+12204+54860423.s390x",
+                "product": {
+                  "name": "python39-numpy-f2py-0:1.19.4-3.module+el8.5.0+12204+54860423.s390x",
+                  "product_id": "python39-numpy-f2py-0:1.19.4-3.module+el8.5.0+12204+54860423.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python39-numpy-f2py@1.19.4-3.module%2Bel8.5.0%2B12204%2B54860423?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python39-psutil-0:5.8.0-4.module+el8.4.0+9822+20bf1249.s390x",
+                "product": {
+                  "name": "python39-psutil-0:5.8.0-4.module+el8.4.0+9822+20bf1249.s390x",
+                  "product_id": "python39-psutil-0:5.8.0-4.module+el8.4.0+9822+20bf1249.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python39-psutil@5.8.0-4.module%2Bel8.4.0%2B9822%2B20bf1249?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python39-psutil-debuginfo-0:5.8.0-4.module+el8.4.0+9822+20bf1249.s390x",
+                "product": {
+                  "name": "python39-psutil-debuginfo-0:5.8.0-4.module+el8.4.0+9822+20bf1249.s390x",
+                  "product_id": "python39-psutil-debuginfo-0:5.8.0-4.module+el8.4.0+9822+20bf1249.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python39-psutil-debuginfo@5.8.0-4.module%2Bel8.4.0%2B9822%2B20bf1249?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python39-psycopg2-0:2.8.6-2.module+el8.4.0+9822+20bf1249.s390x",
+                "product": {
+                  "name": "python39-psycopg2-0:2.8.6-2.module+el8.4.0+9822+20bf1249.s390x",
+                  "product_id": "python39-psycopg2-0:2.8.6-2.module+el8.4.0+9822+20bf1249.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python39-psycopg2@2.8.6-2.module%2Bel8.4.0%2B9822%2B20bf1249?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python39-psycopg2-debuginfo-0:2.8.6-2.module+el8.4.0+9822+20bf1249.s390x",
+                "product": {
+                  "name": "python39-psycopg2-debuginfo-0:2.8.6-2.module+el8.4.0+9822+20bf1249.s390x",
+                  "product_id": "python39-psycopg2-debuginfo-0:2.8.6-2.module+el8.4.0+9822+20bf1249.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python39-psycopg2-debuginfo@2.8.6-2.module%2Bel8.4.0%2B9822%2B20bf1249?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python39-psycopg2-doc-0:2.8.6-2.module+el8.4.0+9822+20bf1249.s390x",
+                "product": {
+                  "name": "python39-psycopg2-doc-0:2.8.6-2.module+el8.4.0+9822+20bf1249.s390x",
+                  "product_id": "python39-psycopg2-doc-0:2.8.6-2.module+el8.4.0+9822+20bf1249.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python39-psycopg2-doc@2.8.6-2.module%2Bel8.4.0%2B9822%2B20bf1249?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python39-psycopg2-tests-0:2.8.6-2.module+el8.4.0+9822+20bf1249.s390x",
+                "product": {
+                  "name": "python39-psycopg2-tests-0:2.8.6-2.module+el8.4.0+9822+20bf1249.s390x",
+                  "product_id": "python39-psycopg2-tests-0:2.8.6-2.module+el8.4.0+9822+20bf1249.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python39-psycopg2-tests@2.8.6-2.module%2Bel8.4.0%2B9822%2B20bf1249?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python39-pyyaml-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.s390x",
+                "product": {
+                  "name": "python39-pyyaml-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.s390x",
+                  "product_id": "python39-pyyaml-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python39-pyyaml@5.4.1-1.module%2Bel8.5.0%2B10613%2B59a13ec4?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python39-pyyaml-debuginfo-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.s390x",
+                "product": {
+                  "name": "python39-pyyaml-debuginfo-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.s390x",
+                  "product_id": "python39-pyyaml-debuginfo-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python39-pyyaml-debuginfo@5.4.1-1.module%2Bel8.5.0%2B10613%2B59a13ec4?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python39-scipy-0:1.5.4-3.module+el8.4.0+9822+20bf1249.s390x",
+                "product": {
+                  "name": "python39-scipy-0:1.5.4-3.module+el8.4.0+9822+20bf1249.s390x",
+                  "product_id": "python39-scipy-0:1.5.4-3.module+el8.4.0+9822+20bf1249.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python39-scipy@1.5.4-3.module%2Bel8.4.0%2B9822%2B20bf1249?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python39-scipy-debuginfo-0:1.5.4-3.module+el8.4.0+9822+20bf1249.s390x",
+                "product": {
+                  "name": "python39-scipy-debuginfo-0:1.5.4-3.module+el8.4.0+9822+20bf1249.s390x",
+                  "product_id": "python39-scipy-debuginfo-0:1.5.4-3.module+el8.4.0+9822+20bf1249.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python39-scipy-debuginfo@1.5.4-3.module%2Bel8.4.0%2B9822%2B20bf1249?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python39-test-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.s390x",
+                "product": {
+                  "name": "python39-test-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.s390x",
+                  "product_id": "python39-test-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python39-test@3.9.7-2.module%2Bel8.6.0%2B20026%2B579726f4.2?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "python39-tkinter-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.s390x",
+                "product": {
+                  "name": "python39-tkinter-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.s390x",
+                  "product_id": "python39-tkinter-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/python39-tkinter@3.9.7-2.module%2Bel8.6.0%2B20026%2B579726f4.2?arch=s390x"
+                  }
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "scipy-debugsource-0:1.5.4-3.module+el8.4.0+9822+20bf1249.s390x",
+                "product": {
+                  "name": "scipy-debugsource-0:1.5.4-3.module+el8.4.0+9822+20bf1249.s390x",
+                  "product_id": "scipy-debugsource-0:1.5.4-3.module+el8.4.0+9822+20bf1249.s390x",
+                  "product_identification_helper": {
+                    "purl": "pkg:rpm/redhat/scipy-debugsource@1.5.4-3.module%2Bel8.4.0%2B9822%2B20bf1249?arch=s390x"
+                  }
+                }
+              }
+            ],
+            "category": "architecture",
+            "name": "s390x"
+          }
+        ],
+        "category": "vendor",
+        "name": "Red Hat"
+      }
+    ],
+    "relationships": [
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream AUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399"
+        },
+        "product_reference": "python39:3.9:8060020240801142753:6a631399",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.AUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "PyYAML-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.src as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream AUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:PyYAML-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.src"
+        },
+        "product_reference": "PyYAML-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.src",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "PyYAML-debugsource-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.x86_64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream AUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:PyYAML-debugsource-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.x86_64"
+        },
+        "product_reference": "PyYAML-debugsource-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.x86_64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "mod_wsgi-0:4.7.1-4.module+el8.4.0+9822+20bf1249.src as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream AUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:mod_wsgi-0:4.7.1-4.module+el8.4.0+9822+20bf1249.src"
+        },
+        "product_reference": "mod_wsgi-0:4.7.1-4.module+el8.4.0+9822+20bf1249.src",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "numpy-0:1.19.4-3.module+el8.5.0+12204+54860423.src as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream AUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:numpy-0:1.19.4-3.module+el8.5.0+12204+54860423.src"
+        },
+        "product_reference": "numpy-0:1.19.4-3.module+el8.5.0+12204+54860423.src",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "numpy-debugsource-0:1.19.4-3.module+el8.5.0+12204+54860423.x86_64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream AUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:numpy-debugsource-0:1.19.4-3.module+el8.5.0+12204+54860423.x86_64"
+        },
+        "product_reference": "numpy-debugsource-0:1.19.4-3.module+el8.5.0+12204+54860423.x86_64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python-PyMySQL-0:0.10.1-2.module+el8.4.0+9822+20bf1249.src as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream AUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python-PyMySQL-0:0.10.1-2.module+el8.4.0+9822+20bf1249.src"
+        },
+        "product_reference": "python-PyMySQL-0:0.10.1-2.module+el8.4.0+9822+20bf1249.src",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python-cffi-0:1.14.3-2.module+el8.4.0+9822+20bf1249.src as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream AUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python-cffi-0:1.14.3-2.module+el8.4.0+9822+20bf1249.src"
+        },
+        "product_reference": "python-cffi-0:1.14.3-2.module+el8.4.0+9822+20bf1249.src",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python-cffi-debugsource-0:1.14.3-2.module+el8.4.0+9822+20bf1249.x86_64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream AUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python-cffi-debugsource-0:1.14.3-2.module+el8.4.0+9822+20bf1249.x86_64"
+        },
+        "product_reference": "python-cffi-debugsource-0:1.14.3-2.module+el8.4.0+9822+20bf1249.x86_64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python-chardet-0:3.0.4-19.module+el8.4.0+9822+20bf1249.src as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream AUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python-chardet-0:3.0.4-19.module+el8.4.0+9822+20bf1249.src"
+        },
+        "product_reference": "python-chardet-0:3.0.4-19.module+el8.4.0+9822+20bf1249.src",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python-cryptography-0:3.3.1-2.module+el8.4.0+9822+20bf1249.src as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream AUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python-cryptography-0:3.3.1-2.module+el8.4.0+9822+20bf1249.src"
+        },
+        "product_reference": "python-cryptography-0:3.3.1-2.module+el8.4.0+9822+20bf1249.src",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python-cryptography-debugsource-0:3.3.1-2.module+el8.4.0+9822+20bf1249.x86_64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream AUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python-cryptography-debugsource-0:3.3.1-2.module+el8.4.0+9822+20bf1249.x86_64"
+        },
+        "product_reference": "python-cryptography-debugsource-0:3.3.1-2.module+el8.4.0+9822+20bf1249.x86_64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python-idna-0:2.10-3.module+el8.4.0+9822+20bf1249.src as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream AUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python-idna-0:2.10-3.module+el8.4.0+9822+20bf1249.src"
+        },
+        "product_reference": "python-idna-0:2.10-3.module+el8.4.0+9822+20bf1249.src",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python-lxml-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.src as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream AUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python-lxml-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.src"
+        },
+        "product_reference": "python-lxml-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.src",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python-lxml-debugsource-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.x86_64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream AUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python-lxml-debugsource-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.x86_64"
+        },
+        "product_reference": "python-lxml-debugsource-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.x86_64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python-ply-0:3.11-10.module+el8.4.0+9822+20bf1249.src as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream AUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python-ply-0:3.11-10.module+el8.4.0+9822+20bf1249.src"
+        },
+        "product_reference": "python-ply-0:3.11-10.module+el8.4.0+9822+20bf1249.src",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python-psutil-0:5.8.0-4.module+el8.4.0+9822+20bf1249.src as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream AUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python-psutil-0:5.8.0-4.module+el8.4.0+9822+20bf1249.src"
+        },
+        "product_reference": "python-psutil-0:5.8.0-4.module+el8.4.0+9822+20bf1249.src",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python-psutil-debugsource-0:5.8.0-4.module+el8.4.0+9822+20bf1249.x86_64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream AUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python-psutil-debugsource-0:5.8.0-4.module+el8.4.0+9822+20bf1249.x86_64"
+        },
+        "product_reference": "python-psutil-debugsource-0:5.8.0-4.module+el8.4.0+9822+20bf1249.x86_64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python-psycopg2-0:2.8.6-2.module+el8.4.0+9822+20bf1249.src as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream AUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python-psycopg2-0:2.8.6-2.module+el8.4.0+9822+20bf1249.src"
+        },
+        "product_reference": "python-psycopg2-0:2.8.6-2.module+el8.4.0+9822+20bf1249.src",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python-psycopg2-debugsource-0:2.8.6-2.module+el8.4.0+9822+20bf1249.x86_64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream AUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python-psycopg2-debugsource-0:2.8.6-2.module+el8.4.0+9822+20bf1249.x86_64"
+        },
+        "product_reference": "python-psycopg2-debugsource-0:2.8.6-2.module+el8.4.0+9822+20bf1249.x86_64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python-pycparser-0:2.20-3.module+el8.4.0+9822+20bf1249.src as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream AUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python-pycparser-0:2.20-3.module+el8.4.0+9822+20bf1249.src"
+        },
+        "product_reference": "python-pycparser-0:2.20-3.module+el8.4.0+9822+20bf1249.src",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python-pysocks-0:1.7.1-4.module+el8.4.0+9822+20bf1249.src as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream AUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python-pysocks-0:1.7.1-4.module+el8.4.0+9822+20bf1249.src"
+        },
+        "product_reference": "python-pysocks-0:1.7.1-4.module+el8.4.0+9822+20bf1249.src",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python-requests-0:2.25.0-2.module+el8.4.0+9822+20bf1249.src as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream AUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python-requests-0:2.25.0-2.module+el8.4.0+9822+20bf1249.src"
+        },
+        "product_reference": "python-requests-0:2.25.0-2.module+el8.4.0+9822+20bf1249.src",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python-toml-0:0.10.1-5.module+el8.4.0+9822+20bf1249.src as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream AUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python-toml-0:0.10.1-5.module+el8.4.0+9822+20bf1249.src"
+        },
+        "product_reference": "python-toml-0:0.10.1-5.module+el8.4.0+9822+20bf1249.src",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python-urllib3-0:1.25.10-4.module+el8.5.0+11712+ea2d2be1.src as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream AUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python-urllib3-0:1.25.10-4.module+el8.5.0+11712+ea2d2be1.src"
+        },
+        "product_reference": "python-urllib3-0:1.25.10-4.module+el8.5.0+11712+ea2d2be1.src",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python-wheel-1:0.35.1-4.module+el8.5.0+12204+54860423.src as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream AUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python-wheel-1:0.35.1-4.module+el8.5.0+12204+54860423.src"
+        },
+        "product_reference": "python-wheel-1:0.35.1-4.module+el8.5.0+12204+54860423.src",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.src as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream AUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.src"
+        },
+        "product_reference": "python39-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.src",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream AUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64"
+        },
+        "product_reference": "python39-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-PyMySQL-0:0.10.1-2.module+el8.4.0+9822+20bf1249.noarch as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream AUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-PyMySQL-0:0.10.1-2.module+el8.4.0+9822+20bf1249.noarch"
+        },
+        "product_reference": "python39-PyMySQL-0:0.10.1-2.module+el8.4.0+9822+20bf1249.noarch",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-cffi-0:1.14.3-2.module+el8.4.0+9822+20bf1249.x86_64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream AUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-cffi-0:1.14.3-2.module+el8.4.0+9822+20bf1249.x86_64"
+        },
+        "product_reference": "python39-cffi-0:1.14.3-2.module+el8.4.0+9822+20bf1249.x86_64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-cffi-debuginfo-0:1.14.3-2.module+el8.4.0+9822+20bf1249.x86_64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream AUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-cffi-debuginfo-0:1.14.3-2.module+el8.4.0+9822+20bf1249.x86_64"
+        },
+        "product_reference": "python39-cffi-debuginfo-0:1.14.3-2.module+el8.4.0+9822+20bf1249.x86_64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-chardet-0:3.0.4-19.module+el8.4.0+9822+20bf1249.noarch as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream AUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-chardet-0:3.0.4-19.module+el8.4.0+9822+20bf1249.noarch"
+        },
+        "product_reference": "python39-chardet-0:3.0.4-19.module+el8.4.0+9822+20bf1249.noarch",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-cryptography-0:3.3.1-2.module+el8.4.0+9822+20bf1249.x86_64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream AUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-cryptography-0:3.3.1-2.module+el8.4.0+9822+20bf1249.x86_64"
+        },
+        "product_reference": "python39-cryptography-0:3.3.1-2.module+el8.4.0+9822+20bf1249.x86_64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-cryptography-debuginfo-0:3.3.1-2.module+el8.4.0+9822+20bf1249.x86_64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream AUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-cryptography-debuginfo-0:3.3.1-2.module+el8.4.0+9822+20bf1249.x86_64"
+        },
+        "product_reference": "python39-cryptography-debuginfo-0:3.3.1-2.module+el8.4.0+9822+20bf1249.x86_64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-debuginfo-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream AUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-debuginfo-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64"
+        },
+        "product_reference": "python39-debuginfo-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-debugsource-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream AUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-debugsource-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64"
+        },
+        "product_reference": "python39-debugsource-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-devel-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream AUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-devel-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64"
+        },
+        "product_reference": "python39-devel-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-idle-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream AUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-idle-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64"
+        },
+        "product_reference": "python39-idle-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-idna-0:2.10-3.module+el8.4.0+9822+20bf1249.noarch as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream AUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-idna-0:2.10-3.module+el8.4.0+9822+20bf1249.noarch"
+        },
+        "product_reference": "python39-idna-0:2.10-3.module+el8.4.0+9822+20bf1249.noarch",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-libs-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream AUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-libs-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64"
+        },
+        "product_reference": "python39-libs-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-lxml-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.x86_64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream AUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-lxml-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.x86_64"
+        },
+        "product_reference": "python39-lxml-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.x86_64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-lxml-debuginfo-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.x86_64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream AUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-lxml-debuginfo-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.x86_64"
+        },
+        "product_reference": "python39-lxml-debuginfo-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.x86_64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-mod_wsgi-0:4.7.1-4.module+el8.4.0+9822+20bf1249.x86_64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream AUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-mod_wsgi-0:4.7.1-4.module+el8.4.0+9822+20bf1249.x86_64"
+        },
+        "product_reference": "python39-mod_wsgi-0:4.7.1-4.module+el8.4.0+9822+20bf1249.x86_64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-numpy-0:1.19.4-3.module+el8.5.0+12204+54860423.x86_64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream AUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-numpy-0:1.19.4-3.module+el8.5.0+12204+54860423.x86_64"
+        },
+        "product_reference": "python39-numpy-0:1.19.4-3.module+el8.5.0+12204+54860423.x86_64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-numpy-debuginfo-0:1.19.4-3.module+el8.5.0+12204+54860423.x86_64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream AUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-numpy-debuginfo-0:1.19.4-3.module+el8.5.0+12204+54860423.x86_64"
+        },
+        "product_reference": "python39-numpy-debuginfo-0:1.19.4-3.module+el8.5.0+12204+54860423.x86_64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-numpy-doc-0:1.19.4-3.module+el8.5.0+12204+54860423.noarch as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream AUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-numpy-doc-0:1.19.4-3.module+el8.5.0+12204+54860423.noarch"
+        },
+        "product_reference": "python39-numpy-doc-0:1.19.4-3.module+el8.5.0+12204+54860423.noarch",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-numpy-f2py-0:1.19.4-3.module+el8.5.0+12204+54860423.x86_64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream AUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-numpy-f2py-0:1.19.4-3.module+el8.5.0+12204+54860423.x86_64"
+        },
+        "product_reference": "python39-numpy-f2py-0:1.19.4-3.module+el8.5.0+12204+54860423.x86_64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-pip-0:20.2.4-7.module+el8.6.0+13003+6bb2c488.noarch as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream AUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-pip-0:20.2.4-7.module+el8.6.0+13003+6bb2c488.noarch"
+        },
+        "product_reference": "python39-pip-0:20.2.4-7.module+el8.6.0+13003+6bb2c488.noarch",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-pip-wheel-0:20.2.4-7.module+el8.6.0+13003+6bb2c488.noarch as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream AUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-pip-wheel-0:20.2.4-7.module+el8.6.0+13003+6bb2c488.noarch"
+        },
+        "product_reference": "python39-pip-wheel-0:20.2.4-7.module+el8.6.0+13003+6bb2c488.noarch",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-ply-0:3.11-10.module+el8.4.0+9822+20bf1249.noarch as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream AUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-ply-0:3.11-10.module+el8.4.0+9822+20bf1249.noarch"
+        },
+        "product_reference": "python39-ply-0:3.11-10.module+el8.4.0+9822+20bf1249.noarch",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-psutil-0:5.8.0-4.module+el8.4.0+9822+20bf1249.x86_64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream AUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-psutil-0:5.8.0-4.module+el8.4.0+9822+20bf1249.x86_64"
+        },
+        "product_reference": "python39-psutil-0:5.8.0-4.module+el8.4.0+9822+20bf1249.x86_64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-psutil-debuginfo-0:5.8.0-4.module+el8.4.0+9822+20bf1249.x86_64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream AUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-psutil-debuginfo-0:5.8.0-4.module+el8.4.0+9822+20bf1249.x86_64"
+        },
+        "product_reference": "python39-psutil-debuginfo-0:5.8.0-4.module+el8.4.0+9822+20bf1249.x86_64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-psycopg2-0:2.8.6-2.module+el8.4.0+9822+20bf1249.x86_64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream AUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-psycopg2-0:2.8.6-2.module+el8.4.0+9822+20bf1249.x86_64"
+        },
+        "product_reference": "python39-psycopg2-0:2.8.6-2.module+el8.4.0+9822+20bf1249.x86_64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-psycopg2-debuginfo-0:2.8.6-2.module+el8.4.0+9822+20bf1249.x86_64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream AUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-psycopg2-debuginfo-0:2.8.6-2.module+el8.4.0+9822+20bf1249.x86_64"
+        },
+        "product_reference": "python39-psycopg2-debuginfo-0:2.8.6-2.module+el8.4.0+9822+20bf1249.x86_64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-psycopg2-doc-0:2.8.6-2.module+el8.4.0+9822+20bf1249.x86_64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream AUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-psycopg2-doc-0:2.8.6-2.module+el8.4.0+9822+20bf1249.x86_64"
+        },
+        "product_reference": "python39-psycopg2-doc-0:2.8.6-2.module+el8.4.0+9822+20bf1249.x86_64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-psycopg2-tests-0:2.8.6-2.module+el8.4.0+9822+20bf1249.x86_64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream AUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-psycopg2-tests-0:2.8.6-2.module+el8.4.0+9822+20bf1249.x86_64"
+        },
+        "product_reference": "python39-psycopg2-tests-0:2.8.6-2.module+el8.4.0+9822+20bf1249.x86_64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-pycparser-0:2.20-3.module+el8.4.0+9822+20bf1249.noarch as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream AUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-pycparser-0:2.20-3.module+el8.4.0+9822+20bf1249.noarch"
+        },
+        "product_reference": "python39-pycparser-0:2.20-3.module+el8.4.0+9822+20bf1249.noarch",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-pysocks-0:1.7.1-4.module+el8.4.0+9822+20bf1249.noarch as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream AUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-pysocks-0:1.7.1-4.module+el8.4.0+9822+20bf1249.noarch"
+        },
+        "product_reference": "python39-pysocks-0:1.7.1-4.module+el8.4.0+9822+20bf1249.noarch",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-pyyaml-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.x86_64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream AUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-pyyaml-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.x86_64"
+        },
+        "product_reference": "python39-pyyaml-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.x86_64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-pyyaml-debuginfo-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.x86_64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream AUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-pyyaml-debuginfo-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.x86_64"
+        },
+        "product_reference": "python39-pyyaml-debuginfo-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.x86_64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-requests-0:2.25.0-2.module+el8.4.0+9822+20bf1249.noarch as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream AUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-requests-0:2.25.0-2.module+el8.4.0+9822+20bf1249.noarch"
+        },
+        "product_reference": "python39-requests-0:2.25.0-2.module+el8.4.0+9822+20bf1249.noarch",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-rpm-macros-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.noarch as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream AUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-rpm-macros-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.noarch"
+        },
+        "product_reference": "python39-rpm-macros-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.noarch",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-scipy-0:1.5.4-3.module+el8.4.0+9822+20bf1249.x86_64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream AUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-scipy-0:1.5.4-3.module+el8.4.0+9822+20bf1249.x86_64"
+        },
+        "product_reference": "python39-scipy-0:1.5.4-3.module+el8.4.0+9822+20bf1249.x86_64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-scipy-debuginfo-0:1.5.4-3.module+el8.4.0+9822+20bf1249.x86_64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream AUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-scipy-debuginfo-0:1.5.4-3.module+el8.4.0+9822+20bf1249.x86_64"
+        },
+        "product_reference": "python39-scipy-debuginfo-0:1.5.4-3.module+el8.4.0+9822+20bf1249.x86_64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-setuptools-0:50.3.2-6.module+el8.6.0+22162+859a69ec.noarch as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream AUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-setuptools-0:50.3.2-6.module+el8.6.0+22162+859a69ec.noarch"
+        },
+        "product_reference": "python39-setuptools-0:50.3.2-6.module+el8.6.0+22162+859a69ec.noarch",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-setuptools-wheel-0:50.3.2-6.module+el8.6.0+22162+859a69ec.noarch as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream AUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-setuptools-wheel-0:50.3.2-6.module+el8.6.0+22162+859a69ec.noarch"
+        },
+        "product_reference": "python39-setuptools-wheel-0:50.3.2-6.module+el8.6.0+22162+859a69ec.noarch",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-six-0:1.15.0-3.module+el8.4.0+9822+20bf1249.noarch as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream AUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-six-0:1.15.0-3.module+el8.4.0+9822+20bf1249.noarch"
+        },
+        "product_reference": "python39-six-0:1.15.0-3.module+el8.4.0+9822+20bf1249.noarch",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-test-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream AUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-test-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64"
+        },
+        "product_reference": "python39-test-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-tkinter-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream AUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-tkinter-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64"
+        },
+        "product_reference": "python39-tkinter-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-toml-0:0.10.1-5.module+el8.4.0+9822+20bf1249.noarch as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream AUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-toml-0:0.10.1-5.module+el8.4.0+9822+20bf1249.noarch"
+        },
+        "product_reference": "python39-toml-0:0.10.1-5.module+el8.4.0+9822+20bf1249.noarch",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-urllib3-0:1.25.10-4.module+el8.5.0+11712+ea2d2be1.noarch as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream AUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-urllib3-0:1.25.10-4.module+el8.5.0+11712+ea2d2be1.noarch"
+        },
+        "product_reference": "python39-urllib3-0:1.25.10-4.module+el8.5.0+11712+ea2d2be1.noarch",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-wheel-1:0.35.1-4.module+el8.5.0+12204+54860423.noarch as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream AUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-wheel-1:0.35.1-4.module+el8.5.0+12204+54860423.noarch"
+        },
+        "product_reference": "python39-wheel-1:0.35.1-4.module+el8.5.0+12204+54860423.noarch",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-wheel-wheel-1:0.35.1-4.module+el8.5.0+12204+54860423.noarch as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream AUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-wheel-wheel-1:0.35.1-4.module+el8.5.0+12204+54860423.noarch"
+        },
+        "product_reference": "python39-wheel-wheel-1:0.35.1-4.module+el8.5.0+12204+54860423.noarch",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python3x-pip-0:20.2.4-7.module+el8.6.0+13003+6bb2c488.src as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream AUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python3x-pip-0:20.2.4-7.module+el8.6.0+13003+6bb2c488.src"
+        },
+        "product_reference": "python3x-pip-0:20.2.4-7.module+el8.6.0+13003+6bb2c488.src",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python3x-setuptools-0:50.3.2-6.module+el8.6.0+22162+859a69ec.src as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream AUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python3x-setuptools-0:50.3.2-6.module+el8.6.0+22162+859a69ec.src"
+        },
+        "product_reference": "python3x-setuptools-0:50.3.2-6.module+el8.6.0+22162+859a69ec.src",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python3x-six-0:1.15.0-3.module+el8.4.0+9822+20bf1249.src as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream AUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python3x-six-0:1.15.0-3.module+el8.4.0+9822+20bf1249.src"
+        },
+        "product_reference": "python3x-six-0:1.15.0-3.module+el8.4.0+9822+20bf1249.src",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "scipy-0:1.5.4-3.module+el8.4.0+9822+20bf1249.src as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream AUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:scipy-0:1.5.4-3.module+el8.4.0+9822+20bf1249.src"
+        },
+        "product_reference": "scipy-0:1.5.4-3.module+el8.4.0+9822+20bf1249.src",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "scipy-debugsource-0:1.5.4-3.module+el8.4.0+9822+20bf1249.x86_64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream AUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:scipy-debugsource-0:1.5.4-3.module+el8.4.0+9822+20bf1249.x86_64"
+        },
+        "product_reference": "scipy-debugsource-0:1.5.4-3.module+el8.4.0+9822+20bf1249.x86_64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+        },
+        "product_reference": "python39:3.9:8060020240801142753:6a631399",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "PyYAML-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.src as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:PyYAML-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.src"
+        },
+        "product_reference": "PyYAML-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.src",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "PyYAML-debugsource-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.aarch64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:PyYAML-debugsource-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.aarch64"
+        },
+        "product_reference": "PyYAML-debugsource-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.aarch64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "PyYAML-debugsource-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.ppc64le as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:PyYAML-debugsource-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.ppc64le"
+        },
+        "product_reference": "PyYAML-debugsource-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.ppc64le",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "PyYAML-debugsource-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.s390x as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:PyYAML-debugsource-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.s390x"
+        },
+        "product_reference": "PyYAML-debugsource-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.s390x",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "PyYAML-debugsource-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.x86_64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:PyYAML-debugsource-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.x86_64"
+        },
+        "product_reference": "PyYAML-debugsource-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.x86_64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "mod_wsgi-0:4.7.1-4.module+el8.4.0+9822+20bf1249.src as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:mod_wsgi-0:4.7.1-4.module+el8.4.0+9822+20bf1249.src"
+        },
+        "product_reference": "mod_wsgi-0:4.7.1-4.module+el8.4.0+9822+20bf1249.src",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "numpy-0:1.19.4-3.module+el8.5.0+12204+54860423.src as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:numpy-0:1.19.4-3.module+el8.5.0+12204+54860423.src"
+        },
+        "product_reference": "numpy-0:1.19.4-3.module+el8.5.0+12204+54860423.src",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "numpy-debugsource-0:1.19.4-3.module+el8.5.0+12204+54860423.aarch64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:numpy-debugsource-0:1.19.4-3.module+el8.5.0+12204+54860423.aarch64"
+        },
+        "product_reference": "numpy-debugsource-0:1.19.4-3.module+el8.5.0+12204+54860423.aarch64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "numpy-debugsource-0:1.19.4-3.module+el8.5.0+12204+54860423.ppc64le as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:numpy-debugsource-0:1.19.4-3.module+el8.5.0+12204+54860423.ppc64le"
+        },
+        "product_reference": "numpy-debugsource-0:1.19.4-3.module+el8.5.0+12204+54860423.ppc64le",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "numpy-debugsource-0:1.19.4-3.module+el8.5.0+12204+54860423.s390x as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:numpy-debugsource-0:1.19.4-3.module+el8.5.0+12204+54860423.s390x"
+        },
+        "product_reference": "numpy-debugsource-0:1.19.4-3.module+el8.5.0+12204+54860423.s390x",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "numpy-debugsource-0:1.19.4-3.module+el8.5.0+12204+54860423.x86_64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:numpy-debugsource-0:1.19.4-3.module+el8.5.0+12204+54860423.x86_64"
+        },
+        "product_reference": "numpy-debugsource-0:1.19.4-3.module+el8.5.0+12204+54860423.x86_64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python-PyMySQL-0:0.10.1-2.module+el8.4.0+9822+20bf1249.src as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-PyMySQL-0:0.10.1-2.module+el8.4.0+9822+20bf1249.src"
+        },
+        "product_reference": "python-PyMySQL-0:0.10.1-2.module+el8.4.0+9822+20bf1249.src",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python-cffi-0:1.14.3-2.module+el8.4.0+9822+20bf1249.src as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-cffi-0:1.14.3-2.module+el8.4.0+9822+20bf1249.src"
+        },
+        "product_reference": "python-cffi-0:1.14.3-2.module+el8.4.0+9822+20bf1249.src",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python-cffi-debugsource-0:1.14.3-2.module+el8.4.0+9822+20bf1249.aarch64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-cffi-debugsource-0:1.14.3-2.module+el8.4.0+9822+20bf1249.aarch64"
+        },
+        "product_reference": "python-cffi-debugsource-0:1.14.3-2.module+el8.4.0+9822+20bf1249.aarch64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python-cffi-debugsource-0:1.14.3-2.module+el8.4.0+9822+20bf1249.ppc64le as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-cffi-debugsource-0:1.14.3-2.module+el8.4.0+9822+20bf1249.ppc64le"
+        },
+        "product_reference": "python-cffi-debugsource-0:1.14.3-2.module+el8.4.0+9822+20bf1249.ppc64le",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python-cffi-debugsource-0:1.14.3-2.module+el8.4.0+9822+20bf1249.s390x as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-cffi-debugsource-0:1.14.3-2.module+el8.4.0+9822+20bf1249.s390x"
+        },
+        "product_reference": "python-cffi-debugsource-0:1.14.3-2.module+el8.4.0+9822+20bf1249.s390x",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python-cffi-debugsource-0:1.14.3-2.module+el8.4.0+9822+20bf1249.x86_64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-cffi-debugsource-0:1.14.3-2.module+el8.4.0+9822+20bf1249.x86_64"
+        },
+        "product_reference": "python-cffi-debugsource-0:1.14.3-2.module+el8.4.0+9822+20bf1249.x86_64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python-chardet-0:3.0.4-19.module+el8.4.0+9822+20bf1249.src as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-chardet-0:3.0.4-19.module+el8.4.0+9822+20bf1249.src"
+        },
+        "product_reference": "python-chardet-0:3.0.4-19.module+el8.4.0+9822+20bf1249.src",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python-cryptography-0:3.3.1-2.module+el8.4.0+9822+20bf1249.src as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-cryptography-0:3.3.1-2.module+el8.4.0+9822+20bf1249.src"
+        },
+        "product_reference": "python-cryptography-0:3.3.1-2.module+el8.4.0+9822+20bf1249.src",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python-cryptography-debugsource-0:3.3.1-2.module+el8.4.0+9822+20bf1249.aarch64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-cryptography-debugsource-0:3.3.1-2.module+el8.4.0+9822+20bf1249.aarch64"
+        },
+        "product_reference": "python-cryptography-debugsource-0:3.3.1-2.module+el8.4.0+9822+20bf1249.aarch64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python-cryptography-debugsource-0:3.3.1-2.module+el8.4.0+9822+20bf1249.ppc64le as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-cryptography-debugsource-0:3.3.1-2.module+el8.4.0+9822+20bf1249.ppc64le"
+        },
+        "product_reference": "python-cryptography-debugsource-0:3.3.1-2.module+el8.4.0+9822+20bf1249.ppc64le",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python-cryptography-debugsource-0:3.3.1-2.module+el8.4.0+9822+20bf1249.s390x as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-cryptography-debugsource-0:3.3.1-2.module+el8.4.0+9822+20bf1249.s390x"
+        },
+        "product_reference": "python-cryptography-debugsource-0:3.3.1-2.module+el8.4.0+9822+20bf1249.s390x",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python-cryptography-debugsource-0:3.3.1-2.module+el8.4.0+9822+20bf1249.x86_64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-cryptography-debugsource-0:3.3.1-2.module+el8.4.0+9822+20bf1249.x86_64"
+        },
+        "product_reference": "python-cryptography-debugsource-0:3.3.1-2.module+el8.4.0+9822+20bf1249.x86_64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python-idna-0:2.10-3.module+el8.4.0+9822+20bf1249.src as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-idna-0:2.10-3.module+el8.4.0+9822+20bf1249.src"
+        },
+        "product_reference": "python-idna-0:2.10-3.module+el8.4.0+9822+20bf1249.src",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python-lxml-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.src as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-lxml-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.src"
+        },
+        "product_reference": "python-lxml-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.src",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python-lxml-debugsource-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.aarch64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-lxml-debugsource-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.aarch64"
+        },
+        "product_reference": "python-lxml-debugsource-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.aarch64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python-lxml-debugsource-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.ppc64le as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-lxml-debugsource-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.ppc64le"
+        },
+        "product_reference": "python-lxml-debugsource-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.ppc64le",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python-lxml-debugsource-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.s390x as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-lxml-debugsource-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.s390x"
+        },
+        "product_reference": "python-lxml-debugsource-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.s390x",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python-lxml-debugsource-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.x86_64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-lxml-debugsource-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.x86_64"
+        },
+        "product_reference": "python-lxml-debugsource-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.x86_64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python-ply-0:3.11-10.module+el8.4.0+9822+20bf1249.src as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-ply-0:3.11-10.module+el8.4.0+9822+20bf1249.src"
+        },
+        "product_reference": "python-ply-0:3.11-10.module+el8.4.0+9822+20bf1249.src",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python-psutil-0:5.8.0-4.module+el8.4.0+9822+20bf1249.src as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-psutil-0:5.8.0-4.module+el8.4.0+9822+20bf1249.src"
+        },
+        "product_reference": "python-psutil-0:5.8.0-4.module+el8.4.0+9822+20bf1249.src",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python-psutil-debugsource-0:5.8.0-4.module+el8.4.0+9822+20bf1249.aarch64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-psutil-debugsource-0:5.8.0-4.module+el8.4.0+9822+20bf1249.aarch64"
+        },
+        "product_reference": "python-psutil-debugsource-0:5.8.0-4.module+el8.4.0+9822+20bf1249.aarch64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python-psutil-debugsource-0:5.8.0-4.module+el8.4.0+9822+20bf1249.ppc64le as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-psutil-debugsource-0:5.8.0-4.module+el8.4.0+9822+20bf1249.ppc64le"
+        },
+        "product_reference": "python-psutil-debugsource-0:5.8.0-4.module+el8.4.0+9822+20bf1249.ppc64le",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python-psutil-debugsource-0:5.8.0-4.module+el8.4.0+9822+20bf1249.s390x as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-psutil-debugsource-0:5.8.0-4.module+el8.4.0+9822+20bf1249.s390x"
+        },
+        "product_reference": "python-psutil-debugsource-0:5.8.0-4.module+el8.4.0+9822+20bf1249.s390x",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python-psutil-debugsource-0:5.8.0-4.module+el8.4.0+9822+20bf1249.x86_64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-psutil-debugsource-0:5.8.0-4.module+el8.4.0+9822+20bf1249.x86_64"
+        },
+        "product_reference": "python-psutil-debugsource-0:5.8.0-4.module+el8.4.0+9822+20bf1249.x86_64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python-psycopg2-0:2.8.6-2.module+el8.4.0+9822+20bf1249.src as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-psycopg2-0:2.8.6-2.module+el8.4.0+9822+20bf1249.src"
+        },
+        "product_reference": "python-psycopg2-0:2.8.6-2.module+el8.4.0+9822+20bf1249.src",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python-psycopg2-debugsource-0:2.8.6-2.module+el8.4.0+9822+20bf1249.aarch64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-psycopg2-debugsource-0:2.8.6-2.module+el8.4.0+9822+20bf1249.aarch64"
+        },
+        "product_reference": "python-psycopg2-debugsource-0:2.8.6-2.module+el8.4.0+9822+20bf1249.aarch64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python-psycopg2-debugsource-0:2.8.6-2.module+el8.4.0+9822+20bf1249.ppc64le as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-psycopg2-debugsource-0:2.8.6-2.module+el8.4.0+9822+20bf1249.ppc64le"
+        },
+        "product_reference": "python-psycopg2-debugsource-0:2.8.6-2.module+el8.4.0+9822+20bf1249.ppc64le",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python-psycopg2-debugsource-0:2.8.6-2.module+el8.4.0+9822+20bf1249.s390x as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-psycopg2-debugsource-0:2.8.6-2.module+el8.4.0+9822+20bf1249.s390x"
+        },
+        "product_reference": "python-psycopg2-debugsource-0:2.8.6-2.module+el8.4.0+9822+20bf1249.s390x",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python-psycopg2-debugsource-0:2.8.6-2.module+el8.4.0+9822+20bf1249.x86_64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-psycopg2-debugsource-0:2.8.6-2.module+el8.4.0+9822+20bf1249.x86_64"
+        },
+        "product_reference": "python-psycopg2-debugsource-0:2.8.6-2.module+el8.4.0+9822+20bf1249.x86_64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python-pycparser-0:2.20-3.module+el8.4.0+9822+20bf1249.src as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-pycparser-0:2.20-3.module+el8.4.0+9822+20bf1249.src"
+        },
+        "product_reference": "python-pycparser-0:2.20-3.module+el8.4.0+9822+20bf1249.src",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python-pysocks-0:1.7.1-4.module+el8.4.0+9822+20bf1249.src as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-pysocks-0:1.7.1-4.module+el8.4.0+9822+20bf1249.src"
+        },
+        "product_reference": "python-pysocks-0:1.7.1-4.module+el8.4.0+9822+20bf1249.src",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python-requests-0:2.25.0-2.module+el8.4.0+9822+20bf1249.src as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-requests-0:2.25.0-2.module+el8.4.0+9822+20bf1249.src"
+        },
+        "product_reference": "python-requests-0:2.25.0-2.module+el8.4.0+9822+20bf1249.src",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python-toml-0:0.10.1-5.module+el8.4.0+9822+20bf1249.src as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-toml-0:0.10.1-5.module+el8.4.0+9822+20bf1249.src"
+        },
+        "product_reference": "python-toml-0:0.10.1-5.module+el8.4.0+9822+20bf1249.src",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python-urllib3-0:1.25.10-4.module+el8.5.0+11712+ea2d2be1.src as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-urllib3-0:1.25.10-4.module+el8.5.0+11712+ea2d2be1.src"
+        },
+        "product_reference": "python-urllib3-0:1.25.10-4.module+el8.5.0+11712+ea2d2be1.src",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python-wheel-1:0.35.1-4.module+el8.5.0+12204+54860423.src as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-wheel-1:0.35.1-4.module+el8.5.0+12204+54860423.src"
+        },
+        "product_reference": "python-wheel-1:0.35.1-4.module+el8.5.0+12204+54860423.src",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.aarch64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.aarch64"
+        },
+        "product_reference": "python39-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.aarch64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.ppc64le as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.ppc64le"
+        },
+        "product_reference": "python39-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.ppc64le",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.s390x as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.s390x"
+        },
+        "product_reference": "python39-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.s390x",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.src as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.src"
+        },
+        "product_reference": "python39-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.src",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64"
+        },
+        "product_reference": "python39-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-PyMySQL-0:0.10.1-2.module+el8.4.0+9822+20bf1249.noarch as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-PyMySQL-0:0.10.1-2.module+el8.4.0+9822+20bf1249.noarch"
+        },
+        "product_reference": "python39-PyMySQL-0:0.10.1-2.module+el8.4.0+9822+20bf1249.noarch",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-cffi-0:1.14.3-2.module+el8.4.0+9822+20bf1249.aarch64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-cffi-0:1.14.3-2.module+el8.4.0+9822+20bf1249.aarch64"
+        },
+        "product_reference": "python39-cffi-0:1.14.3-2.module+el8.4.0+9822+20bf1249.aarch64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-cffi-0:1.14.3-2.module+el8.4.0+9822+20bf1249.ppc64le as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-cffi-0:1.14.3-2.module+el8.4.0+9822+20bf1249.ppc64le"
+        },
+        "product_reference": "python39-cffi-0:1.14.3-2.module+el8.4.0+9822+20bf1249.ppc64le",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-cffi-0:1.14.3-2.module+el8.4.0+9822+20bf1249.s390x as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-cffi-0:1.14.3-2.module+el8.4.0+9822+20bf1249.s390x"
+        },
+        "product_reference": "python39-cffi-0:1.14.3-2.module+el8.4.0+9822+20bf1249.s390x",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-cffi-0:1.14.3-2.module+el8.4.0+9822+20bf1249.x86_64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-cffi-0:1.14.3-2.module+el8.4.0+9822+20bf1249.x86_64"
+        },
+        "product_reference": "python39-cffi-0:1.14.3-2.module+el8.4.0+9822+20bf1249.x86_64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-cffi-debuginfo-0:1.14.3-2.module+el8.4.0+9822+20bf1249.aarch64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-cffi-debuginfo-0:1.14.3-2.module+el8.4.0+9822+20bf1249.aarch64"
+        },
+        "product_reference": "python39-cffi-debuginfo-0:1.14.3-2.module+el8.4.0+9822+20bf1249.aarch64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-cffi-debuginfo-0:1.14.3-2.module+el8.4.0+9822+20bf1249.ppc64le as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-cffi-debuginfo-0:1.14.3-2.module+el8.4.0+9822+20bf1249.ppc64le"
+        },
+        "product_reference": "python39-cffi-debuginfo-0:1.14.3-2.module+el8.4.0+9822+20bf1249.ppc64le",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-cffi-debuginfo-0:1.14.3-2.module+el8.4.0+9822+20bf1249.s390x as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-cffi-debuginfo-0:1.14.3-2.module+el8.4.0+9822+20bf1249.s390x"
+        },
+        "product_reference": "python39-cffi-debuginfo-0:1.14.3-2.module+el8.4.0+9822+20bf1249.s390x",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-cffi-debuginfo-0:1.14.3-2.module+el8.4.0+9822+20bf1249.x86_64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-cffi-debuginfo-0:1.14.3-2.module+el8.4.0+9822+20bf1249.x86_64"
+        },
+        "product_reference": "python39-cffi-debuginfo-0:1.14.3-2.module+el8.4.0+9822+20bf1249.x86_64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-chardet-0:3.0.4-19.module+el8.4.0+9822+20bf1249.noarch as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-chardet-0:3.0.4-19.module+el8.4.0+9822+20bf1249.noarch"
+        },
+        "product_reference": "python39-chardet-0:3.0.4-19.module+el8.4.0+9822+20bf1249.noarch",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-cryptography-0:3.3.1-2.module+el8.4.0+9822+20bf1249.aarch64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-cryptography-0:3.3.1-2.module+el8.4.0+9822+20bf1249.aarch64"
+        },
+        "product_reference": "python39-cryptography-0:3.3.1-2.module+el8.4.0+9822+20bf1249.aarch64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-cryptography-0:3.3.1-2.module+el8.4.0+9822+20bf1249.ppc64le as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-cryptography-0:3.3.1-2.module+el8.4.0+9822+20bf1249.ppc64le"
+        },
+        "product_reference": "python39-cryptography-0:3.3.1-2.module+el8.4.0+9822+20bf1249.ppc64le",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-cryptography-0:3.3.1-2.module+el8.4.0+9822+20bf1249.s390x as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-cryptography-0:3.3.1-2.module+el8.4.0+9822+20bf1249.s390x"
+        },
+        "product_reference": "python39-cryptography-0:3.3.1-2.module+el8.4.0+9822+20bf1249.s390x",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-cryptography-0:3.3.1-2.module+el8.4.0+9822+20bf1249.x86_64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-cryptography-0:3.3.1-2.module+el8.4.0+9822+20bf1249.x86_64"
+        },
+        "product_reference": "python39-cryptography-0:3.3.1-2.module+el8.4.0+9822+20bf1249.x86_64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-cryptography-debuginfo-0:3.3.1-2.module+el8.4.0+9822+20bf1249.aarch64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-cryptography-debuginfo-0:3.3.1-2.module+el8.4.0+9822+20bf1249.aarch64"
+        },
+        "product_reference": "python39-cryptography-debuginfo-0:3.3.1-2.module+el8.4.0+9822+20bf1249.aarch64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-cryptography-debuginfo-0:3.3.1-2.module+el8.4.0+9822+20bf1249.ppc64le as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-cryptography-debuginfo-0:3.3.1-2.module+el8.4.0+9822+20bf1249.ppc64le"
+        },
+        "product_reference": "python39-cryptography-debuginfo-0:3.3.1-2.module+el8.4.0+9822+20bf1249.ppc64le",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-cryptography-debuginfo-0:3.3.1-2.module+el8.4.0+9822+20bf1249.s390x as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-cryptography-debuginfo-0:3.3.1-2.module+el8.4.0+9822+20bf1249.s390x"
+        },
+        "product_reference": "python39-cryptography-debuginfo-0:3.3.1-2.module+el8.4.0+9822+20bf1249.s390x",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-cryptography-debuginfo-0:3.3.1-2.module+el8.4.0+9822+20bf1249.x86_64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-cryptography-debuginfo-0:3.3.1-2.module+el8.4.0+9822+20bf1249.x86_64"
+        },
+        "product_reference": "python39-cryptography-debuginfo-0:3.3.1-2.module+el8.4.0+9822+20bf1249.x86_64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-debuginfo-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.aarch64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-debuginfo-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.aarch64"
+        },
+        "product_reference": "python39-debuginfo-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.aarch64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-debuginfo-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.ppc64le as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-debuginfo-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.ppc64le"
+        },
+        "product_reference": "python39-debuginfo-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.ppc64le",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-debuginfo-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.s390x as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-debuginfo-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.s390x"
+        },
+        "product_reference": "python39-debuginfo-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.s390x",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-debuginfo-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-debuginfo-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64"
+        },
+        "product_reference": "python39-debuginfo-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-debugsource-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.aarch64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-debugsource-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.aarch64"
+        },
+        "product_reference": "python39-debugsource-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.aarch64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-debugsource-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.ppc64le as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-debugsource-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.ppc64le"
+        },
+        "product_reference": "python39-debugsource-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.ppc64le",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-debugsource-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.s390x as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-debugsource-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.s390x"
+        },
+        "product_reference": "python39-debugsource-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.s390x",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-debugsource-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-debugsource-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64"
+        },
+        "product_reference": "python39-debugsource-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-devel-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.aarch64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-devel-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.aarch64"
+        },
+        "product_reference": "python39-devel-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.aarch64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-devel-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.ppc64le as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-devel-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.ppc64le"
+        },
+        "product_reference": "python39-devel-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.ppc64le",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-devel-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.s390x as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-devel-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.s390x"
+        },
+        "product_reference": "python39-devel-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.s390x",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-devel-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-devel-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64"
+        },
+        "product_reference": "python39-devel-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-idle-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.aarch64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-idle-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.aarch64"
+        },
+        "product_reference": "python39-idle-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.aarch64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-idle-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.ppc64le as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-idle-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.ppc64le"
+        },
+        "product_reference": "python39-idle-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.ppc64le",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-idle-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.s390x as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-idle-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.s390x"
+        },
+        "product_reference": "python39-idle-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.s390x",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-idle-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-idle-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64"
+        },
+        "product_reference": "python39-idle-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-idna-0:2.10-3.module+el8.4.0+9822+20bf1249.noarch as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-idna-0:2.10-3.module+el8.4.0+9822+20bf1249.noarch"
+        },
+        "product_reference": "python39-idna-0:2.10-3.module+el8.4.0+9822+20bf1249.noarch",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-libs-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.aarch64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-libs-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.aarch64"
+        },
+        "product_reference": "python39-libs-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.aarch64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-libs-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.ppc64le as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-libs-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.ppc64le"
+        },
+        "product_reference": "python39-libs-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.ppc64le",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-libs-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.s390x as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-libs-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.s390x"
+        },
+        "product_reference": "python39-libs-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.s390x",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-libs-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-libs-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64"
+        },
+        "product_reference": "python39-libs-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-lxml-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.aarch64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-lxml-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.aarch64"
+        },
+        "product_reference": "python39-lxml-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.aarch64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-lxml-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.ppc64le as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-lxml-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.ppc64le"
+        },
+        "product_reference": "python39-lxml-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.ppc64le",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-lxml-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.s390x as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-lxml-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.s390x"
+        },
+        "product_reference": "python39-lxml-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.s390x",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-lxml-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.x86_64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-lxml-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.x86_64"
+        },
+        "product_reference": "python39-lxml-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.x86_64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-lxml-debuginfo-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.aarch64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-lxml-debuginfo-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.aarch64"
+        },
+        "product_reference": "python39-lxml-debuginfo-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.aarch64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-lxml-debuginfo-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.ppc64le as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-lxml-debuginfo-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.ppc64le"
+        },
+        "product_reference": "python39-lxml-debuginfo-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.ppc64le",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-lxml-debuginfo-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.s390x as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-lxml-debuginfo-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.s390x"
+        },
+        "product_reference": "python39-lxml-debuginfo-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.s390x",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-lxml-debuginfo-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.x86_64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-lxml-debuginfo-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.x86_64"
+        },
+        "product_reference": "python39-lxml-debuginfo-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.x86_64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-mod_wsgi-0:4.7.1-4.module+el8.4.0+9822+20bf1249.aarch64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-mod_wsgi-0:4.7.1-4.module+el8.4.0+9822+20bf1249.aarch64"
+        },
+        "product_reference": "python39-mod_wsgi-0:4.7.1-4.module+el8.4.0+9822+20bf1249.aarch64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-mod_wsgi-0:4.7.1-4.module+el8.4.0+9822+20bf1249.ppc64le as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-mod_wsgi-0:4.7.1-4.module+el8.4.0+9822+20bf1249.ppc64le"
+        },
+        "product_reference": "python39-mod_wsgi-0:4.7.1-4.module+el8.4.0+9822+20bf1249.ppc64le",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-mod_wsgi-0:4.7.1-4.module+el8.4.0+9822+20bf1249.s390x as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-mod_wsgi-0:4.7.1-4.module+el8.4.0+9822+20bf1249.s390x"
+        },
+        "product_reference": "python39-mod_wsgi-0:4.7.1-4.module+el8.4.0+9822+20bf1249.s390x",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-mod_wsgi-0:4.7.1-4.module+el8.4.0+9822+20bf1249.x86_64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-mod_wsgi-0:4.7.1-4.module+el8.4.0+9822+20bf1249.x86_64"
+        },
+        "product_reference": "python39-mod_wsgi-0:4.7.1-4.module+el8.4.0+9822+20bf1249.x86_64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-numpy-0:1.19.4-3.module+el8.5.0+12204+54860423.aarch64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-numpy-0:1.19.4-3.module+el8.5.0+12204+54860423.aarch64"
+        },
+        "product_reference": "python39-numpy-0:1.19.4-3.module+el8.5.0+12204+54860423.aarch64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-numpy-0:1.19.4-3.module+el8.5.0+12204+54860423.ppc64le as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-numpy-0:1.19.4-3.module+el8.5.0+12204+54860423.ppc64le"
+        },
+        "product_reference": "python39-numpy-0:1.19.4-3.module+el8.5.0+12204+54860423.ppc64le",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-numpy-0:1.19.4-3.module+el8.5.0+12204+54860423.s390x as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-numpy-0:1.19.4-3.module+el8.5.0+12204+54860423.s390x"
+        },
+        "product_reference": "python39-numpy-0:1.19.4-3.module+el8.5.0+12204+54860423.s390x",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-numpy-0:1.19.4-3.module+el8.5.0+12204+54860423.x86_64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-numpy-0:1.19.4-3.module+el8.5.0+12204+54860423.x86_64"
+        },
+        "product_reference": "python39-numpy-0:1.19.4-3.module+el8.5.0+12204+54860423.x86_64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-numpy-debuginfo-0:1.19.4-3.module+el8.5.0+12204+54860423.aarch64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-numpy-debuginfo-0:1.19.4-3.module+el8.5.0+12204+54860423.aarch64"
+        },
+        "product_reference": "python39-numpy-debuginfo-0:1.19.4-3.module+el8.5.0+12204+54860423.aarch64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-numpy-debuginfo-0:1.19.4-3.module+el8.5.0+12204+54860423.ppc64le as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-numpy-debuginfo-0:1.19.4-3.module+el8.5.0+12204+54860423.ppc64le"
+        },
+        "product_reference": "python39-numpy-debuginfo-0:1.19.4-3.module+el8.5.0+12204+54860423.ppc64le",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-numpy-debuginfo-0:1.19.4-3.module+el8.5.0+12204+54860423.s390x as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-numpy-debuginfo-0:1.19.4-3.module+el8.5.0+12204+54860423.s390x"
+        },
+        "product_reference": "python39-numpy-debuginfo-0:1.19.4-3.module+el8.5.0+12204+54860423.s390x",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-numpy-debuginfo-0:1.19.4-3.module+el8.5.0+12204+54860423.x86_64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-numpy-debuginfo-0:1.19.4-3.module+el8.5.0+12204+54860423.x86_64"
+        },
+        "product_reference": "python39-numpy-debuginfo-0:1.19.4-3.module+el8.5.0+12204+54860423.x86_64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-numpy-doc-0:1.19.4-3.module+el8.5.0+12204+54860423.noarch as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-numpy-doc-0:1.19.4-3.module+el8.5.0+12204+54860423.noarch"
+        },
+        "product_reference": "python39-numpy-doc-0:1.19.4-3.module+el8.5.0+12204+54860423.noarch",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-numpy-f2py-0:1.19.4-3.module+el8.5.0+12204+54860423.aarch64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-numpy-f2py-0:1.19.4-3.module+el8.5.0+12204+54860423.aarch64"
+        },
+        "product_reference": "python39-numpy-f2py-0:1.19.4-3.module+el8.5.0+12204+54860423.aarch64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-numpy-f2py-0:1.19.4-3.module+el8.5.0+12204+54860423.ppc64le as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-numpy-f2py-0:1.19.4-3.module+el8.5.0+12204+54860423.ppc64le"
+        },
+        "product_reference": "python39-numpy-f2py-0:1.19.4-3.module+el8.5.0+12204+54860423.ppc64le",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-numpy-f2py-0:1.19.4-3.module+el8.5.0+12204+54860423.s390x as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-numpy-f2py-0:1.19.4-3.module+el8.5.0+12204+54860423.s390x"
+        },
+        "product_reference": "python39-numpy-f2py-0:1.19.4-3.module+el8.5.0+12204+54860423.s390x",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-numpy-f2py-0:1.19.4-3.module+el8.5.0+12204+54860423.x86_64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-numpy-f2py-0:1.19.4-3.module+el8.5.0+12204+54860423.x86_64"
+        },
+        "product_reference": "python39-numpy-f2py-0:1.19.4-3.module+el8.5.0+12204+54860423.x86_64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-pip-0:20.2.4-7.module+el8.6.0+13003+6bb2c488.noarch as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-pip-0:20.2.4-7.module+el8.6.0+13003+6bb2c488.noarch"
+        },
+        "product_reference": "python39-pip-0:20.2.4-7.module+el8.6.0+13003+6bb2c488.noarch",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-pip-wheel-0:20.2.4-7.module+el8.6.0+13003+6bb2c488.noarch as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-pip-wheel-0:20.2.4-7.module+el8.6.0+13003+6bb2c488.noarch"
+        },
+        "product_reference": "python39-pip-wheel-0:20.2.4-7.module+el8.6.0+13003+6bb2c488.noarch",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-ply-0:3.11-10.module+el8.4.0+9822+20bf1249.noarch as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-ply-0:3.11-10.module+el8.4.0+9822+20bf1249.noarch"
+        },
+        "product_reference": "python39-ply-0:3.11-10.module+el8.4.0+9822+20bf1249.noarch",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-psutil-0:5.8.0-4.module+el8.4.0+9822+20bf1249.aarch64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-psutil-0:5.8.0-4.module+el8.4.0+9822+20bf1249.aarch64"
+        },
+        "product_reference": "python39-psutil-0:5.8.0-4.module+el8.4.0+9822+20bf1249.aarch64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-psutil-0:5.8.0-4.module+el8.4.0+9822+20bf1249.ppc64le as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-psutil-0:5.8.0-4.module+el8.4.0+9822+20bf1249.ppc64le"
+        },
+        "product_reference": "python39-psutil-0:5.8.0-4.module+el8.4.0+9822+20bf1249.ppc64le",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-psutil-0:5.8.0-4.module+el8.4.0+9822+20bf1249.s390x as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-psutil-0:5.8.0-4.module+el8.4.0+9822+20bf1249.s390x"
+        },
+        "product_reference": "python39-psutil-0:5.8.0-4.module+el8.4.0+9822+20bf1249.s390x",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-psutil-0:5.8.0-4.module+el8.4.0+9822+20bf1249.x86_64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-psutil-0:5.8.0-4.module+el8.4.0+9822+20bf1249.x86_64"
+        },
+        "product_reference": "python39-psutil-0:5.8.0-4.module+el8.4.0+9822+20bf1249.x86_64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-psutil-debuginfo-0:5.8.0-4.module+el8.4.0+9822+20bf1249.aarch64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-psutil-debuginfo-0:5.8.0-4.module+el8.4.0+9822+20bf1249.aarch64"
+        },
+        "product_reference": "python39-psutil-debuginfo-0:5.8.0-4.module+el8.4.0+9822+20bf1249.aarch64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-psutil-debuginfo-0:5.8.0-4.module+el8.4.0+9822+20bf1249.ppc64le as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-psutil-debuginfo-0:5.8.0-4.module+el8.4.0+9822+20bf1249.ppc64le"
+        },
+        "product_reference": "python39-psutil-debuginfo-0:5.8.0-4.module+el8.4.0+9822+20bf1249.ppc64le",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-psutil-debuginfo-0:5.8.0-4.module+el8.4.0+9822+20bf1249.s390x as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-psutil-debuginfo-0:5.8.0-4.module+el8.4.0+9822+20bf1249.s390x"
+        },
+        "product_reference": "python39-psutil-debuginfo-0:5.8.0-4.module+el8.4.0+9822+20bf1249.s390x",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-psutil-debuginfo-0:5.8.0-4.module+el8.4.0+9822+20bf1249.x86_64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-psutil-debuginfo-0:5.8.0-4.module+el8.4.0+9822+20bf1249.x86_64"
+        },
+        "product_reference": "python39-psutil-debuginfo-0:5.8.0-4.module+el8.4.0+9822+20bf1249.x86_64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-psycopg2-0:2.8.6-2.module+el8.4.0+9822+20bf1249.aarch64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-psycopg2-0:2.8.6-2.module+el8.4.0+9822+20bf1249.aarch64"
+        },
+        "product_reference": "python39-psycopg2-0:2.8.6-2.module+el8.4.0+9822+20bf1249.aarch64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-psycopg2-0:2.8.6-2.module+el8.4.0+9822+20bf1249.ppc64le as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-psycopg2-0:2.8.6-2.module+el8.4.0+9822+20bf1249.ppc64le"
+        },
+        "product_reference": "python39-psycopg2-0:2.8.6-2.module+el8.4.0+9822+20bf1249.ppc64le",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-psycopg2-0:2.8.6-2.module+el8.4.0+9822+20bf1249.s390x as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-psycopg2-0:2.8.6-2.module+el8.4.0+9822+20bf1249.s390x"
+        },
+        "product_reference": "python39-psycopg2-0:2.8.6-2.module+el8.4.0+9822+20bf1249.s390x",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-psycopg2-0:2.8.6-2.module+el8.4.0+9822+20bf1249.x86_64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-psycopg2-0:2.8.6-2.module+el8.4.0+9822+20bf1249.x86_64"
+        },
+        "product_reference": "python39-psycopg2-0:2.8.6-2.module+el8.4.0+9822+20bf1249.x86_64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-psycopg2-debuginfo-0:2.8.6-2.module+el8.4.0+9822+20bf1249.aarch64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-psycopg2-debuginfo-0:2.8.6-2.module+el8.4.0+9822+20bf1249.aarch64"
+        },
+        "product_reference": "python39-psycopg2-debuginfo-0:2.8.6-2.module+el8.4.0+9822+20bf1249.aarch64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-psycopg2-debuginfo-0:2.8.6-2.module+el8.4.0+9822+20bf1249.ppc64le as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-psycopg2-debuginfo-0:2.8.6-2.module+el8.4.0+9822+20bf1249.ppc64le"
+        },
+        "product_reference": "python39-psycopg2-debuginfo-0:2.8.6-2.module+el8.4.0+9822+20bf1249.ppc64le",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-psycopg2-debuginfo-0:2.8.6-2.module+el8.4.0+9822+20bf1249.s390x as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-psycopg2-debuginfo-0:2.8.6-2.module+el8.4.0+9822+20bf1249.s390x"
+        },
+        "product_reference": "python39-psycopg2-debuginfo-0:2.8.6-2.module+el8.4.0+9822+20bf1249.s390x",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-psycopg2-debuginfo-0:2.8.6-2.module+el8.4.0+9822+20bf1249.x86_64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-psycopg2-debuginfo-0:2.8.6-2.module+el8.4.0+9822+20bf1249.x86_64"
+        },
+        "product_reference": "python39-psycopg2-debuginfo-0:2.8.6-2.module+el8.4.0+9822+20bf1249.x86_64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-psycopg2-doc-0:2.8.6-2.module+el8.4.0+9822+20bf1249.aarch64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-psycopg2-doc-0:2.8.6-2.module+el8.4.0+9822+20bf1249.aarch64"
+        },
+        "product_reference": "python39-psycopg2-doc-0:2.8.6-2.module+el8.4.0+9822+20bf1249.aarch64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-psycopg2-doc-0:2.8.6-2.module+el8.4.0+9822+20bf1249.ppc64le as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-psycopg2-doc-0:2.8.6-2.module+el8.4.0+9822+20bf1249.ppc64le"
+        },
+        "product_reference": "python39-psycopg2-doc-0:2.8.6-2.module+el8.4.0+9822+20bf1249.ppc64le",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-psycopg2-doc-0:2.8.6-2.module+el8.4.0+9822+20bf1249.s390x as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-psycopg2-doc-0:2.8.6-2.module+el8.4.0+9822+20bf1249.s390x"
+        },
+        "product_reference": "python39-psycopg2-doc-0:2.8.6-2.module+el8.4.0+9822+20bf1249.s390x",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-psycopg2-doc-0:2.8.6-2.module+el8.4.0+9822+20bf1249.x86_64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-psycopg2-doc-0:2.8.6-2.module+el8.4.0+9822+20bf1249.x86_64"
+        },
+        "product_reference": "python39-psycopg2-doc-0:2.8.6-2.module+el8.4.0+9822+20bf1249.x86_64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-psycopg2-tests-0:2.8.6-2.module+el8.4.0+9822+20bf1249.aarch64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-psycopg2-tests-0:2.8.6-2.module+el8.4.0+9822+20bf1249.aarch64"
+        },
+        "product_reference": "python39-psycopg2-tests-0:2.8.6-2.module+el8.4.0+9822+20bf1249.aarch64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-psycopg2-tests-0:2.8.6-2.module+el8.4.0+9822+20bf1249.ppc64le as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-psycopg2-tests-0:2.8.6-2.module+el8.4.0+9822+20bf1249.ppc64le"
+        },
+        "product_reference": "python39-psycopg2-tests-0:2.8.6-2.module+el8.4.0+9822+20bf1249.ppc64le",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-psycopg2-tests-0:2.8.6-2.module+el8.4.0+9822+20bf1249.s390x as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-psycopg2-tests-0:2.8.6-2.module+el8.4.0+9822+20bf1249.s390x"
+        },
+        "product_reference": "python39-psycopg2-tests-0:2.8.6-2.module+el8.4.0+9822+20bf1249.s390x",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-psycopg2-tests-0:2.8.6-2.module+el8.4.0+9822+20bf1249.x86_64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-psycopg2-tests-0:2.8.6-2.module+el8.4.0+9822+20bf1249.x86_64"
+        },
+        "product_reference": "python39-psycopg2-tests-0:2.8.6-2.module+el8.4.0+9822+20bf1249.x86_64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-pycparser-0:2.20-3.module+el8.4.0+9822+20bf1249.noarch as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-pycparser-0:2.20-3.module+el8.4.0+9822+20bf1249.noarch"
+        },
+        "product_reference": "python39-pycparser-0:2.20-3.module+el8.4.0+9822+20bf1249.noarch",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-pysocks-0:1.7.1-4.module+el8.4.0+9822+20bf1249.noarch as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-pysocks-0:1.7.1-4.module+el8.4.0+9822+20bf1249.noarch"
+        },
+        "product_reference": "python39-pysocks-0:1.7.1-4.module+el8.4.0+9822+20bf1249.noarch",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-pyyaml-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.aarch64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-pyyaml-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.aarch64"
+        },
+        "product_reference": "python39-pyyaml-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.aarch64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-pyyaml-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.ppc64le as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-pyyaml-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.ppc64le"
+        },
+        "product_reference": "python39-pyyaml-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.ppc64le",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-pyyaml-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.s390x as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-pyyaml-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.s390x"
+        },
+        "product_reference": "python39-pyyaml-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.s390x",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-pyyaml-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.x86_64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-pyyaml-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.x86_64"
+        },
+        "product_reference": "python39-pyyaml-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.x86_64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-pyyaml-debuginfo-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.aarch64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-pyyaml-debuginfo-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.aarch64"
+        },
+        "product_reference": "python39-pyyaml-debuginfo-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.aarch64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-pyyaml-debuginfo-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.ppc64le as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-pyyaml-debuginfo-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.ppc64le"
+        },
+        "product_reference": "python39-pyyaml-debuginfo-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.ppc64le",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-pyyaml-debuginfo-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.s390x as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-pyyaml-debuginfo-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.s390x"
+        },
+        "product_reference": "python39-pyyaml-debuginfo-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.s390x",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-pyyaml-debuginfo-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.x86_64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-pyyaml-debuginfo-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.x86_64"
+        },
+        "product_reference": "python39-pyyaml-debuginfo-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.x86_64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-requests-0:2.25.0-2.module+el8.4.0+9822+20bf1249.noarch as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-requests-0:2.25.0-2.module+el8.4.0+9822+20bf1249.noarch"
+        },
+        "product_reference": "python39-requests-0:2.25.0-2.module+el8.4.0+9822+20bf1249.noarch",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-rpm-macros-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.noarch as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-rpm-macros-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.noarch"
+        },
+        "product_reference": "python39-rpm-macros-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.noarch",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-scipy-0:1.5.4-3.module+el8.4.0+9822+20bf1249.aarch64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-scipy-0:1.5.4-3.module+el8.4.0+9822+20bf1249.aarch64"
+        },
+        "product_reference": "python39-scipy-0:1.5.4-3.module+el8.4.0+9822+20bf1249.aarch64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-scipy-0:1.5.4-3.module+el8.4.0+9822+20bf1249.ppc64le as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-scipy-0:1.5.4-3.module+el8.4.0+9822+20bf1249.ppc64le"
+        },
+        "product_reference": "python39-scipy-0:1.5.4-3.module+el8.4.0+9822+20bf1249.ppc64le",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-scipy-0:1.5.4-3.module+el8.4.0+9822+20bf1249.s390x as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-scipy-0:1.5.4-3.module+el8.4.0+9822+20bf1249.s390x"
+        },
+        "product_reference": "python39-scipy-0:1.5.4-3.module+el8.4.0+9822+20bf1249.s390x",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-scipy-0:1.5.4-3.module+el8.4.0+9822+20bf1249.x86_64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-scipy-0:1.5.4-3.module+el8.4.0+9822+20bf1249.x86_64"
+        },
+        "product_reference": "python39-scipy-0:1.5.4-3.module+el8.4.0+9822+20bf1249.x86_64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-scipy-debuginfo-0:1.5.4-3.module+el8.4.0+9822+20bf1249.aarch64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-scipy-debuginfo-0:1.5.4-3.module+el8.4.0+9822+20bf1249.aarch64"
+        },
+        "product_reference": "python39-scipy-debuginfo-0:1.5.4-3.module+el8.4.0+9822+20bf1249.aarch64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-scipy-debuginfo-0:1.5.4-3.module+el8.4.0+9822+20bf1249.ppc64le as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-scipy-debuginfo-0:1.5.4-3.module+el8.4.0+9822+20bf1249.ppc64le"
+        },
+        "product_reference": "python39-scipy-debuginfo-0:1.5.4-3.module+el8.4.0+9822+20bf1249.ppc64le",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-scipy-debuginfo-0:1.5.4-3.module+el8.4.0+9822+20bf1249.s390x as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-scipy-debuginfo-0:1.5.4-3.module+el8.4.0+9822+20bf1249.s390x"
+        },
+        "product_reference": "python39-scipy-debuginfo-0:1.5.4-3.module+el8.4.0+9822+20bf1249.s390x",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-scipy-debuginfo-0:1.5.4-3.module+el8.4.0+9822+20bf1249.x86_64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-scipy-debuginfo-0:1.5.4-3.module+el8.4.0+9822+20bf1249.x86_64"
+        },
+        "product_reference": "python39-scipy-debuginfo-0:1.5.4-3.module+el8.4.0+9822+20bf1249.x86_64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-setuptools-0:50.3.2-6.module+el8.6.0+22162+859a69ec.noarch as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-setuptools-0:50.3.2-6.module+el8.6.0+22162+859a69ec.noarch"
+        },
+        "product_reference": "python39-setuptools-0:50.3.2-6.module+el8.6.0+22162+859a69ec.noarch",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-setuptools-wheel-0:50.3.2-6.module+el8.6.0+22162+859a69ec.noarch as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-setuptools-wheel-0:50.3.2-6.module+el8.6.0+22162+859a69ec.noarch"
+        },
+        "product_reference": "python39-setuptools-wheel-0:50.3.2-6.module+el8.6.0+22162+859a69ec.noarch",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-six-0:1.15.0-3.module+el8.4.0+9822+20bf1249.noarch as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-six-0:1.15.0-3.module+el8.4.0+9822+20bf1249.noarch"
+        },
+        "product_reference": "python39-six-0:1.15.0-3.module+el8.4.0+9822+20bf1249.noarch",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-test-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.aarch64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-test-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.aarch64"
+        },
+        "product_reference": "python39-test-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.aarch64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-test-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.ppc64le as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-test-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.ppc64le"
+        },
+        "product_reference": "python39-test-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.ppc64le",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-test-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.s390x as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-test-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.s390x"
+        },
+        "product_reference": "python39-test-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.s390x",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-test-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-test-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64"
+        },
+        "product_reference": "python39-test-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-tkinter-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.aarch64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-tkinter-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.aarch64"
+        },
+        "product_reference": "python39-tkinter-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.aarch64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-tkinter-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.ppc64le as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-tkinter-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.ppc64le"
+        },
+        "product_reference": "python39-tkinter-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.ppc64le",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-tkinter-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.s390x as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-tkinter-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.s390x"
+        },
+        "product_reference": "python39-tkinter-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.s390x",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-tkinter-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-tkinter-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64"
+        },
+        "product_reference": "python39-tkinter-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-toml-0:0.10.1-5.module+el8.4.0+9822+20bf1249.noarch as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-toml-0:0.10.1-5.module+el8.4.0+9822+20bf1249.noarch"
+        },
+        "product_reference": "python39-toml-0:0.10.1-5.module+el8.4.0+9822+20bf1249.noarch",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-urllib3-0:1.25.10-4.module+el8.5.0+11712+ea2d2be1.noarch as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-urllib3-0:1.25.10-4.module+el8.5.0+11712+ea2d2be1.noarch"
+        },
+        "product_reference": "python39-urllib3-0:1.25.10-4.module+el8.5.0+11712+ea2d2be1.noarch",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-wheel-1:0.35.1-4.module+el8.5.0+12204+54860423.noarch as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-wheel-1:0.35.1-4.module+el8.5.0+12204+54860423.noarch"
+        },
+        "product_reference": "python39-wheel-1:0.35.1-4.module+el8.5.0+12204+54860423.noarch",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-wheel-wheel-1:0.35.1-4.module+el8.5.0+12204+54860423.noarch as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-wheel-wheel-1:0.35.1-4.module+el8.5.0+12204+54860423.noarch"
+        },
+        "product_reference": "python39-wheel-wheel-1:0.35.1-4.module+el8.5.0+12204+54860423.noarch",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python3x-pip-0:20.2.4-7.module+el8.6.0+13003+6bb2c488.src as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python3x-pip-0:20.2.4-7.module+el8.6.0+13003+6bb2c488.src"
+        },
+        "product_reference": "python3x-pip-0:20.2.4-7.module+el8.6.0+13003+6bb2c488.src",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python3x-setuptools-0:50.3.2-6.module+el8.6.0+22162+859a69ec.src as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python3x-setuptools-0:50.3.2-6.module+el8.6.0+22162+859a69ec.src"
+        },
+        "product_reference": "python3x-setuptools-0:50.3.2-6.module+el8.6.0+22162+859a69ec.src",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python3x-six-0:1.15.0-3.module+el8.4.0+9822+20bf1249.src as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python3x-six-0:1.15.0-3.module+el8.4.0+9822+20bf1249.src"
+        },
+        "product_reference": "python3x-six-0:1.15.0-3.module+el8.4.0+9822+20bf1249.src",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "scipy-0:1.5.4-3.module+el8.4.0+9822+20bf1249.src as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:scipy-0:1.5.4-3.module+el8.4.0+9822+20bf1249.src"
+        },
+        "product_reference": "scipy-0:1.5.4-3.module+el8.4.0+9822+20bf1249.src",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "scipy-debugsource-0:1.5.4-3.module+el8.4.0+9822+20bf1249.aarch64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:scipy-debugsource-0:1.5.4-3.module+el8.4.0+9822+20bf1249.aarch64"
+        },
+        "product_reference": "scipy-debugsource-0:1.5.4-3.module+el8.4.0+9822+20bf1249.aarch64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "scipy-debugsource-0:1.5.4-3.module+el8.4.0+9822+20bf1249.ppc64le as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:scipy-debugsource-0:1.5.4-3.module+el8.4.0+9822+20bf1249.ppc64le"
+        },
+        "product_reference": "scipy-debugsource-0:1.5.4-3.module+el8.4.0+9822+20bf1249.ppc64le",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "scipy-debugsource-0:1.5.4-3.module+el8.4.0+9822+20bf1249.s390x as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:scipy-debugsource-0:1.5.4-3.module+el8.4.0+9822+20bf1249.s390x"
+        },
+        "product_reference": "scipy-debugsource-0:1.5.4-3.module+el8.4.0+9822+20bf1249.s390x",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "scipy-debugsource-0:1.5.4-3.module+el8.4.0+9822+20bf1249.x86_64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream E4S (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:scipy-debugsource-0:1.5.4-3.module+el8.4.0+9822+20bf1249.x86_64"
+        },
+        "product_reference": "scipy-debugsource-0:1.5.4-3.module+el8.4.0+9822+20bf1249.x86_64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream TUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399"
+        },
+        "product_reference": "python39:3.9:8060020240801142753:6a631399",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.TUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "PyYAML-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.src as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream TUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:PyYAML-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.src"
+        },
+        "product_reference": "PyYAML-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.src",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "PyYAML-debugsource-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.x86_64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream TUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:PyYAML-debugsource-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.x86_64"
+        },
+        "product_reference": "PyYAML-debugsource-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.x86_64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "mod_wsgi-0:4.7.1-4.module+el8.4.0+9822+20bf1249.src as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream TUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:mod_wsgi-0:4.7.1-4.module+el8.4.0+9822+20bf1249.src"
+        },
+        "product_reference": "mod_wsgi-0:4.7.1-4.module+el8.4.0+9822+20bf1249.src",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "numpy-0:1.19.4-3.module+el8.5.0+12204+54860423.src as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream TUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:numpy-0:1.19.4-3.module+el8.5.0+12204+54860423.src"
+        },
+        "product_reference": "numpy-0:1.19.4-3.module+el8.5.0+12204+54860423.src",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "numpy-debugsource-0:1.19.4-3.module+el8.5.0+12204+54860423.x86_64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream TUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:numpy-debugsource-0:1.19.4-3.module+el8.5.0+12204+54860423.x86_64"
+        },
+        "product_reference": "numpy-debugsource-0:1.19.4-3.module+el8.5.0+12204+54860423.x86_64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python-PyMySQL-0:0.10.1-2.module+el8.4.0+9822+20bf1249.src as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream TUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python-PyMySQL-0:0.10.1-2.module+el8.4.0+9822+20bf1249.src"
+        },
+        "product_reference": "python-PyMySQL-0:0.10.1-2.module+el8.4.0+9822+20bf1249.src",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python-cffi-0:1.14.3-2.module+el8.4.0+9822+20bf1249.src as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream TUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python-cffi-0:1.14.3-2.module+el8.4.0+9822+20bf1249.src"
+        },
+        "product_reference": "python-cffi-0:1.14.3-2.module+el8.4.0+9822+20bf1249.src",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python-cffi-debugsource-0:1.14.3-2.module+el8.4.0+9822+20bf1249.x86_64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream TUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python-cffi-debugsource-0:1.14.3-2.module+el8.4.0+9822+20bf1249.x86_64"
+        },
+        "product_reference": "python-cffi-debugsource-0:1.14.3-2.module+el8.4.0+9822+20bf1249.x86_64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python-chardet-0:3.0.4-19.module+el8.4.0+9822+20bf1249.src as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream TUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python-chardet-0:3.0.4-19.module+el8.4.0+9822+20bf1249.src"
+        },
+        "product_reference": "python-chardet-0:3.0.4-19.module+el8.4.0+9822+20bf1249.src",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python-cryptography-0:3.3.1-2.module+el8.4.0+9822+20bf1249.src as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream TUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python-cryptography-0:3.3.1-2.module+el8.4.0+9822+20bf1249.src"
+        },
+        "product_reference": "python-cryptography-0:3.3.1-2.module+el8.4.0+9822+20bf1249.src",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python-cryptography-debugsource-0:3.3.1-2.module+el8.4.0+9822+20bf1249.x86_64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream TUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python-cryptography-debugsource-0:3.3.1-2.module+el8.4.0+9822+20bf1249.x86_64"
+        },
+        "product_reference": "python-cryptography-debugsource-0:3.3.1-2.module+el8.4.0+9822+20bf1249.x86_64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python-idna-0:2.10-3.module+el8.4.0+9822+20bf1249.src as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream TUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python-idna-0:2.10-3.module+el8.4.0+9822+20bf1249.src"
+        },
+        "product_reference": "python-idna-0:2.10-3.module+el8.4.0+9822+20bf1249.src",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python-lxml-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.src as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream TUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python-lxml-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.src"
+        },
+        "product_reference": "python-lxml-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.src",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python-lxml-debugsource-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.x86_64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream TUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python-lxml-debugsource-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.x86_64"
+        },
+        "product_reference": "python-lxml-debugsource-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.x86_64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python-ply-0:3.11-10.module+el8.4.0+9822+20bf1249.src as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream TUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python-ply-0:3.11-10.module+el8.4.0+9822+20bf1249.src"
+        },
+        "product_reference": "python-ply-0:3.11-10.module+el8.4.0+9822+20bf1249.src",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python-psutil-0:5.8.0-4.module+el8.4.0+9822+20bf1249.src as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream TUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python-psutil-0:5.8.0-4.module+el8.4.0+9822+20bf1249.src"
+        },
+        "product_reference": "python-psutil-0:5.8.0-4.module+el8.4.0+9822+20bf1249.src",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python-psutil-debugsource-0:5.8.0-4.module+el8.4.0+9822+20bf1249.x86_64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream TUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python-psutil-debugsource-0:5.8.0-4.module+el8.4.0+9822+20bf1249.x86_64"
+        },
+        "product_reference": "python-psutil-debugsource-0:5.8.0-4.module+el8.4.0+9822+20bf1249.x86_64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python-psycopg2-0:2.8.6-2.module+el8.4.0+9822+20bf1249.src as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream TUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python-psycopg2-0:2.8.6-2.module+el8.4.0+9822+20bf1249.src"
+        },
+        "product_reference": "python-psycopg2-0:2.8.6-2.module+el8.4.0+9822+20bf1249.src",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python-psycopg2-debugsource-0:2.8.6-2.module+el8.4.0+9822+20bf1249.x86_64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream TUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python-psycopg2-debugsource-0:2.8.6-2.module+el8.4.0+9822+20bf1249.x86_64"
+        },
+        "product_reference": "python-psycopg2-debugsource-0:2.8.6-2.module+el8.4.0+9822+20bf1249.x86_64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python-pycparser-0:2.20-3.module+el8.4.0+9822+20bf1249.src as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream TUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python-pycparser-0:2.20-3.module+el8.4.0+9822+20bf1249.src"
+        },
+        "product_reference": "python-pycparser-0:2.20-3.module+el8.4.0+9822+20bf1249.src",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python-pysocks-0:1.7.1-4.module+el8.4.0+9822+20bf1249.src as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream TUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python-pysocks-0:1.7.1-4.module+el8.4.0+9822+20bf1249.src"
+        },
+        "product_reference": "python-pysocks-0:1.7.1-4.module+el8.4.0+9822+20bf1249.src",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python-requests-0:2.25.0-2.module+el8.4.0+9822+20bf1249.src as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream TUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python-requests-0:2.25.0-2.module+el8.4.0+9822+20bf1249.src"
+        },
+        "product_reference": "python-requests-0:2.25.0-2.module+el8.4.0+9822+20bf1249.src",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python-toml-0:0.10.1-5.module+el8.4.0+9822+20bf1249.src as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream TUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python-toml-0:0.10.1-5.module+el8.4.0+9822+20bf1249.src"
+        },
+        "product_reference": "python-toml-0:0.10.1-5.module+el8.4.0+9822+20bf1249.src",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python-urllib3-0:1.25.10-4.module+el8.5.0+11712+ea2d2be1.src as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream TUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python-urllib3-0:1.25.10-4.module+el8.5.0+11712+ea2d2be1.src"
+        },
+        "product_reference": "python-urllib3-0:1.25.10-4.module+el8.5.0+11712+ea2d2be1.src",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python-wheel-1:0.35.1-4.module+el8.5.0+12204+54860423.src as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream TUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python-wheel-1:0.35.1-4.module+el8.5.0+12204+54860423.src"
+        },
+        "product_reference": "python-wheel-1:0.35.1-4.module+el8.5.0+12204+54860423.src",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.src as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream TUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.src"
+        },
+        "product_reference": "python39-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.src",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream TUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64"
+        },
+        "product_reference": "python39-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-PyMySQL-0:0.10.1-2.module+el8.4.0+9822+20bf1249.noarch as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream TUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-PyMySQL-0:0.10.1-2.module+el8.4.0+9822+20bf1249.noarch"
+        },
+        "product_reference": "python39-PyMySQL-0:0.10.1-2.module+el8.4.0+9822+20bf1249.noarch",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-cffi-0:1.14.3-2.module+el8.4.0+9822+20bf1249.x86_64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream TUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-cffi-0:1.14.3-2.module+el8.4.0+9822+20bf1249.x86_64"
+        },
+        "product_reference": "python39-cffi-0:1.14.3-2.module+el8.4.0+9822+20bf1249.x86_64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-cffi-debuginfo-0:1.14.3-2.module+el8.4.0+9822+20bf1249.x86_64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream TUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-cffi-debuginfo-0:1.14.3-2.module+el8.4.0+9822+20bf1249.x86_64"
+        },
+        "product_reference": "python39-cffi-debuginfo-0:1.14.3-2.module+el8.4.0+9822+20bf1249.x86_64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-chardet-0:3.0.4-19.module+el8.4.0+9822+20bf1249.noarch as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream TUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-chardet-0:3.0.4-19.module+el8.4.0+9822+20bf1249.noarch"
+        },
+        "product_reference": "python39-chardet-0:3.0.4-19.module+el8.4.0+9822+20bf1249.noarch",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-cryptography-0:3.3.1-2.module+el8.4.0+9822+20bf1249.x86_64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream TUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-cryptography-0:3.3.1-2.module+el8.4.0+9822+20bf1249.x86_64"
+        },
+        "product_reference": "python39-cryptography-0:3.3.1-2.module+el8.4.0+9822+20bf1249.x86_64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-cryptography-debuginfo-0:3.3.1-2.module+el8.4.0+9822+20bf1249.x86_64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream TUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-cryptography-debuginfo-0:3.3.1-2.module+el8.4.0+9822+20bf1249.x86_64"
+        },
+        "product_reference": "python39-cryptography-debuginfo-0:3.3.1-2.module+el8.4.0+9822+20bf1249.x86_64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-debuginfo-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream TUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-debuginfo-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64"
+        },
+        "product_reference": "python39-debuginfo-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-debugsource-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream TUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-debugsource-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64"
+        },
+        "product_reference": "python39-debugsource-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-devel-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream TUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-devel-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64"
+        },
+        "product_reference": "python39-devel-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-idle-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream TUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-idle-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64"
+        },
+        "product_reference": "python39-idle-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-idna-0:2.10-3.module+el8.4.0+9822+20bf1249.noarch as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream TUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-idna-0:2.10-3.module+el8.4.0+9822+20bf1249.noarch"
+        },
+        "product_reference": "python39-idna-0:2.10-3.module+el8.4.0+9822+20bf1249.noarch",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-libs-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream TUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-libs-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64"
+        },
+        "product_reference": "python39-libs-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-lxml-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.x86_64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream TUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-lxml-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.x86_64"
+        },
+        "product_reference": "python39-lxml-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.x86_64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-lxml-debuginfo-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.x86_64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream TUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-lxml-debuginfo-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.x86_64"
+        },
+        "product_reference": "python39-lxml-debuginfo-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.x86_64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-mod_wsgi-0:4.7.1-4.module+el8.4.0+9822+20bf1249.x86_64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream TUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-mod_wsgi-0:4.7.1-4.module+el8.4.0+9822+20bf1249.x86_64"
+        },
+        "product_reference": "python39-mod_wsgi-0:4.7.1-4.module+el8.4.0+9822+20bf1249.x86_64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-numpy-0:1.19.4-3.module+el8.5.0+12204+54860423.x86_64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream TUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-numpy-0:1.19.4-3.module+el8.5.0+12204+54860423.x86_64"
+        },
+        "product_reference": "python39-numpy-0:1.19.4-3.module+el8.5.0+12204+54860423.x86_64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-numpy-debuginfo-0:1.19.4-3.module+el8.5.0+12204+54860423.x86_64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream TUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-numpy-debuginfo-0:1.19.4-3.module+el8.5.0+12204+54860423.x86_64"
+        },
+        "product_reference": "python39-numpy-debuginfo-0:1.19.4-3.module+el8.5.0+12204+54860423.x86_64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-numpy-doc-0:1.19.4-3.module+el8.5.0+12204+54860423.noarch as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream TUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-numpy-doc-0:1.19.4-3.module+el8.5.0+12204+54860423.noarch"
+        },
+        "product_reference": "python39-numpy-doc-0:1.19.4-3.module+el8.5.0+12204+54860423.noarch",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-numpy-f2py-0:1.19.4-3.module+el8.5.0+12204+54860423.x86_64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream TUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-numpy-f2py-0:1.19.4-3.module+el8.5.0+12204+54860423.x86_64"
+        },
+        "product_reference": "python39-numpy-f2py-0:1.19.4-3.module+el8.5.0+12204+54860423.x86_64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-pip-0:20.2.4-7.module+el8.6.0+13003+6bb2c488.noarch as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream TUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-pip-0:20.2.4-7.module+el8.6.0+13003+6bb2c488.noarch"
+        },
+        "product_reference": "python39-pip-0:20.2.4-7.module+el8.6.0+13003+6bb2c488.noarch",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-pip-wheel-0:20.2.4-7.module+el8.6.0+13003+6bb2c488.noarch as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream TUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-pip-wheel-0:20.2.4-7.module+el8.6.0+13003+6bb2c488.noarch"
+        },
+        "product_reference": "python39-pip-wheel-0:20.2.4-7.module+el8.6.0+13003+6bb2c488.noarch",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-ply-0:3.11-10.module+el8.4.0+9822+20bf1249.noarch as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream TUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-ply-0:3.11-10.module+el8.4.0+9822+20bf1249.noarch"
+        },
+        "product_reference": "python39-ply-0:3.11-10.module+el8.4.0+9822+20bf1249.noarch",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-psutil-0:5.8.0-4.module+el8.4.0+9822+20bf1249.x86_64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream TUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-psutil-0:5.8.0-4.module+el8.4.0+9822+20bf1249.x86_64"
+        },
+        "product_reference": "python39-psutil-0:5.8.0-4.module+el8.4.0+9822+20bf1249.x86_64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-psutil-debuginfo-0:5.8.0-4.module+el8.4.0+9822+20bf1249.x86_64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream TUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-psutil-debuginfo-0:5.8.0-4.module+el8.4.0+9822+20bf1249.x86_64"
+        },
+        "product_reference": "python39-psutil-debuginfo-0:5.8.0-4.module+el8.4.0+9822+20bf1249.x86_64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-psycopg2-0:2.8.6-2.module+el8.4.0+9822+20bf1249.x86_64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream TUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-psycopg2-0:2.8.6-2.module+el8.4.0+9822+20bf1249.x86_64"
+        },
+        "product_reference": "python39-psycopg2-0:2.8.6-2.module+el8.4.0+9822+20bf1249.x86_64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-psycopg2-debuginfo-0:2.8.6-2.module+el8.4.0+9822+20bf1249.x86_64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream TUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-psycopg2-debuginfo-0:2.8.6-2.module+el8.4.0+9822+20bf1249.x86_64"
+        },
+        "product_reference": "python39-psycopg2-debuginfo-0:2.8.6-2.module+el8.4.0+9822+20bf1249.x86_64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-psycopg2-doc-0:2.8.6-2.module+el8.4.0+9822+20bf1249.x86_64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream TUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-psycopg2-doc-0:2.8.6-2.module+el8.4.0+9822+20bf1249.x86_64"
+        },
+        "product_reference": "python39-psycopg2-doc-0:2.8.6-2.module+el8.4.0+9822+20bf1249.x86_64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-psycopg2-tests-0:2.8.6-2.module+el8.4.0+9822+20bf1249.x86_64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream TUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-psycopg2-tests-0:2.8.6-2.module+el8.4.0+9822+20bf1249.x86_64"
+        },
+        "product_reference": "python39-psycopg2-tests-0:2.8.6-2.module+el8.4.0+9822+20bf1249.x86_64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-pycparser-0:2.20-3.module+el8.4.0+9822+20bf1249.noarch as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream TUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-pycparser-0:2.20-3.module+el8.4.0+9822+20bf1249.noarch"
+        },
+        "product_reference": "python39-pycparser-0:2.20-3.module+el8.4.0+9822+20bf1249.noarch",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-pysocks-0:1.7.1-4.module+el8.4.0+9822+20bf1249.noarch as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream TUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-pysocks-0:1.7.1-4.module+el8.4.0+9822+20bf1249.noarch"
+        },
+        "product_reference": "python39-pysocks-0:1.7.1-4.module+el8.4.0+9822+20bf1249.noarch",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-pyyaml-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.x86_64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream TUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-pyyaml-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.x86_64"
+        },
+        "product_reference": "python39-pyyaml-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.x86_64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-pyyaml-debuginfo-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.x86_64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream TUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-pyyaml-debuginfo-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.x86_64"
+        },
+        "product_reference": "python39-pyyaml-debuginfo-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.x86_64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-requests-0:2.25.0-2.module+el8.4.0+9822+20bf1249.noarch as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream TUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-requests-0:2.25.0-2.module+el8.4.0+9822+20bf1249.noarch"
+        },
+        "product_reference": "python39-requests-0:2.25.0-2.module+el8.4.0+9822+20bf1249.noarch",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-rpm-macros-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.noarch as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream TUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-rpm-macros-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.noarch"
+        },
+        "product_reference": "python39-rpm-macros-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.noarch",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-scipy-0:1.5.4-3.module+el8.4.0+9822+20bf1249.x86_64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream TUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-scipy-0:1.5.4-3.module+el8.4.0+9822+20bf1249.x86_64"
+        },
+        "product_reference": "python39-scipy-0:1.5.4-3.module+el8.4.0+9822+20bf1249.x86_64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-scipy-debuginfo-0:1.5.4-3.module+el8.4.0+9822+20bf1249.x86_64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream TUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-scipy-debuginfo-0:1.5.4-3.module+el8.4.0+9822+20bf1249.x86_64"
+        },
+        "product_reference": "python39-scipy-debuginfo-0:1.5.4-3.module+el8.4.0+9822+20bf1249.x86_64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-setuptools-0:50.3.2-6.module+el8.6.0+22162+859a69ec.noarch as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream TUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-setuptools-0:50.3.2-6.module+el8.6.0+22162+859a69ec.noarch"
+        },
+        "product_reference": "python39-setuptools-0:50.3.2-6.module+el8.6.0+22162+859a69ec.noarch",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-setuptools-wheel-0:50.3.2-6.module+el8.6.0+22162+859a69ec.noarch as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream TUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-setuptools-wheel-0:50.3.2-6.module+el8.6.0+22162+859a69ec.noarch"
+        },
+        "product_reference": "python39-setuptools-wheel-0:50.3.2-6.module+el8.6.0+22162+859a69ec.noarch",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-six-0:1.15.0-3.module+el8.4.0+9822+20bf1249.noarch as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream TUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-six-0:1.15.0-3.module+el8.4.0+9822+20bf1249.noarch"
+        },
+        "product_reference": "python39-six-0:1.15.0-3.module+el8.4.0+9822+20bf1249.noarch",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-test-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream TUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-test-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64"
+        },
+        "product_reference": "python39-test-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-tkinter-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream TUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-tkinter-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64"
+        },
+        "product_reference": "python39-tkinter-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-toml-0:0.10.1-5.module+el8.4.0+9822+20bf1249.noarch as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream TUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-toml-0:0.10.1-5.module+el8.4.0+9822+20bf1249.noarch"
+        },
+        "product_reference": "python39-toml-0:0.10.1-5.module+el8.4.0+9822+20bf1249.noarch",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-urllib3-0:1.25.10-4.module+el8.5.0+11712+ea2d2be1.noarch as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream TUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-urllib3-0:1.25.10-4.module+el8.5.0+11712+ea2d2be1.noarch"
+        },
+        "product_reference": "python39-urllib3-0:1.25.10-4.module+el8.5.0+11712+ea2d2be1.noarch",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-wheel-1:0.35.1-4.module+el8.5.0+12204+54860423.noarch as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream TUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-wheel-1:0.35.1-4.module+el8.5.0+12204+54860423.noarch"
+        },
+        "product_reference": "python39-wheel-1:0.35.1-4.module+el8.5.0+12204+54860423.noarch",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python39-wheel-wheel-1:0.35.1-4.module+el8.5.0+12204+54860423.noarch as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream TUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-wheel-wheel-1:0.35.1-4.module+el8.5.0+12204+54860423.noarch"
+        },
+        "product_reference": "python39-wheel-wheel-1:0.35.1-4.module+el8.5.0+12204+54860423.noarch",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python3x-pip-0:20.2.4-7.module+el8.6.0+13003+6bb2c488.src as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream TUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python3x-pip-0:20.2.4-7.module+el8.6.0+13003+6bb2c488.src"
+        },
+        "product_reference": "python3x-pip-0:20.2.4-7.module+el8.6.0+13003+6bb2c488.src",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python3x-setuptools-0:50.3.2-6.module+el8.6.0+22162+859a69ec.src as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream TUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python3x-setuptools-0:50.3.2-6.module+el8.6.0+22162+859a69ec.src"
+        },
+        "product_reference": "python3x-setuptools-0:50.3.2-6.module+el8.6.0+22162+859a69ec.src",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "python3x-six-0:1.15.0-3.module+el8.4.0+9822+20bf1249.src as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream TUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python3x-six-0:1.15.0-3.module+el8.4.0+9822+20bf1249.src"
+        },
+        "product_reference": "python3x-six-0:1.15.0-3.module+el8.4.0+9822+20bf1249.src",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "scipy-0:1.5.4-3.module+el8.4.0+9822+20bf1249.src as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream TUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:scipy-0:1.5.4-3.module+el8.4.0+9822+20bf1249.src"
+        },
+        "product_reference": "scipy-0:1.5.4-3.module+el8.4.0+9822+20bf1249.src",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "scipy-debugsource-0:1.5.4-3.module+el8.4.0+9822+20bf1249.x86_64 as a component of python39:3.9:8060020240801142753:6a631399 as a component of Red Hat Enterprise Linux AppStream TUS (v.8.6)",
+          "product_id": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:scipy-debugsource-0:1.5.4-3.module+el8.4.0+9822+20bf1249.x86_64"
+        },
+        "product_reference": "scipy-debugsource-0:1.5.4-3.module+el8.4.0+9822+20bf1249.x86_64",
+        "relates_to_product_reference": "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399"
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "cve": "CVE-2024-6345",
+      "cwe": {
+        "id": "CWE-94",
+        "name": "Improper Control of Generation of Code ('Code Injection')"
+      },
+      "discovery_date": "2024-07-15T00:00:00+00:00",
+      "ids": [
+        {
+          "system_name": "Red Hat Bugzilla ID",
+          "text": "2297771"
+        }
+      ],
+      "notes": [
+        {
+          "category": "description",
+          "text": "A flaw was found in the package_index module of pypa/setuptools. Affected versions of this package allow remote code execution via its download functions. These functions, which are used to download packages from URLs provided by users or retrieved from package index servers, are susceptible to code injection. If these functions are exposed to user-controlled inputs, such as package URLs, they can execute arbitrary commands on the system.",
+          "title": "Vulnerability description"
+        },
+        {
+          "category": "summary",
+          "text": "pypa/setuptools: Remote code execution via download functions in the package_index module in pypa/setuptools",
+          "title": "Vulnerability summary"
+        },
+        {
+          "category": "other",
+          "text": "Red Hat OpenStack does not include setuptools. The ImcSdk component uses it only during compile time in our build systems, and we do not support recompiling SRPMs. As a result, Red Hat OpenStack is not affected by this flaw.",
+          "title": "Statement"
+        },
+        {
+          "category": "general",
+          "text": "The CVSS score(s) listed for this vulnerability do not reflect the associated product's status, and are included for informational purposes to better understand the severity of this vulnerability.",
+          "title": "CVSS score applicability"
+        }
+      ],
+      "product_status": {
+        "fixed": [
+          "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399",
+          "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:PyYAML-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.src",
+          "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:PyYAML-debugsource-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.x86_64",
+          "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:mod_wsgi-0:4.7.1-4.module+el8.4.0+9822+20bf1249.src",
+          "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:numpy-0:1.19.4-3.module+el8.5.0+12204+54860423.src",
+          "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:numpy-debugsource-0:1.19.4-3.module+el8.5.0+12204+54860423.x86_64",
+          "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python-PyMySQL-0:0.10.1-2.module+el8.4.0+9822+20bf1249.src",
+          "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python-cffi-0:1.14.3-2.module+el8.4.0+9822+20bf1249.src",
+          "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python-cffi-debugsource-0:1.14.3-2.module+el8.4.0+9822+20bf1249.x86_64",
+          "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python-chardet-0:3.0.4-19.module+el8.4.0+9822+20bf1249.src",
+          "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python-cryptography-0:3.3.1-2.module+el8.4.0+9822+20bf1249.src",
+          "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python-cryptography-debugsource-0:3.3.1-2.module+el8.4.0+9822+20bf1249.x86_64",
+          "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python-idna-0:2.10-3.module+el8.4.0+9822+20bf1249.src",
+          "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python-lxml-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.src",
+          "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python-lxml-debugsource-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.x86_64",
+          "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python-ply-0:3.11-10.module+el8.4.0+9822+20bf1249.src",
+          "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python-psutil-0:5.8.0-4.module+el8.4.0+9822+20bf1249.src",
+          "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python-psutil-debugsource-0:5.8.0-4.module+el8.4.0+9822+20bf1249.x86_64",
+          "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python-psycopg2-0:2.8.6-2.module+el8.4.0+9822+20bf1249.src",
+          "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python-psycopg2-debugsource-0:2.8.6-2.module+el8.4.0+9822+20bf1249.x86_64",
+          "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python-pycparser-0:2.20-3.module+el8.4.0+9822+20bf1249.src",
+          "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python-pysocks-0:1.7.1-4.module+el8.4.0+9822+20bf1249.src",
+          "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python-requests-0:2.25.0-2.module+el8.4.0+9822+20bf1249.src",
+          "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python-toml-0:0.10.1-5.module+el8.4.0+9822+20bf1249.src",
+          "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python-urllib3-0:1.25.10-4.module+el8.5.0+11712+ea2d2be1.src",
+          "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python-wheel-1:0.35.1-4.module+el8.5.0+12204+54860423.src",
+          "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.src",
+          "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+          "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-PyMySQL-0:0.10.1-2.module+el8.4.0+9822+20bf1249.noarch",
+          "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-cffi-0:1.14.3-2.module+el8.4.0+9822+20bf1249.x86_64",
+          "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-cffi-debuginfo-0:1.14.3-2.module+el8.4.0+9822+20bf1249.x86_64",
+          "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-chardet-0:3.0.4-19.module+el8.4.0+9822+20bf1249.noarch",
+          "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-cryptography-0:3.3.1-2.module+el8.4.0+9822+20bf1249.x86_64",
+          "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-cryptography-debuginfo-0:3.3.1-2.module+el8.4.0+9822+20bf1249.x86_64",
+          "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-debuginfo-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+          "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-debugsource-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+          "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-devel-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+          "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-idle-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+          "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-idna-0:2.10-3.module+el8.4.0+9822+20bf1249.noarch",
+          "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-libs-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+          "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-lxml-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.x86_64",
+          "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-lxml-debuginfo-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.x86_64",
+          "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-mod_wsgi-0:4.7.1-4.module+el8.4.0+9822+20bf1249.x86_64",
+          "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-numpy-0:1.19.4-3.module+el8.5.0+12204+54860423.x86_64",
+          "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-numpy-debuginfo-0:1.19.4-3.module+el8.5.0+12204+54860423.x86_64",
+          "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-numpy-doc-0:1.19.4-3.module+el8.5.0+12204+54860423.noarch",
+          "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-numpy-f2py-0:1.19.4-3.module+el8.5.0+12204+54860423.x86_64",
+          "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-pip-0:20.2.4-7.module+el8.6.0+13003+6bb2c488.noarch",
+          "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-pip-wheel-0:20.2.4-7.module+el8.6.0+13003+6bb2c488.noarch",
+          "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-ply-0:3.11-10.module+el8.4.0+9822+20bf1249.noarch",
+          "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-psutil-0:5.8.0-4.module+el8.4.0+9822+20bf1249.x86_64",
+          "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-psutil-debuginfo-0:5.8.0-4.module+el8.4.0+9822+20bf1249.x86_64",
+          "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-psycopg2-0:2.8.6-2.module+el8.4.0+9822+20bf1249.x86_64",
+          "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-psycopg2-debuginfo-0:2.8.6-2.module+el8.4.0+9822+20bf1249.x86_64",
+          "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-psycopg2-doc-0:2.8.6-2.module+el8.4.0+9822+20bf1249.x86_64",
+          "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-psycopg2-tests-0:2.8.6-2.module+el8.4.0+9822+20bf1249.x86_64",
+          "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-pycparser-0:2.20-3.module+el8.4.0+9822+20bf1249.noarch",
+          "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-pysocks-0:1.7.1-4.module+el8.4.0+9822+20bf1249.noarch",
+          "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-pyyaml-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.x86_64",
+          "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-pyyaml-debuginfo-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.x86_64",
+          "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-requests-0:2.25.0-2.module+el8.4.0+9822+20bf1249.noarch",
+          "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-rpm-macros-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.noarch",
+          "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-scipy-0:1.5.4-3.module+el8.4.0+9822+20bf1249.x86_64",
+          "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-scipy-debuginfo-0:1.5.4-3.module+el8.4.0+9822+20bf1249.x86_64",
+          "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-setuptools-0:50.3.2-6.module+el8.6.0+22162+859a69ec.noarch",
+          "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-setuptools-wheel-0:50.3.2-6.module+el8.6.0+22162+859a69ec.noarch",
+          "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-six-0:1.15.0-3.module+el8.4.0+9822+20bf1249.noarch",
+          "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-test-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+          "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-tkinter-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+          "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-toml-0:0.10.1-5.module+el8.4.0+9822+20bf1249.noarch",
+          "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-urllib3-0:1.25.10-4.module+el8.5.0+11712+ea2d2be1.noarch",
+          "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-wheel-1:0.35.1-4.module+el8.5.0+12204+54860423.noarch",
+          "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-wheel-wheel-1:0.35.1-4.module+el8.5.0+12204+54860423.noarch",
+          "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python3x-pip-0:20.2.4-7.module+el8.6.0+13003+6bb2c488.src",
+          "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python3x-setuptools-0:50.3.2-6.module+el8.6.0+22162+859a69ec.src",
+          "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python3x-six-0:1.15.0-3.module+el8.4.0+9822+20bf1249.src",
+          "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:scipy-0:1.5.4-3.module+el8.4.0+9822+20bf1249.src",
+          "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:scipy-debugsource-0:1.5.4-3.module+el8.4.0+9822+20bf1249.x86_64",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:PyYAML-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.src",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:PyYAML-debugsource-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.aarch64",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:PyYAML-debugsource-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.ppc64le",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:PyYAML-debugsource-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.s390x",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:PyYAML-debugsource-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.x86_64",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:mod_wsgi-0:4.7.1-4.module+el8.4.0+9822+20bf1249.src",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:numpy-0:1.19.4-3.module+el8.5.0+12204+54860423.src",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:numpy-debugsource-0:1.19.4-3.module+el8.5.0+12204+54860423.aarch64",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:numpy-debugsource-0:1.19.4-3.module+el8.5.0+12204+54860423.ppc64le",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:numpy-debugsource-0:1.19.4-3.module+el8.5.0+12204+54860423.s390x",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:numpy-debugsource-0:1.19.4-3.module+el8.5.0+12204+54860423.x86_64",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-PyMySQL-0:0.10.1-2.module+el8.4.0+9822+20bf1249.src",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-cffi-0:1.14.3-2.module+el8.4.0+9822+20bf1249.src",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-cffi-debugsource-0:1.14.3-2.module+el8.4.0+9822+20bf1249.aarch64",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-cffi-debugsource-0:1.14.3-2.module+el8.4.0+9822+20bf1249.ppc64le",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-cffi-debugsource-0:1.14.3-2.module+el8.4.0+9822+20bf1249.s390x",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-cffi-debugsource-0:1.14.3-2.module+el8.4.0+9822+20bf1249.x86_64",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-chardet-0:3.0.4-19.module+el8.4.0+9822+20bf1249.src",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-cryptography-0:3.3.1-2.module+el8.4.0+9822+20bf1249.src",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-cryptography-debugsource-0:3.3.1-2.module+el8.4.0+9822+20bf1249.aarch64",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-cryptography-debugsource-0:3.3.1-2.module+el8.4.0+9822+20bf1249.ppc64le",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-cryptography-debugsource-0:3.3.1-2.module+el8.4.0+9822+20bf1249.s390x",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-cryptography-debugsource-0:3.3.1-2.module+el8.4.0+9822+20bf1249.x86_64",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-idna-0:2.10-3.module+el8.4.0+9822+20bf1249.src",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-lxml-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.src",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-lxml-debugsource-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.aarch64",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-lxml-debugsource-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.ppc64le",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-lxml-debugsource-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.s390x",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-lxml-debugsource-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.x86_64",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-ply-0:3.11-10.module+el8.4.0+9822+20bf1249.src",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-psutil-0:5.8.0-4.module+el8.4.0+9822+20bf1249.src",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-psutil-debugsource-0:5.8.0-4.module+el8.4.0+9822+20bf1249.aarch64",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-psutil-debugsource-0:5.8.0-4.module+el8.4.0+9822+20bf1249.ppc64le",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-psutil-debugsource-0:5.8.0-4.module+el8.4.0+9822+20bf1249.s390x",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-psutil-debugsource-0:5.8.0-4.module+el8.4.0+9822+20bf1249.x86_64",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-psycopg2-0:2.8.6-2.module+el8.4.0+9822+20bf1249.src",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-psycopg2-debugsource-0:2.8.6-2.module+el8.4.0+9822+20bf1249.aarch64",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-psycopg2-debugsource-0:2.8.6-2.module+el8.4.0+9822+20bf1249.ppc64le",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-psycopg2-debugsource-0:2.8.6-2.module+el8.4.0+9822+20bf1249.s390x",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-psycopg2-debugsource-0:2.8.6-2.module+el8.4.0+9822+20bf1249.x86_64",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-pycparser-0:2.20-3.module+el8.4.0+9822+20bf1249.src",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-pysocks-0:1.7.1-4.module+el8.4.0+9822+20bf1249.src",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-requests-0:2.25.0-2.module+el8.4.0+9822+20bf1249.src",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-toml-0:0.10.1-5.module+el8.4.0+9822+20bf1249.src",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-urllib3-0:1.25.10-4.module+el8.5.0+11712+ea2d2be1.src",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-wheel-1:0.35.1-4.module+el8.5.0+12204+54860423.src",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.aarch64",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.ppc64le",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.s390x",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.src",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-PyMySQL-0:0.10.1-2.module+el8.4.0+9822+20bf1249.noarch",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-cffi-0:1.14.3-2.module+el8.4.0+9822+20bf1249.aarch64",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-cffi-0:1.14.3-2.module+el8.4.0+9822+20bf1249.ppc64le",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-cffi-0:1.14.3-2.module+el8.4.0+9822+20bf1249.s390x",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-cffi-0:1.14.3-2.module+el8.4.0+9822+20bf1249.x86_64",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-cffi-debuginfo-0:1.14.3-2.module+el8.4.0+9822+20bf1249.aarch64",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-cffi-debuginfo-0:1.14.3-2.module+el8.4.0+9822+20bf1249.ppc64le",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-cffi-debuginfo-0:1.14.3-2.module+el8.4.0+9822+20bf1249.s390x",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-cffi-debuginfo-0:1.14.3-2.module+el8.4.0+9822+20bf1249.x86_64",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-chardet-0:3.0.4-19.module+el8.4.0+9822+20bf1249.noarch",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-cryptography-0:3.3.1-2.module+el8.4.0+9822+20bf1249.aarch64",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-cryptography-0:3.3.1-2.module+el8.4.0+9822+20bf1249.ppc64le",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-cryptography-0:3.3.1-2.module+el8.4.0+9822+20bf1249.s390x",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-cryptography-0:3.3.1-2.module+el8.4.0+9822+20bf1249.x86_64",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-cryptography-debuginfo-0:3.3.1-2.module+el8.4.0+9822+20bf1249.aarch64",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-cryptography-debuginfo-0:3.3.1-2.module+el8.4.0+9822+20bf1249.ppc64le",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-cryptography-debuginfo-0:3.3.1-2.module+el8.4.0+9822+20bf1249.s390x",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-cryptography-debuginfo-0:3.3.1-2.module+el8.4.0+9822+20bf1249.x86_64",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-debuginfo-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.aarch64",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-debuginfo-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.ppc64le",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-debuginfo-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.s390x",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-debuginfo-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-debugsource-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.aarch64",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-debugsource-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.ppc64le",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-debugsource-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.s390x",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-debugsource-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-devel-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.aarch64",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-devel-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.ppc64le",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-devel-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.s390x",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-devel-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-idle-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.aarch64",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-idle-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.ppc64le",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-idle-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.s390x",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-idle-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-idna-0:2.10-3.module+el8.4.0+9822+20bf1249.noarch",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-libs-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.aarch64",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-libs-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.ppc64le",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-libs-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.s390x",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-libs-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-lxml-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.aarch64",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-lxml-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.ppc64le",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-lxml-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.s390x",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-lxml-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.x86_64",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-lxml-debuginfo-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.aarch64",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-lxml-debuginfo-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.ppc64le",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-lxml-debuginfo-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.s390x",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-lxml-debuginfo-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.x86_64",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-mod_wsgi-0:4.7.1-4.module+el8.4.0+9822+20bf1249.aarch64",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-mod_wsgi-0:4.7.1-4.module+el8.4.0+9822+20bf1249.ppc64le",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-mod_wsgi-0:4.7.1-4.module+el8.4.0+9822+20bf1249.s390x",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-mod_wsgi-0:4.7.1-4.module+el8.4.0+9822+20bf1249.x86_64",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-numpy-0:1.19.4-3.module+el8.5.0+12204+54860423.aarch64",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-numpy-0:1.19.4-3.module+el8.5.0+12204+54860423.ppc64le",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-numpy-0:1.19.4-3.module+el8.5.0+12204+54860423.s390x",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-numpy-0:1.19.4-3.module+el8.5.0+12204+54860423.x86_64",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-numpy-debuginfo-0:1.19.4-3.module+el8.5.0+12204+54860423.aarch64",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-numpy-debuginfo-0:1.19.4-3.module+el8.5.0+12204+54860423.ppc64le",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-numpy-debuginfo-0:1.19.4-3.module+el8.5.0+12204+54860423.s390x",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-numpy-debuginfo-0:1.19.4-3.module+el8.5.0+12204+54860423.x86_64",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-numpy-doc-0:1.19.4-3.module+el8.5.0+12204+54860423.noarch",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-numpy-f2py-0:1.19.4-3.module+el8.5.0+12204+54860423.aarch64",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-numpy-f2py-0:1.19.4-3.module+el8.5.0+12204+54860423.ppc64le",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-numpy-f2py-0:1.19.4-3.module+el8.5.0+12204+54860423.s390x",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-numpy-f2py-0:1.19.4-3.module+el8.5.0+12204+54860423.x86_64",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-pip-0:20.2.4-7.module+el8.6.0+13003+6bb2c488.noarch",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-pip-wheel-0:20.2.4-7.module+el8.6.0+13003+6bb2c488.noarch",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-ply-0:3.11-10.module+el8.4.0+9822+20bf1249.noarch",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-psutil-0:5.8.0-4.module+el8.4.0+9822+20bf1249.aarch64",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-psutil-0:5.8.0-4.module+el8.4.0+9822+20bf1249.ppc64le",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-psutil-0:5.8.0-4.module+el8.4.0+9822+20bf1249.s390x",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-psutil-0:5.8.0-4.module+el8.4.0+9822+20bf1249.x86_64",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-psutil-debuginfo-0:5.8.0-4.module+el8.4.0+9822+20bf1249.aarch64",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-psutil-debuginfo-0:5.8.0-4.module+el8.4.0+9822+20bf1249.ppc64le",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-psutil-debuginfo-0:5.8.0-4.module+el8.4.0+9822+20bf1249.s390x",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-psutil-debuginfo-0:5.8.0-4.module+el8.4.0+9822+20bf1249.x86_64",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-psycopg2-0:2.8.6-2.module+el8.4.0+9822+20bf1249.aarch64",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-psycopg2-0:2.8.6-2.module+el8.4.0+9822+20bf1249.ppc64le",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-psycopg2-0:2.8.6-2.module+el8.4.0+9822+20bf1249.s390x",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-psycopg2-0:2.8.6-2.module+el8.4.0+9822+20bf1249.x86_64",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-psycopg2-debuginfo-0:2.8.6-2.module+el8.4.0+9822+20bf1249.aarch64",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-psycopg2-debuginfo-0:2.8.6-2.module+el8.4.0+9822+20bf1249.ppc64le",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-psycopg2-debuginfo-0:2.8.6-2.module+el8.4.0+9822+20bf1249.s390x",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-psycopg2-debuginfo-0:2.8.6-2.module+el8.4.0+9822+20bf1249.x86_64",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-psycopg2-doc-0:2.8.6-2.module+el8.4.0+9822+20bf1249.aarch64",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-psycopg2-doc-0:2.8.6-2.module+el8.4.0+9822+20bf1249.ppc64le",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-psycopg2-doc-0:2.8.6-2.module+el8.4.0+9822+20bf1249.s390x",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-psycopg2-doc-0:2.8.6-2.module+el8.4.0+9822+20bf1249.x86_64",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-psycopg2-tests-0:2.8.6-2.module+el8.4.0+9822+20bf1249.aarch64",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-psycopg2-tests-0:2.8.6-2.module+el8.4.0+9822+20bf1249.ppc64le",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-psycopg2-tests-0:2.8.6-2.module+el8.4.0+9822+20bf1249.s390x",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-psycopg2-tests-0:2.8.6-2.module+el8.4.0+9822+20bf1249.x86_64",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-pycparser-0:2.20-3.module+el8.4.0+9822+20bf1249.noarch",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-pysocks-0:1.7.1-4.module+el8.4.0+9822+20bf1249.noarch",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-pyyaml-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.aarch64",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-pyyaml-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.ppc64le",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-pyyaml-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.s390x",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-pyyaml-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.x86_64",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-pyyaml-debuginfo-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.aarch64",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-pyyaml-debuginfo-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.ppc64le",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-pyyaml-debuginfo-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.s390x",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-pyyaml-debuginfo-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.x86_64",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-requests-0:2.25.0-2.module+el8.4.0+9822+20bf1249.noarch",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-rpm-macros-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.noarch",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-scipy-0:1.5.4-3.module+el8.4.0+9822+20bf1249.aarch64",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-scipy-0:1.5.4-3.module+el8.4.0+9822+20bf1249.ppc64le",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-scipy-0:1.5.4-3.module+el8.4.0+9822+20bf1249.s390x",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-scipy-0:1.5.4-3.module+el8.4.0+9822+20bf1249.x86_64",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-scipy-debuginfo-0:1.5.4-3.module+el8.4.0+9822+20bf1249.aarch64",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-scipy-debuginfo-0:1.5.4-3.module+el8.4.0+9822+20bf1249.ppc64le",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-scipy-debuginfo-0:1.5.4-3.module+el8.4.0+9822+20bf1249.s390x",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-scipy-debuginfo-0:1.5.4-3.module+el8.4.0+9822+20bf1249.x86_64",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-setuptools-0:50.3.2-6.module+el8.6.0+22162+859a69ec.noarch",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-setuptools-wheel-0:50.3.2-6.module+el8.6.0+22162+859a69ec.noarch",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-six-0:1.15.0-3.module+el8.4.0+9822+20bf1249.noarch",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-test-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.aarch64",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-test-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.ppc64le",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-test-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.s390x",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-test-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-tkinter-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.aarch64",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-tkinter-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.ppc64le",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-tkinter-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.s390x",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-tkinter-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-toml-0:0.10.1-5.module+el8.4.0+9822+20bf1249.noarch",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-urllib3-0:1.25.10-4.module+el8.5.0+11712+ea2d2be1.noarch",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-wheel-1:0.35.1-4.module+el8.5.0+12204+54860423.noarch",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-wheel-wheel-1:0.35.1-4.module+el8.5.0+12204+54860423.noarch",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python3x-pip-0:20.2.4-7.module+el8.6.0+13003+6bb2c488.src",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python3x-setuptools-0:50.3.2-6.module+el8.6.0+22162+859a69ec.src",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python3x-six-0:1.15.0-3.module+el8.4.0+9822+20bf1249.src",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:scipy-0:1.5.4-3.module+el8.4.0+9822+20bf1249.src",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:scipy-debugsource-0:1.5.4-3.module+el8.4.0+9822+20bf1249.aarch64",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:scipy-debugsource-0:1.5.4-3.module+el8.4.0+9822+20bf1249.ppc64le",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:scipy-debugsource-0:1.5.4-3.module+el8.4.0+9822+20bf1249.s390x",
+          "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:scipy-debugsource-0:1.5.4-3.module+el8.4.0+9822+20bf1249.x86_64",
+          "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399",
+          "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:PyYAML-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.src",
+          "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:PyYAML-debugsource-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.x86_64",
+          "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:mod_wsgi-0:4.7.1-4.module+el8.4.0+9822+20bf1249.src",
+          "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:numpy-0:1.19.4-3.module+el8.5.0+12204+54860423.src",
+          "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:numpy-debugsource-0:1.19.4-3.module+el8.5.0+12204+54860423.x86_64",
+          "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python-PyMySQL-0:0.10.1-2.module+el8.4.0+9822+20bf1249.src",
+          "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python-cffi-0:1.14.3-2.module+el8.4.0+9822+20bf1249.src",
+          "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python-cffi-debugsource-0:1.14.3-2.module+el8.4.0+9822+20bf1249.x86_64",
+          "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python-chardet-0:3.0.4-19.module+el8.4.0+9822+20bf1249.src",
+          "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python-cryptography-0:3.3.1-2.module+el8.4.0+9822+20bf1249.src",
+          "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python-cryptography-debugsource-0:3.3.1-2.module+el8.4.0+9822+20bf1249.x86_64",
+          "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python-idna-0:2.10-3.module+el8.4.0+9822+20bf1249.src",
+          "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python-lxml-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.src",
+          "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python-lxml-debugsource-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.x86_64",
+          "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python-ply-0:3.11-10.module+el8.4.0+9822+20bf1249.src",
+          "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python-psutil-0:5.8.0-4.module+el8.4.0+9822+20bf1249.src",
+          "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python-psutil-debugsource-0:5.8.0-4.module+el8.4.0+9822+20bf1249.x86_64",
+          "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python-psycopg2-0:2.8.6-2.module+el8.4.0+9822+20bf1249.src",
+          "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python-psycopg2-debugsource-0:2.8.6-2.module+el8.4.0+9822+20bf1249.x86_64",
+          "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python-pycparser-0:2.20-3.module+el8.4.0+9822+20bf1249.src",
+          "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python-pysocks-0:1.7.1-4.module+el8.4.0+9822+20bf1249.src",
+          "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python-requests-0:2.25.0-2.module+el8.4.0+9822+20bf1249.src",
+          "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python-toml-0:0.10.1-5.module+el8.4.0+9822+20bf1249.src",
+          "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python-urllib3-0:1.25.10-4.module+el8.5.0+11712+ea2d2be1.src",
+          "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python-wheel-1:0.35.1-4.module+el8.5.0+12204+54860423.src",
+          "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.src",
+          "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+          "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-PyMySQL-0:0.10.1-2.module+el8.4.0+9822+20bf1249.noarch",
+          "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-cffi-0:1.14.3-2.module+el8.4.0+9822+20bf1249.x86_64",
+          "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-cffi-debuginfo-0:1.14.3-2.module+el8.4.0+9822+20bf1249.x86_64",
+          "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-chardet-0:3.0.4-19.module+el8.4.0+9822+20bf1249.noarch",
+          "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-cryptography-0:3.3.1-2.module+el8.4.0+9822+20bf1249.x86_64",
+          "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-cryptography-debuginfo-0:3.3.1-2.module+el8.4.0+9822+20bf1249.x86_64",
+          "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-debuginfo-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+          "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-debugsource-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+          "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-devel-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+          "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-idle-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+          "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-idna-0:2.10-3.module+el8.4.0+9822+20bf1249.noarch",
+          "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-libs-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+          "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-lxml-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.x86_64",
+          "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-lxml-debuginfo-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.x86_64",
+          "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-mod_wsgi-0:4.7.1-4.module+el8.4.0+9822+20bf1249.x86_64",
+          "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-numpy-0:1.19.4-3.module+el8.5.0+12204+54860423.x86_64",
+          "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-numpy-debuginfo-0:1.19.4-3.module+el8.5.0+12204+54860423.x86_64",
+          "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-numpy-doc-0:1.19.4-3.module+el8.5.0+12204+54860423.noarch",
+          "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-numpy-f2py-0:1.19.4-3.module+el8.5.0+12204+54860423.x86_64",
+          "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-pip-0:20.2.4-7.module+el8.6.0+13003+6bb2c488.noarch",
+          "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-pip-wheel-0:20.2.4-7.module+el8.6.0+13003+6bb2c488.noarch",
+          "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-ply-0:3.11-10.module+el8.4.0+9822+20bf1249.noarch",
+          "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-psutil-0:5.8.0-4.module+el8.4.0+9822+20bf1249.x86_64",
+          "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-psutil-debuginfo-0:5.8.0-4.module+el8.4.0+9822+20bf1249.x86_64",
+          "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-psycopg2-0:2.8.6-2.module+el8.4.0+9822+20bf1249.x86_64",
+          "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-psycopg2-debuginfo-0:2.8.6-2.module+el8.4.0+9822+20bf1249.x86_64",
+          "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-psycopg2-doc-0:2.8.6-2.module+el8.4.0+9822+20bf1249.x86_64",
+          "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-psycopg2-tests-0:2.8.6-2.module+el8.4.0+9822+20bf1249.x86_64",
+          "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-pycparser-0:2.20-3.module+el8.4.0+9822+20bf1249.noarch",
+          "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-pysocks-0:1.7.1-4.module+el8.4.0+9822+20bf1249.noarch",
+          "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-pyyaml-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.x86_64",
+          "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-pyyaml-debuginfo-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.x86_64",
+          "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-requests-0:2.25.0-2.module+el8.4.0+9822+20bf1249.noarch",
+          "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-rpm-macros-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.noarch",
+          "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-scipy-0:1.5.4-3.module+el8.4.0+9822+20bf1249.x86_64",
+          "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-scipy-debuginfo-0:1.5.4-3.module+el8.4.0+9822+20bf1249.x86_64",
+          "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-setuptools-0:50.3.2-6.module+el8.6.0+22162+859a69ec.noarch",
+          "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-setuptools-wheel-0:50.3.2-6.module+el8.6.0+22162+859a69ec.noarch",
+          "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-six-0:1.15.0-3.module+el8.4.0+9822+20bf1249.noarch",
+          "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-test-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+          "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-tkinter-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+          "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-toml-0:0.10.1-5.module+el8.4.0+9822+20bf1249.noarch",
+          "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-urllib3-0:1.25.10-4.module+el8.5.0+11712+ea2d2be1.noarch",
+          "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-wheel-1:0.35.1-4.module+el8.5.0+12204+54860423.noarch",
+          "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-wheel-wheel-1:0.35.1-4.module+el8.5.0+12204+54860423.noarch",
+          "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python3x-pip-0:20.2.4-7.module+el8.6.0+13003+6bb2c488.src",
+          "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python3x-setuptools-0:50.3.2-6.module+el8.6.0+22162+859a69ec.src",
+          "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python3x-six-0:1.15.0-3.module+el8.4.0+9822+20bf1249.src",
+          "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:scipy-0:1.5.4-3.module+el8.4.0+9822+20bf1249.src",
+          "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:scipy-debugsource-0:1.5.4-3.module+el8.4.0+9822+20bf1249.x86_64"
+        ]
+      },
+      "references": [
+        {
+          "category": "self",
+          "summary": "Canonical URL",
+          "url": "https://access.redhat.com/security/cve/CVE-2024-6345"
+        },
+        {
+          "category": "external",
+          "summary": "RHBZ#2297771",
+          "url": "https://bugzilla.redhat.com/show_bug.cgi?id=2297771"
+        },
+        {
+          "category": "external",
+          "summary": "https://www.cve.org/CVERecord?id=CVE-2024-6345",
+          "url": "https://www.cve.org/CVERecord?id=CVE-2024-6345"
+        },
+        {
+          "category": "external",
+          "summary": "https://nvd.nist.gov/vuln/detail/CVE-2024-6345",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-6345"
+        },
+        {
+          "category": "external",
+          "summary": "https://github.com/pypa/setuptools/commit/88807c7062788254f654ea8c03427adc859321f0",
+          "url": "https://github.com/pypa/setuptools/commit/88807c7062788254f654ea8c03427adc859321f0"
+        },
+        {
+          "category": "external",
+          "summary": "https://huntr.com/bounties/d6362117-ad57-4e83-951f-b8141c6e7ca5",
+          "url": "https://huntr.com/bounties/d6362117-ad57-4e83-951f-b8141c6e7ca5"
+        }
+      ],
+      "release_date": "2024-07-15T00:00:00+00:00",
+      "remediations": [
+        {
+          "category": "vendor_fix",
+          "details": "For details on how to apply this update, which includes the changes described in this advisory, refer to:\n\nhttps://access.redhat.com/articles/11258",
+          "product_ids": [
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:PyYAML-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.src",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:PyYAML-debugsource-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.x86_64",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:mod_wsgi-0:4.7.1-4.module+el8.4.0+9822+20bf1249.src",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:numpy-0:1.19.4-3.module+el8.5.0+12204+54860423.src",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:numpy-debugsource-0:1.19.4-3.module+el8.5.0+12204+54860423.x86_64",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python-PyMySQL-0:0.10.1-2.module+el8.4.0+9822+20bf1249.src",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python-cffi-0:1.14.3-2.module+el8.4.0+9822+20bf1249.src",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python-cffi-debugsource-0:1.14.3-2.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python-chardet-0:3.0.4-19.module+el8.4.0+9822+20bf1249.src",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python-cryptography-0:3.3.1-2.module+el8.4.0+9822+20bf1249.src",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python-cryptography-debugsource-0:3.3.1-2.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python-idna-0:2.10-3.module+el8.4.0+9822+20bf1249.src",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python-lxml-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.src",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python-lxml-debugsource-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.x86_64",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python-ply-0:3.11-10.module+el8.4.0+9822+20bf1249.src",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python-psutil-0:5.8.0-4.module+el8.4.0+9822+20bf1249.src",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python-psutil-debugsource-0:5.8.0-4.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python-psycopg2-0:2.8.6-2.module+el8.4.0+9822+20bf1249.src",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python-psycopg2-debugsource-0:2.8.6-2.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python-pycparser-0:2.20-3.module+el8.4.0+9822+20bf1249.src",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python-pysocks-0:1.7.1-4.module+el8.4.0+9822+20bf1249.src",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python-requests-0:2.25.0-2.module+el8.4.0+9822+20bf1249.src",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python-toml-0:0.10.1-5.module+el8.4.0+9822+20bf1249.src",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python-urllib3-0:1.25.10-4.module+el8.5.0+11712+ea2d2be1.src",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python-wheel-1:0.35.1-4.module+el8.5.0+12204+54860423.src",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.src",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-PyMySQL-0:0.10.1-2.module+el8.4.0+9822+20bf1249.noarch",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-cffi-0:1.14.3-2.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-cffi-debuginfo-0:1.14.3-2.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-chardet-0:3.0.4-19.module+el8.4.0+9822+20bf1249.noarch",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-cryptography-0:3.3.1-2.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-cryptography-debuginfo-0:3.3.1-2.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-debuginfo-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-debugsource-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-devel-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-idle-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-idna-0:2.10-3.module+el8.4.0+9822+20bf1249.noarch",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-libs-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-lxml-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.x86_64",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-lxml-debuginfo-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.x86_64",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-mod_wsgi-0:4.7.1-4.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-numpy-0:1.19.4-3.module+el8.5.0+12204+54860423.x86_64",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-numpy-debuginfo-0:1.19.4-3.module+el8.5.0+12204+54860423.x86_64",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-numpy-doc-0:1.19.4-3.module+el8.5.0+12204+54860423.noarch",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-numpy-f2py-0:1.19.4-3.module+el8.5.0+12204+54860423.x86_64",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-pip-0:20.2.4-7.module+el8.6.0+13003+6bb2c488.noarch",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-pip-wheel-0:20.2.4-7.module+el8.6.0+13003+6bb2c488.noarch",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-ply-0:3.11-10.module+el8.4.0+9822+20bf1249.noarch",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-psutil-0:5.8.0-4.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-psutil-debuginfo-0:5.8.0-4.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-psycopg2-0:2.8.6-2.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-psycopg2-debuginfo-0:2.8.6-2.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-psycopg2-doc-0:2.8.6-2.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-psycopg2-tests-0:2.8.6-2.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-pycparser-0:2.20-3.module+el8.4.0+9822+20bf1249.noarch",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-pysocks-0:1.7.1-4.module+el8.4.0+9822+20bf1249.noarch",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-pyyaml-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.x86_64",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-pyyaml-debuginfo-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.x86_64",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-requests-0:2.25.0-2.module+el8.4.0+9822+20bf1249.noarch",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-rpm-macros-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.noarch",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-scipy-0:1.5.4-3.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-scipy-debuginfo-0:1.5.4-3.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-setuptools-0:50.3.2-6.module+el8.6.0+22162+859a69ec.noarch",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-setuptools-wheel-0:50.3.2-6.module+el8.6.0+22162+859a69ec.noarch",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-six-0:1.15.0-3.module+el8.4.0+9822+20bf1249.noarch",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-test-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-tkinter-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-toml-0:0.10.1-5.module+el8.4.0+9822+20bf1249.noarch",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-urllib3-0:1.25.10-4.module+el8.5.0+11712+ea2d2be1.noarch",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-wheel-1:0.35.1-4.module+el8.5.0+12204+54860423.noarch",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-wheel-wheel-1:0.35.1-4.module+el8.5.0+12204+54860423.noarch",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python3x-pip-0:20.2.4-7.module+el8.6.0+13003+6bb2c488.src",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python3x-setuptools-0:50.3.2-6.module+el8.6.0+22162+859a69ec.src",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python3x-six-0:1.15.0-3.module+el8.4.0+9822+20bf1249.src",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:scipy-0:1.5.4-3.module+el8.4.0+9822+20bf1249.src",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:scipy-debugsource-0:1.5.4-3.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:PyYAML-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.src",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:PyYAML-debugsource-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.aarch64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:PyYAML-debugsource-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.ppc64le",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:PyYAML-debugsource-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.s390x",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:PyYAML-debugsource-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.x86_64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:mod_wsgi-0:4.7.1-4.module+el8.4.0+9822+20bf1249.src",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:numpy-0:1.19.4-3.module+el8.5.0+12204+54860423.src",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:numpy-debugsource-0:1.19.4-3.module+el8.5.0+12204+54860423.aarch64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:numpy-debugsource-0:1.19.4-3.module+el8.5.0+12204+54860423.ppc64le",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:numpy-debugsource-0:1.19.4-3.module+el8.5.0+12204+54860423.s390x",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:numpy-debugsource-0:1.19.4-3.module+el8.5.0+12204+54860423.x86_64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-PyMySQL-0:0.10.1-2.module+el8.4.0+9822+20bf1249.src",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-cffi-0:1.14.3-2.module+el8.4.0+9822+20bf1249.src",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-cffi-debugsource-0:1.14.3-2.module+el8.4.0+9822+20bf1249.aarch64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-cffi-debugsource-0:1.14.3-2.module+el8.4.0+9822+20bf1249.ppc64le",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-cffi-debugsource-0:1.14.3-2.module+el8.4.0+9822+20bf1249.s390x",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-cffi-debugsource-0:1.14.3-2.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-chardet-0:3.0.4-19.module+el8.4.0+9822+20bf1249.src",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-cryptography-0:3.3.1-2.module+el8.4.0+9822+20bf1249.src",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-cryptography-debugsource-0:3.3.1-2.module+el8.4.0+9822+20bf1249.aarch64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-cryptography-debugsource-0:3.3.1-2.module+el8.4.0+9822+20bf1249.ppc64le",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-cryptography-debugsource-0:3.3.1-2.module+el8.4.0+9822+20bf1249.s390x",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-cryptography-debugsource-0:3.3.1-2.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-idna-0:2.10-3.module+el8.4.0+9822+20bf1249.src",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-lxml-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.src",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-lxml-debugsource-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.aarch64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-lxml-debugsource-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.ppc64le",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-lxml-debugsource-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.s390x",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-lxml-debugsource-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.x86_64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-ply-0:3.11-10.module+el8.4.0+9822+20bf1249.src",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-psutil-0:5.8.0-4.module+el8.4.0+9822+20bf1249.src",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-psutil-debugsource-0:5.8.0-4.module+el8.4.0+9822+20bf1249.aarch64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-psutil-debugsource-0:5.8.0-4.module+el8.4.0+9822+20bf1249.ppc64le",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-psutil-debugsource-0:5.8.0-4.module+el8.4.0+9822+20bf1249.s390x",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-psutil-debugsource-0:5.8.0-4.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-psycopg2-0:2.8.6-2.module+el8.4.0+9822+20bf1249.src",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-psycopg2-debugsource-0:2.8.6-2.module+el8.4.0+9822+20bf1249.aarch64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-psycopg2-debugsource-0:2.8.6-2.module+el8.4.0+9822+20bf1249.ppc64le",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-psycopg2-debugsource-0:2.8.6-2.module+el8.4.0+9822+20bf1249.s390x",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-psycopg2-debugsource-0:2.8.6-2.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-pycparser-0:2.20-3.module+el8.4.0+9822+20bf1249.src",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-pysocks-0:1.7.1-4.module+el8.4.0+9822+20bf1249.src",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-requests-0:2.25.0-2.module+el8.4.0+9822+20bf1249.src",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-toml-0:0.10.1-5.module+el8.4.0+9822+20bf1249.src",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-urllib3-0:1.25.10-4.module+el8.5.0+11712+ea2d2be1.src",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-wheel-1:0.35.1-4.module+el8.5.0+12204+54860423.src",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.aarch64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.ppc64le",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.s390x",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.src",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-PyMySQL-0:0.10.1-2.module+el8.4.0+9822+20bf1249.noarch",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-cffi-0:1.14.3-2.module+el8.4.0+9822+20bf1249.aarch64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-cffi-0:1.14.3-2.module+el8.4.0+9822+20bf1249.ppc64le",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-cffi-0:1.14.3-2.module+el8.4.0+9822+20bf1249.s390x",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-cffi-0:1.14.3-2.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-cffi-debuginfo-0:1.14.3-2.module+el8.4.0+9822+20bf1249.aarch64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-cffi-debuginfo-0:1.14.3-2.module+el8.4.0+9822+20bf1249.ppc64le",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-cffi-debuginfo-0:1.14.3-2.module+el8.4.0+9822+20bf1249.s390x",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-cffi-debuginfo-0:1.14.3-2.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-chardet-0:3.0.4-19.module+el8.4.0+9822+20bf1249.noarch",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-cryptography-0:3.3.1-2.module+el8.4.0+9822+20bf1249.aarch64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-cryptography-0:3.3.1-2.module+el8.4.0+9822+20bf1249.ppc64le",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-cryptography-0:3.3.1-2.module+el8.4.0+9822+20bf1249.s390x",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-cryptography-0:3.3.1-2.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-cryptography-debuginfo-0:3.3.1-2.module+el8.4.0+9822+20bf1249.aarch64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-cryptography-debuginfo-0:3.3.1-2.module+el8.4.0+9822+20bf1249.ppc64le",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-cryptography-debuginfo-0:3.3.1-2.module+el8.4.0+9822+20bf1249.s390x",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-cryptography-debuginfo-0:3.3.1-2.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-debuginfo-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.aarch64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-debuginfo-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.ppc64le",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-debuginfo-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.s390x",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-debuginfo-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-debugsource-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.aarch64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-debugsource-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.ppc64le",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-debugsource-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.s390x",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-debugsource-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-devel-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.aarch64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-devel-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.ppc64le",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-devel-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.s390x",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-devel-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-idle-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.aarch64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-idle-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.ppc64le",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-idle-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.s390x",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-idle-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-idna-0:2.10-3.module+el8.4.0+9822+20bf1249.noarch",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-libs-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.aarch64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-libs-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.ppc64le",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-libs-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.s390x",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-libs-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-lxml-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.aarch64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-lxml-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.ppc64le",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-lxml-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.s390x",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-lxml-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.x86_64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-lxml-debuginfo-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.aarch64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-lxml-debuginfo-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.ppc64le",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-lxml-debuginfo-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.s390x",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-lxml-debuginfo-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.x86_64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-mod_wsgi-0:4.7.1-4.module+el8.4.0+9822+20bf1249.aarch64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-mod_wsgi-0:4.7.1-4.module+el8.4.0+9822+20bf1249.ppc64le",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-mod_wsgi-0:4.7.1-4.module+el8.4.0+9822+20bf1249.s390x",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-mod_wsgi-0:4.7.1-4.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-numpy-0:1.19.4-3.module+el8.5.0+12204+54860423.aarch64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-numpy-0:1.19.4-3.module+el8.5.0+12204+54860423.ppc64le",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-numpy-0:1.19.4-3.module+el8.5.0+12204+54860423.s390x",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-numpy-0:1.19.4-3.module+el8.5.0+12204+54860423.x86_64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-numpy-debuginfo-0:1.19.4-3.module+el8.5.0+12204+54860423.aarch64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-numpy-debuginfo-0:1.19.4-3.module+el8.5.0+12204+54860423.ppc64le",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-numpy-debuginfo-0:1.19.4-3.module+el8.5.0+12204+54860423.s390x",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-numpy-debuginfo-0:1.19.4-3.module+el8.5.0+12204+54860423.x86_64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-numpy-doc-0:1.19.4-3.module+el8.5.0+12204+54860423.noarch",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-numpy-f2py-0:1.19.4-3.module+el8.5.0+12204+54860423.aarch64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-numpy-f2py-0:1.19.4-3.module+el8.5.0+12204+54860423.ppc64le",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-numpy-f2py-0:1.19.4-3.module+el8.5.0+12204+54860423.s390x",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-numpy-f2py-0:1.19.4-3.module+el8.5.0+12204+54860423.x86_64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-pip-0:20.2.4-7.module+el8.6.0+13003+6bb2c488.noarch",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-pip-wheel-0:20.2.4-7.module+el8.6.0+13003+6bb2c488.noarch",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-ply-0:3.11-10.module+el8.4.0+9822+20bf1249.noarch",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-psutil-0:5.8.0-4.module+el8.4.0+9822+20bf1249.aarch64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-psutil-0:5.8.0-4.module+el8.4.0+9822+20bf1249.ppc64le",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-psutil-0:5.8.0-4.module+el8.4.0+9822+20bf1249.s390x",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-psutil-0:5.8.0-4.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-psutil-debuginfo-0:5.8.0-4.module+el8.4.0+9822+20bf1249.aarch64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-psutil-debuginfo-0:5.8.0-4.module+el8.4.0+9822+20bf1249.ppc64le",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-psutil-debuginfo-0:5.8.0-4.module+el8.4.0+9822+20bf1249.s390x",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-psutil-debuginfo-0:5.8.0-4.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-psycopg2-0:2.8.6-2.module+el8.4.0+9822+20bf1249.aarch64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-psycopg2-0:2.8.6-2.module+el8.4.0+9822+20bf1249.ppc64le",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-psycopg2-0:2.8.6-2.module+el8.4.0+9822+20bf1249.s390x",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-psycopg2-0:2.8.6-2.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-psycopg2-debuginfo-0:2.8.6-2.module+el8.4.0+9822+20bf1249.aarch64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-psycopg2-debuginfo-0:2.8.6-2.module+el8.4.0+9822+20bf1249.ppc64le",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-psycopg2-debuginfo-0:2.8.6-2.module+el8.4.0+9822+20bf1249.s390x",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-psycopg2-debuginfo-0:2.8.6-2.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-psycopg2-doc-0:2.8.6-2.module+el8.4.0+9822+20bf1249.aarch64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-psycopg2-doc-0:2.8.6-2.module+el8.4.0+9822+20bf1249.ppc64le",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-psycopg2-doc-0:2.8.6-2.module+el8.4.0+9822+20bf1249.s390x",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-psycopg2-doc-0:2.8.6-2.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-psycopg2-tests-0:2.8.6-2.module+el8.4.0+9822+20bf1249.aarch64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-psycopg2-tests-0:2.8.6-2.module+el8.4.0+9822+20bf1249.ppc64le",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-psycopg2-tests-0:2.8.6-2.module+el8.4.0+9822+20bf1249.s390x",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-psycopg2-tests-0:2.8.6-2.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-pycparser-0:2.20-3.module+el8.4.0+9822+20bf1249.noarch",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-pysocks-0:1.7.1-4.module+el8.4.0+9822+20bf1249.noarch",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-pyyaml-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.aarch64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-pyyaml-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.ppc64le",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-pyyaml-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.s390x",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-pyyaml-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.x86_64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-pyyaml-debuginfo-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.aarch64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-pyyaml-debuginfo-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.ppc64le",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-pyyaml-debuginfo-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.s390x",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-pyyaml-debuginfo-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.x86_64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-requests-0:2.25.0-2.module+el8.4.0+9822+20bf1249.noarch",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-rpm-macros-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.noarch",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-scipy-0:1.5.4-3.module+el8.4.0+9822+20bf1249.aarch64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-scipy-0:1.5.4-3.module+el8.4.0+9822+20bf1249.ppc64le",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-scipy-0:1.5.4-3.module+el8.4.0+9822+20bf1249.s390x",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-scipy-0:1.5.4-3.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-scipy-debuginfo-0:1.5.4-3.module+el8.4.0+9822+20bf1249.aarch64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-scipy-debuginfo-0:1.5.4-3.module+el8.4.0+9822+20bf1249.ppc64le",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-scipy-debuginfo-0:1.5.4-3.module+el8.4.0+9822+20bf1249.s390x",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-scipy-debuginfo-0:1.5.4-3.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-setuptools-0:50.3.2-6.module+el8.6.0+22162+859a69ec.noarch",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-setuptools-wheel-0:50.3.2-6.module+el8.6.0+22162+859a69ec.noarch",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-six-0:1.15.0-3.module+el8.4.0+9822+20bf1249.noarch",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-test-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.aarch64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-test-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.ppc64le",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-test-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.s390x",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-test-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-tkinter-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.aarch64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-tkinter-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.ppc64le",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-tkinter-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.s390x",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-tkinter-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-toml-0:0.10.1-5.module+el8.4.0+9822+20bf1249.noarch",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-urllib3-0:1.25.10-4.module+el8.5.0+11712+ea2d2be1.noarch",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-wheel-1:0.35.1-4.module+el8.5.0+12204+54860423.noarch",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-wheel-wheel-1:0.35.1-4.module+el8.5.0+12204+54860423.noarch",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python3x-pip-0:20.2.4-7.module+el8.6.0+13003+6bb2c488.src",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python3x-setuptools-0:50.3.2-6.module+el8.6.0+22162+859a69ec.src",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python3x-six-0:1.15.0-3.module+el8.4.0+9822+20bf1249.src",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:scipy-0:1.5.4-3.module+el8.4.0+9822+20bf1249.src",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:scipy-debugsource-0:1.5.4-3.module+el8.4.0+9822+20bf1249.aarch64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:scipy-debugsource-0:1.5.4-3.module+el8.4.0+9822+20bf1249.ppc64le",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:scipy-debugsource-0:1.5.4-3.module+el8.4.0+9822+20bf1249.s390x",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:scipy-debugsource-0:1.5.4-3.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:PyYAML-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.src",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:PyYAML-debugsource-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.x86_64",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:mod_wsgi-0:4.7.1-4.module+el8.4.0+9822+20bf1249.src",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:numpy-0:1.19.4-3.module+el8.5.0+12204+54860423.src",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:numpy-debugsource-0:1.19.4-3.module+el8.5.0+12204+54860423.x86_64",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python-PyMySQL-0:0.10.1-2.module+el8.4.0+9822+20bf1249.src",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python-cffi-0:1.14.3-2.module+el8.4.0+9822+20bf1249.src",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python-cffi-debugsource-0:1.14.3-2.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python-chardet-0:3.0.4-19.module+el8.4.0+9822+20bf1249.src",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python-cryptography-0:3.3.1-2.module+el8.4.0+9822+20bf1249.src",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python-cryptography-debugsource-0:3.3.1-2.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python-idna-0:2.10-3.module+el8.4.0+9822+20bf1249.src",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python-lxml-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.src",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python-lxml-debugsource-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.x86_64",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python-ply-0:3.11-10.module+el8.4.0+9822+20bf1249.src",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python-psutil-0:5.8.0-4.module+el8.4.0+9822+20bf1249.src",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python-psutil-debugsource-0:5.8.0-4.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python-psycopg2-0:2.8.6-2.module+el8.4.0+9822+20bf1249.src",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python-psycopg2-debugsource-0:2.8.6-2.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python-pycparser-0:2.20-3.module+el8.4.0+9822+20bf1249.src",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python-pysocks-0:1.7.1-4.module+el8.4.0+9822+20bf1249.src",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python-requests-0:2.25.0-2.module+el8.4.0+9822+20bf1249.src",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python-toml-0:0.10.1-5.module+el8.4.0+9822+20bf1249.src",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python-urllib3-0:1.25.10-4.module+el8.5.0+11712+ea2d2be1.src",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python-wheel-1:0.35.1-4.module+el8.5.0+12204+54860423.src",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.src",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-PyMySQL-0:0.10.1-2.module+el8.4.0+9822+20bf1249.noarch",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-cffi-0:1.14.3-2.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-cffi-debuginfo-0:1.14.3-2.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-chardet-0:3.0.4-19.module+el8.4.0+9822+20bf1249.noarch",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-cryptography-0:3.3.1-2.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-cryptography-debuginfo-0:3.3.1-2.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-debuginfo-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-debugsource-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-devel-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-idle-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-idna-0:2.10-3.module+el8.4.0+9822+20bf1249.noarch",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-libs-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-lxml-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.x86_64",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-lxml-debuginfo-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.x86_64",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-mod_wsgi-0:4.7.1-4.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-numpy-0:1.19.4-3.module+el8.5.0+12204+54860423.x86_64",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-numpy-debuginfo-0:1.19.4-3.module+el8.5.0+12204+54860423.x86_64",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-numpy-doc-0:1.19.4-3.module+el8.5.0+12204+54860423.noarch",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-numpy-f2py-0:1.19.4-3.module+el8.5.0+12204+54860423.x86_64",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-pip-0:20.2.4-7.module+el8.6.0+13003+6bb2c488.noarch",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-pip-wheel-0:20.2.4-7.module+el8.6.0+13003+6bb2c488.noarch",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-ply-0:3.11-10.module+el8.4.0+9822+20bf1249.noarch",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-psutil-0:5.8.0-4.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-psutil-debuginfo-0:5.8.0-4.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-psycopg2-0:2.8.6-2.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-psycopg2-debuginfo-0:2.8.6-2.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-psycopg2-doc-0:2.8.6-2.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-psycopg2-tests-0:2.8.6-2.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-pycparser-0:2.20-3.module+el8.4.0+9822+20bf1249.noarch",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-pysocks-0:1.7.1-4.module+el8.4.0+9822+20bf1249.noarch",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-pyyaml-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.x86_64",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-pyyaml-debuginfo-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.x86_64",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-requests-0:2.25.0-2.module+el8.4.0+9822+20bf1249.noarch",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-rpm-macros-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.noarch",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-scipy-0:1.5.4-3.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-scipy-debuginfo-0:1.5.4-3.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-setuptools-0:50.3.2-6.module+el8.6.0+22162+859a69ec.noarch",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-setuptools-wheel-0:50.3.2-6.module+el8.6.0+22162+859a69ec.noarch",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-six-0:1.15.0-3.module+el8.4.0+9822+20bf1249.noarch",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-test-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-tkinter-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-toml-0:0.10.1-5.module+el8.4.0+9822+20bf1249.noarch",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-urllib3-0:1.25.10-4.module+el8.5.0+11712+ea2d2be1.noarch",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-wheel-1:0.35.1-4.module+el8.5.0+12204+54860423.noarch",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-wheel-wheel-1:0.35.1-4.module+el8.5.0+12204+54860423.noarch",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python3x-pip-0:20.2.4-7.module+el8.6.0+13003+6bb2c488.src",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python3x-setuptools-0:50.3.2-6.module+el8.6.0+22162+859a69ec.src",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python3x-six-0:1.15.0-3.module+el8.4.0+9822+20bf1249.src",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:scipy-0:1.5.4-3.module+el8.4.0+9822+20bf1249.src",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:scipy-debugsource-0:1.5.4-3.module+el8.4.0+9822+20bf1249.x86_64"
+          ],
+          "restart_required": {
+            "category": "none"
+          },
+          "url": "https://access.redhat.com/errata/RHSA-2024:6220"
+        },
+        {
+          "category": "workaround",
+          "details": "Mitigation for this issue is either not available or the currently available options do not meet the Red Hat Product Security criteria comprising ease of use and deployment, applicability to widespread installation base or stability.",
+          "product_ids": [
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:PyYAML-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.src",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:PyYAML-debugsource-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.x86_64",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:mod_wsgi-0:4.7.1-4.module+el8.4.0+9822+20bf1249.src",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:numpy-0:1.19.4-3.module+el8.5.0+12204+54860423.src",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:numpy-debugsource-0:1.19.4-3.module+el8.5.0+12204+54860423.x86_64",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python-PyMySQL-0:0.10.1-2.module+el8.4.0+9822+20bf1249.src",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python-cffi-0:1.14.3-2.module+el8.4.0+9822+20bf1249.src",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python-cffi-debugsource-0:1.14.3-2.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python-chardet-0:3.0.4-19.module+el8.4.0+9822+20bf1249.src",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python-cryptography-0:3.3.1-2.module+el8.4.0+9822+20bf1249.src",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python-cryptography-debugsource-0:3.3.1-2.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python-idna-0:2.10-3.module+el8.4.0+9822+20bf1249.src",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python-lxml-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.src",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python-lxml-debugsource-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.x86_64",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python-ply-0:3.11-10.module+el8.4.0+9822+20bf1249.src",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python-psutil-0:5.8.0-4.module+el8.4.0+9822+20bf1249.src",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python-psutil-debugsource-0:5.8.0-4.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python-psycopg2-0:2.8.6-2.module+el8.4.0+9822+20bf1249.src",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python-psycopg2-debugsource-0:2.8.6-2.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python-pycparser-0:2.20-3.module+el8.4.0+9822+20bf1249.src",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python-pysocks-0:1.7.1-4.module+el8.4.0+9822+20bf1249.src",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python-requests-0:2.25.0-2.module+el8.4.0+9822+20bf1249.src",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python-toml-0:0.10.1-5.module+el8.4.0+9822+20bf1249.src",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python-urllib3-0:1.25.10-4.module+el8.5.0+11712+ea2d2be1.src",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python-wheel-1:0.35.1-4.module+el8.5.0+12204+54860423.src",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.src",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-PyMySQL-0:0.10.1-2.module+el8.4.0+9822+20bf1249.noarch",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-cffi-0:1.14.3-2.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-cffi-debuginfo-0:1.14.3-2.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-chardet-0:3.0.4-19.module+el8.4.0+9822+20bf1249.noarch",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-cryptography-0:3.3.1-2.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-cryptography-debuginfo-0:3.3.1-2.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-debuginfo-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-debugsource-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-devel-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-idle-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-idna-0:2.10-3.module+el8.4.0+9822+20bf1249.noarch",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-libs-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-lxml-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.x86_64",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-lxml-debuginfo-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.x86_64",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-mod_wsgi-0:4.7.1-4.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-numpy-0:1.19.4-3.module+el8.5.0+12204+54860423.x86_64",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-numpy-debuginfo-0:1.19.4-3.module+el8.5.0+12204+54860423.x86_64",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-numpy-doc-0:1.19.4-3.module+el8.5.0+12204+54860423.noarch",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-numpy-f2py-0:1.19.4-3.module+el8.5.0+12204+54860423.x86_64",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-pip-0:20.2.4-7.module+el8.6.0+13003+6bb2c488.noarch",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-pip-wheel-0:20.2.4-7.module+el8.6.0+13003+6bb2c488.noarch",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-ply-0:3.11-10.module+el8.4.0+9822+20bf1249.noarch",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-psutil-0:5.8.0-4.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-psutil-debuginfo-0:5.8.0-4.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-psycopg2-0:2.8.6-2.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-psycopg2-debuginfo-0:2.8.6-2.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-psycopg2-doc-0:2.8.6-2.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-psycopg2-tests-0:2.8.6-2.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-pycparser-0:2.20-3.module+el8.4.0+9822+20bf1249.noarch",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-pysocks-0:1.7.1-4.module+el8.4.0+9822+20bf1249.noarch",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-pyyaml-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.x86_64",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-pyyaml-debuginfo-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.x86_64",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-requests-0:2.25.0-2.module+el8.4.0+9822+20bf1249.noarch",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-rpm-macros-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.noarch",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-scipy-0:1.5.4-3.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-scipy-debuginfo-0:1.5.4-3.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-setuptools-0:50.3.2-6.module+el8.6.0+22162+859a69ec.noarch",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-setuptools-wheel-0:50.3.2-6.module+el8.6.0+22162+859a69ec.noarch",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-six-0:1.15.0-3.module+el8.4.0+9822+20bf1249.noarch",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-test-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-tkinter-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-toml-0:0.10.1-5.module+el8.4.0+9822+20bf1249.noarch",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-urllib3-0:1.25.10-4.module+el8.5.0+11712+ea2d2be1.noarch",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-wheel-1:0.35.1-4.module+el8.5.0+12204+54860423.noarch",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-wheel-wheel-1:0.35.1-4.module+el8.5.0+12204+54860423.noarch",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python3x-pip-0:20.2.4-7.module+el8.6.0+13003+6bb2c488.src",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python3x-setuptools-0:50.3.2-6.module+el8.6.0+22162+859a69ec.src",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python3x-six-0:1.15.0-3.module+el8.4.0+9822+20bf1249.src",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:scipy-0:1.5.4-3.module+el8.4.0+9822+20bf1249.src",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:scipy-debugsource-0:1.5.4-3.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:PyYAML-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.src",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:PyYAML-debugsource-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.aarch64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:PyYAML-debugsource-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.ppc64le",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:PyYAML-debugsource-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.s390x",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:PyYAML-debugsource-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.x86_64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:mod_wsgi-0:4.7.1-4.module+el8.4.0+9822+20bf1249.src",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:numpy-0:1.19.4-3.module+el8.5.0+12204+54860423.src",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:numpy-debugsource-0:1.19.4-3.module+el8.5.0+12204+54860423.aarch64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:numpy-debugsource-0:1.19.4-3.module+el8.5.0+12204+54860423.ppc64le",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:numpy-debugsource-0:1.19.4-3.module+el8.5.0+12204+54860423.s390x",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:numpy-debugsource-0:1.19.4-3.module+el8.5.0+12204+54860423.x86_64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-PyMySQL-0:0.10.1-2.module+el8.4.0+9822+20bf1249.src",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-cffi-0:1.14.3-2.module+el8.4.0+9822+20bf1249.src",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-cffi-debugsource-0:1.14.3-2.module+el8.4.0+9822+20bf1249.aarch64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-cffi-debugsource-0:1.14.3-2.module+el8.4.0+9822+20bf1249.ppc64le",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-cffi-debugsource-0:1.14.3-2.module+el8.4.0+9822+20bf1249.s390x",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-cffi-debugsource-0:1.14.3-2.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-chardet-0:3.0.4-19.module+el8.4.0+9822+20bf1249.src",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-cryptography-0:3.3.1-2.module+el8.4.0+9822+20bf1249.src",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-cryptography-debugsource-0:3.3.1-2.module+el8.4.0+9822+20bf1249.aarch64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-cryptography-debugsource-0:3.3.1-2.module+el8.4.0+9822+20bf1249.ppc64le",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-cryptography-debugsource-0:3.3.1-2.module+el8.4.0+9822+20bf1249.s390x",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-cryptography-debugsource-0:3.3.1-2.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-idna-0:2.10-3.module+el8.4.0+9822+20bf1249.src",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-lxml-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.src",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-lxml-debugsource-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.aarch64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-lxml-debugsource-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.ppc64le",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-lxml-debugsource-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.s390x",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-lxml-debugsource-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.x86_64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-ply-0:3.11-10.module+el8.4.0+9822+20bf1249.src",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-psutil-0:5.8.0-4.module+el8.4.0+9822+20bf1249.src",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-psutil-debugsource-0:5.8.0-4.module+el8.4.0+9822+20bf1249.aarch64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-psutil-debugsource-0:5.8.0-4.module+el8.4.0+9822+20bf1249.ppc64le",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-psutil-debugsource-0:5.8.0-4.module+el8.4.0+9822+20bf1249.s390x",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-psutil-debugsource-0:5.8.0-4.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-psycopg2-0:2.8.6-2.module+el8.4.0+9822+20bf1249.src",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-psycopg2-debugsource-0:2.8.6-2.module+el8.4.0+9822+20bf1249.aarch64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-psycopg2-debugsource-0:2.8.6-2.module+el8.4.0+9822+20bf1249.ppc64le",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-psycopg2-debugsource-0:2.8.6-2.module+el8.4.0+9822+20bf1249.s390x",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-psycopg2-debugsource-0:2.8.6-2.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-pycparser-0:2.20-3.module+el8.4.0+9822+20bf1249.src",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-pysocks-0:1.7.1-4.module+el8.4.0+9822+20bf1249.src",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-requests-0:2.25.0-2.module+el8.4.0+9822+20bf1249.src",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-toml-0:0.10.1-5.module+el8.4.0+9822+20bf1249.src",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-urllib3-0:1.25.10-4.module+el8.5.0+11712+ea2d2be1.src",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-wheel-1:0.35.1-4.module+el8.5.0+12204+54860423.src",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.aarch64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.ppc64le",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.s390x",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.src",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-PyMySQL-0:0.10.1-2.module+el8.4.0+9822+20bf1249.noarch",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-cffi-0:1.14.3-2.module+el8.4.0+9822+20bf1249.aarch64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-cffi-0:1.14.3-2.module+el8.4.0+9822+20bf1249.ppc64le",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-cffi-0:1.14.3-2.module+el8.4.0+9822+20bf1249.s390x",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-cffi-0:1.14.3-2.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-cffi-debuginfo-0:1.14.3-2.module+el8.4.0+9822+20bf1249.aarch64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-cffi-debuginfo-0:1.14.3-2.module+el8.4.0+9822+20bf1249.ppc64le",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-cffi-debuginfo-0:1.14.3-2.module+el8.4.0+9822+20bf1249.s390x",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-cffi-debuginfo-0:1.14.3-2.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-chardet-0:3.0.4-19.module+el8.4.0+9822+20bf1249.noarch",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-cryptography-0:3.3.1-2.module+el8.4.0+9822+20bf1249.aarch64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-cryptography-0:3.3.1-2.module+el8.4.0+9822+20bf1249.ppc64le",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-cryptography-0:3.3.1-2.module+el8.4.0+9822+20bf1249.s390x",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-cryptography-0:3.3.1-2.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-cryptography-debuginfo-0:3.3.1-2.module+el8.4.0+9822+20bf1249.aarch64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-cryptography-debuginfo-0:3.3.1-2.module+el8.4.0+9822+20bf1249.ppc64le",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-cryptography-debuginfo-0:3.3.1-2.module+el8.4.0+9822+20bf1249.s390x",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-cryptography-debuginfo-0:3.3.1-2.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-debuginfo-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.aarch64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-debuginfo-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.ppc64le",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-debuginfo-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.s390x",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-debuginfo-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-debugsource-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.aarch64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-debugsource-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.ppc64le",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-debugsource-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.s390x",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-debugsource-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-devel-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.aarch64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-devel-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.ppc64le",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-devel-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.s390x",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-devel-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-idle-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.aarch64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-idle-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.ppc64le",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-idle-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.s390x",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-idle-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-idna-0:2.10-3.module+el8.4.0+9822+20bf1249.noarch",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-libs-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.aarch64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-libs-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.ppc64le",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-libs-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.s390x",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-libs-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-lxml-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.aarch64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-lxml-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.ppc64le",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-lxml-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.s390x",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-lxml-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.x86_64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-lxml-debuginfo-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.aarch64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-lxml-debuginfo-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.ppc64le",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-lxml-debuginfo-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.s390x",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-lxml-debuginfo-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.x86_64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-mod_wsgi-0:4.7.1-4.module+el8.4.0+9822+20bf1249.aarch64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-mod_wsgi-0:4.7.1-4.module+el8.4.0+9822+20bf1249.ppc64le",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-mod_wsgi-0:4.7.1-4.module+el8.4.0+9822+20bf1249.s390x",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-mod_wsgi-0:4.7.1-4.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-numpy-0:1.19.4-3.module+el8.5.0+12204+54860423.aarch64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-numpy-0:1.19.4-3.module+el8.5.0+12204+54860423.ppc64le",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-numpy-0:1.19.4-3.module+el8.5.0+12204+54860423.s390x",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-numpy-0:1.19.4-3.module+el8.5.0+12204+54860423.x86_64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-numpy-debuginfo-0:1.19.4-3.module+el8.5.0+12204+54860423.aarch64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-numpy-debuginfo-0:1.19.4-3.module+el8.5.0+12204+54860423.ppc64le",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-numpy-debuginfo-0:1.19.4-3.module+el8.5.0+12204+54860423.s390x",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-numpy-debuginfo-0:1.19.4-3.module+el8.5.0+12204+54860423.x86_64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-numpy-doc-0:1.19.4-3.module+el8.5.0+12204+54860423.noarch",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-numpy-f2py-0:1.19.4-3.module+el8.5.0+12204+54860423.aarch64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-numpy-f2py-0:1.19.4-3.module+el8.5.0+12204+54860423.ppc64le",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-numpy-f2py-0:1.19.4-3.module+el8.5.0+12204+54860423.s390x",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-numpy-f2py-0:1.19.4-3.module+el8.5.0+12204+54860423.x86_64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-pip-0:20.2.4-7.module+el8.6.0+13003+6bb2c488.noarch",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-pip-wheel-0:20.2.4-7.module+el8.6.0+13003+6bb2c488.noarch",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-ply-0:3.11-10.module+el8.4.0+9822+20bf1249.noarch",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-psutil-0:5.8.0-4.module+el8.4.0+9822+20bf1249.aarch64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-psutil-0:5.8.0-4.module+el8.4.0+9822+20bf1249.ppc64le",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-psutil-0:5.8.0-4.module+el8.4.0+9822+20bf1249.s390x",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-psutil-0:5.8.0-4.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-psutil-debuginfo-0:5.8.0-4.module+el8.4.0+9822+20bf1249.aarch64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-psutil-debuginfo-0:5.8.0-4.module+el8.4.0+9822+20bf1249.ppc64le",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-psutil-debuginfo-0:5.8.0-4.module+el8.4.0+9822+20bf1249.s390x",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-psutil-debuginfo-0:5.8.0-4.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-psycopg2-0:2.8.6-2.module+el8.4.0+9822+20bf1249.aarch64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-psycopg2-0:2.8.6-2.module+el8.4.0+9822+20bf1249.ppc64le",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-psycopg2-0:2.8.6-2.module+el8.4.0+9822+20bf1249.s390x",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-psycopg2-0:2.8.6-2.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-psycopg2-debuginfo-0:2.8.6-2.module+el8.4.0+9822+20bf1249.aarch64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-psycopg2-debuginfo-0:2.8.6-2.module+el8.4.0+9822+20bf1249.ppc64le",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-psycopg2-debuginfo-0:2.8.6-2.module+el8.4.0+9822+20bf1249.s390x",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-psycopg2-debuginfo-0:2.8.6-2.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-psycopg2-doc-0:2.8.6-2.module+el8.4.0+9822+20bf1249.aarch64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-psycopg2-doc-0:2.8.6-2.module+el8.4.0+9822+20bf1249.ppc64le",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-psycopg2-doc-0:2.8.6-2.module+el8.4.0+9822+20bf1249.s390x",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-psycopg2-doc-0:2.8.6-2.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-psycopg2-tests-0:2.8.6-2.module+el8.4.0+9822+20bf1249.aarch64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-psycopg2-tests-0:2.8.6-2.module+el8.4.0+9822+20bf1249.ppc64le",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-psycopg2-tests-0:2.8.6-2.module+el8.4.0+9822+20bf1249.s390x",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-psycopg2-tests-0:2.8.6-2.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-pycparser-0:2.20-3.module+el8.4.0+9822+20bf1249.noarch",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-pysocks-0:1.7.1-4.module+el8.4.0+9822+20bf1249.noarch",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-pyyaml-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.aarch64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-pyyaml-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.ppc64le",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-pyyaml-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.s390x",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-pyyaml-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.x86_64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-pyyaml-debuginfo-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.aarch64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-pyyaml-debuginfo-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.ppc64le",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-pyyaml-debuginfo-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.s390x",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-pyyaml-debuginfo-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.x86_64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-requests-0:2.25.0-2.module+el8.4.0+9822+20bf1249.noarch",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-rpm-macros-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.noarch",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-scipy-0:1.5.4-3.module+el8.4.0+9822+20bf1249.aarch64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-scipy-0:1.5.4-3.module+el8.4.0+9822+20bf1249.ppc64le",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-scipy-0:1.5.4-3.module+el8.4.0+9822+20bf1249.s390x",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-scipy-0:1.5.4-3.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-scipy-debuginfo-0:1.5.4-3.module+el8.4.0+9822+20bf1249.aarch64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-scipy-debuginfo-0:1.5.4-3.module+el8.4.0+9822+20bf1249.ppc64le",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-scipy-debuginfo-0:1.5.4-3.module+el8.4.0+9822+20bf1249.s390x",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-scipy-debuginfo-0:1.5.4-3.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-setuptools-0:50.3.2-6.module+el8.6.0+22162+859a69ec.noarch",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-setuptools-wheel-0:50.3.2-6.module+el8.6.0+22162+859a69ec.noarch",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-six-0:1.15.0-3.module+el8.4.0+9822+20bf1249.noarch",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-test-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.aarch64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-test-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.ppc64le",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-test-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.s390x",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-test-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-tkinter-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.aarch64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-tkinter-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.ppc64le",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-tkinter-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.s390x",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-tkinter-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-toml-0:0.10.1-5.module+el8.4.0+9822+20bf1249.noarch",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-urllib3-0:1.25.10-4.module+el8.5.0+11712+ea2d2be1.noarch",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-wheel-1:0.35.1-4.module+el8.5.0+12204+54860423.noarch",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-wheel-wheel-1:0.35.1-4.module+el8.5.0+12204+54860423.noarch",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python3x-pip-0:20.2.4-7.module+el8.6.0+13003+6bb2c488.src",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python3x-setuptools-0:50.3.2-6.module+el8.6.0+22162+859a69ec.src",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python3x-six-0:1.15.0-3.module+el8.4.0+9822+20bf1249.src",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:scipy-0:1.5.4-3.module+el8.4.0+9822+20bf1249.src",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:scipy-debugsource-0:1.5.4-3.module+el8.4.0+9822+20bf1249.aarch64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:scipy-debugsource-0:1.5.4-3.module+el8.4.0+9822+20bf1249.ppc64le",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:scipy-debugsource-0:1.5.4-3.module+el8.4.0+9822+20bf1249.s390x",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:scipy-debugsource-0:1.5.4-3.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:PyYAML-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.src",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:PyYAML-debugsource-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.x86_64",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:mod_wsgi-0:4.7.1-4.module+el8.4.0+9822+20bf1249.src",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:numpy-0:1.19.4-3.module+el8.5.0+12204+54860423.src",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:numpy-debugsource-0:1.19.4-3.module+el8.5.0+12204+54860423.x86_64",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python-PyMySQL-0:0.10.1-2.module+el8.4.0+9822+20bf1249.src",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python-cffi-0:1.14.3-2.module+el8.4.0+9822+20bf1249.src",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python-cffi-debugsource-0:1.14.3-2.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python-chardet-0:3.0.4-19.module+el8.4.0+9822+20bf1249.src",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python-cryptography-0:3.3.1-2.module+el8.4.0+9822+20bf1249.src",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python-cryptography-debugsource-0:3.3.1-2.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python-idna-0:2.10-3.module+el8.4.0+9822+20bf1249.src",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python-lxml-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.src",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python-lxml-debugsource-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.x86_64",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python-ply-0:3.11-10.module+el8.4.0+9822+20bf1249.src",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python-psutil-0:5.8.0-4.module+el8.4.0+9822+20bf1249.src",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python-psutil-debugsource-0:5.8.0-4.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python-psycopg2-0:2.8.6-2.module+el8.4.0+9822+20bf1249.src",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python-psycopg2-debugsource-0:2.8.6-2.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python-pycparser-0:2.20-3.module+el8.4.0+9822+20bf1249.src",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python-pysocks-0:1.7.1-4.module+el8.4.0+9822+20bf1249.src",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python-requests-0:2.25.0-2.module+el8.4.0+9822+20bf1249.src",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python-toml-0:0.10.1-5.module+el8.4.0+9822+20bf1249.src",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python-urllib3-0:1.25.10-4.module+el8.5.0+11712+ea2d2be1.src",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python-wheel-1:0.35.1-4.module+el8.5.0+12204+54860423.src",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.src",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-PyMySQL-0:0.10.1-2.module+el8.4.0+9822+20bf1249.noarch",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-cffi-0:1.14.3-2.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-cffi-debuginfo-0:1.14.3-2.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-chardet-0:3.0.4-19.module+el8.4.0+9822+20bf1249.noarch",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-cryptography-0:3.3.1-2.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-cryptography-debuginfo-0:3.3.1-2.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-debuginfo-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-debugsource-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-devel-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-idle-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-idna-0:2.10-3.module+el8.4.0+9822+20bf1249.noarch",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-libs-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-lxml-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.x86_64",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-lxml-debuginfo-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.x86_64",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-mod_wsgi-0:4.7.1-4.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-numpy-0:1.19.4-3.module+el8.5.0+12204+54860423.x86_64",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-numpy-debuginfo-0:1.19.4-3.module+el8.5.0+12204+54860423.x86_64",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-numpy-doc-0:1.19.4-3.module+el8.5.0+12204+54860423.noarch",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-numpy-f2py-0:1.19.4-3.module+el8.5.0+12204+54860423.x86_64",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-pip-0:20.2.4-7.module+el8.6.0+13003+6bb2c488.noarch",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-pip-wheel-0:20.2.4-7.module+el8.6.0+13003+6bb2c488.noarch",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-ply-0:3.11-10.module+el8.4.0+9822+20bf1249.noarch",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-psutil-0:5.8.0-4.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-psutil-debuginfo-0:5.8.0-4.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-psycopg2-0:2.8.6-2.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-psycopg2-debuginfo-0:2.8.6-2.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-psycopg2-doc-0:2.8.6-2.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-psycopg2-tests-0:2.8.6-2.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-pycparser-0:2.20-3.module+el8.4.0+9822+20bf1249.noarch",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-pysocks-0:1.7.1-4.module+el8.4.0+9822+20bf1249.noarch",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-pyyaml-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.x86_64",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-pyyaml-debuginfo-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.x86_64",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-requests-0:2.25.0-2.module+el8.4.0+9822+20bf1249.noarch",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-rpm-macros-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.noarch",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-scipy-0:1.5.4-3.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-scipy-debuginfo-0:1.5.4-3.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-setuptools-0:50.3.2-6.module+el8.6.0+22162+859a69ec.noarch",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-setuptools-wheel-0:50.3.2-6.module+el8.6.0+22162+859a69ec.noarch",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-six-0:1.15.0-3.module+el8.4.0+9822+20bf1249.noarch",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-test-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-tkinter-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-toml-0:0.10.1-5.module+el8.4.0+9822+20bf1249.noarch",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-urllib3-0:1.25.10-4.module+el8.5.0+11712+ea2d2be1.noarch",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-wheel-1:0.35.1-4.module+el8.5.0+12204+54860423.noarch",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-wheel-wheel-1:0.35.1-4.module+el8.5.0+12204+54860423.noarch",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python3x-pip-0:20.2.4-7.module+el8.6.0+13003+6bb2c488.src",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python3x-setuptools-0:50.3.2-6.module+el8.6.0+22162+859a69ec.src",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python3x-six-0:1.15.0-3.module+el8.4.0+9822+20bf1249.src",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:scipy-0:1.5.4-3.module+el8.4.0+9822+20bf1249.src",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:scipy-debugsource-0:1.5.4-3.module+el8.4.0+9822+20bf1249.x86_64"
+          ]
+        }
+      ],
+      "scores": [
+        {
+          "cvss_v3": {
+            "attackComplexity": "LOW",
+            "attackVector": "NETWORK",
+            "availabilityImpact": "HIGH",
+            "baseScore": 8.8,
+            "baseSeverity": "HIGH",
+            "confidentialityImpact": "HIGH",
+            "integrityImpact": "HIGH",
+            "privilegesRequired": "NONE",
+            "scope": "UNCHANGED",
+            "userInteraction": "REQUIRED",
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+            "version": "3.1"
+          },
+          "products": [
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:PyYAML-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.src",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:PyYAML-debugsource-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.x86_64",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:mod_wsgi-0:4.7.1-4.module+el8.4.0+9822+20bf1249.src",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:numpy-0:1.19.4-3.module+el8.5.0+12204+54860423.src",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:numpy-debugsource-0:1.19.4-3.module+el8.5.0+12204+54860423.x86_64",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python-PyMySQL-0:0.10.1-2.module+el8.4.0+9822+20bf1249.src",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python-cffi-0:1.14.3-2.module+el8.4.0+9822+20bf1249.src",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python-cffi-debugsource-0:1.14.3-2.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python-chardet-0:3.0.4-19.module+el8.4.0+9822+20bf1249.src",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python-cryptography-0:3.3.1-2.module+el8.4.0+9822+20bf1249.src",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python-cryptography-debugsource-0:3.3.1-2.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python-idna-0:2.10-3.module+el8.4.0+9822+20bf1249.src",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python-lxml-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.src",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python-lxml-debugsource-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.x86_64",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python-ply-0:3.11-10.module+el8.4.0+9822+20bf1249.src",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python-psutil-0:5.8.0-4.module+el8.4.0+9822+20bf1249.src",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python-psutil-debugsource-0:5.8.0-4.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python-psycopg2-0:2.8.6-2.module+el8.4.0+9822+20bf1249.src",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python-psycopg2-debugsource-0:2.8.6-2.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python-pycparser-0:2.20-3.module+el8.4.0+9822+20bf1249.src",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python-pysocks-0:1.7.1-4.module+el8.4.0+9822+20bf1249.src",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python-requests-0:2.25.0-2.module+el8.4.0+9822+20bf1249.src",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python-toml-0:0.10.1-5.module+el8.4.0+9822+20bf1249.src",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python-urllib3-0:1.25.10-4.module+el8.5.0+11712+ea2d2be1.src",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python-wheel-1:0.35.1-4.module+el8.5.0+12204+54860423.src",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.src",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-PyMySQL-0:0.10.1-2.module+el8.4.0+9822+20bf1249.noarch",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-cffi-0:1.14.3-2.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-cffi-debuginfo-0:1.14.3-2.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-chardet-0:3.0.4-19.module+el8.4.0+9822+20bf1249.noarch",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-cryptography-0:3.3.1-2.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-cryptography-debuginfo-0:3.3.1-2.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-debuginfo-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-debugsource-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-devel-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-idle-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-idna-0:2.10-3.module+el8.4.0+9822+20bf1249.noarch",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-libs-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-lxml-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.x86_64",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-lxml-debuginfo-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.x86_64",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-mod_wsgi-0:4.7.1-4.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-numpy-0:1.19.4-3.module+el8.5.0+12204+54860423.x86_64",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-numpy-debuginfo-0:1.19.4-3.module+el8.5.0+12204+54860423.x86_64",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-numpy-doc-0:1.19.4-3.module+el8.5.0+12204+54860423.noarch",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-numpy-f2py-0:1.19.4-3.module+el8.5.0+12204+54860423.x86_64",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-pip-0:20.2.4-7.module+el8.6.0+13003+6bb2c488.noarch",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-pip-wheel-0:20.2.4-7.module+el8.6.0+13003+6bb2c488.noarch",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-ply-0:3.11-10.module+el8.4.0+9822+20bf1249.noarch",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-psutil-0:5.8.0-4.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-psutil-debuginfo-0:5.8.0-4.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-psycopg2-0:2.8.6-2.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-psycopg2-debuginfo-0:2.8.6-2.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-psycopg2-doc-0:2.8.6-2.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-psycopg2-tests-0:2.8.6-2.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-pycparser-0:2.20-3.module+el8.4.0+9822+20bf1249.noarch",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-pysocks-0:1.7.1-4.module+el8.4.0+9822+20bf1249.noarch",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-pyyaml-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.x86_64",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-pyyaml-debuginfo-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.x86_64",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-requests-0:2.25.0-2.module+el8.4.0+9822+20bf1249.noarch",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-rpm-macros-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.noarch",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-scipy-0:1.5.4-3.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-scipy-debuginfo-0:1.5.4-3.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-setuptools-0:50.3.2-6.module+el8.6.0+22162+859a69ec.noarch",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-setuptools-wheel-0:50.3.2-6.module+el8.6.0+22162+859a69ec.noarch",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-six-0:1.15.0-3.module+el8.4.0+9822+20bf1249.noarch",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-test-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-tkinter-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-toml-0:0.10.1-5.module+el8.4.0+9822+20bf1249.noarch",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-urllib3-0:1.25.10-4.module+el8.5.0+11712+ea2d2be1.noarch",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-wheel-1:0.35.1-4.module+el8.5.0+12204+54860423.noarch",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python39-wheel-wheel-1:0.35.1-4.module+el8.5.0+12204+54860423.noarch",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python3x-pip-0:20.2.4-7.module+el8.6.0+13003+6bb2c488.src",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python3x-setuptools-0:50.3.2-6.module+el8.6.0+22162+859a69ec.src",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:python3x-six-0:1.15.0-3.module+el8.4.0+9822+20bf1249.src",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:scipy-0:1.5.4-3.module+el8.4.0+9822+20bf1249.src",
+            "AppStream-8.6.0.Z.AUS:python39:3.9:8060020240801142753:6a631399:scipy-debugsource-0:1.5.4-3.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:PyYAML-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.src",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:PyYAML-debugsource-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.aarch64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:PyYAML-debugsource-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.ppc64le",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:PyYAML-debugsource-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.s390x",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:PyYAML-debugsource-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.x86_64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:mod_wsgi-0:4.7.1-4.module+el8.4.0+9822+20bf1249.src",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:numpy-0:1.19.4-3.module+el8.5.0+12204+54860423.src",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:numpy-debugsource-0:1.19.4-3.module+el8.5.0+12204+54860423.aarch64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:numpy-debugsource-0:1.19.4-3.module+el8.5.0+12204+54860423.ppc64le",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:numpy-debugsource-0:1.19.4-3.module+el8.5.0+12204+54860423.s390x",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:numpy-debugsource-0:1.19.4-3.module+el8.5.0+12204+54860423.x86_64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-PyMySQL-0:0.10.1-2.module+el8.4.0+9822+20bf1249.src",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-cffi-0:1.14.3-2.module+el8.4.0+9822+20bf1249.src",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-cffi-debugsource-0:1.14.3-2.module+el8.4.0+9822+20bf1249.aarch64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-cffi-debugsource-0:1.14.3-2.module+el8.4.0+9822+20bf1249.ppc64le",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-cffi-debugsource-0:1.14.3-2.module+el8.4.0+9822+20bf1249.s390x",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-cffi-debugsource-0:1.14.3-2.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-chardet-0:3.0.4-19.module+el8.4.0+9822+20bf1249.src",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-cryptography-0:3.3.1-2.module+el8.4.0+9822+20bf1249.src",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-cryptography-debugsource-0:3.3.1-2.module+el8.4.0+9822+20bf1249.aarch64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-cryptography-debugsource-0:3.3.1-2.module+el8.4.0+9822+20bf1249.ppc64le",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-cryptography-debugsource-0:3.3.1-2.module+el8.4.0+9822+20bf1249.s390x",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-cryptography-debugsource-0:3.3.1-2.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-idna-0:2.10-3.module+el8.4.0+9822+20bf1249.src",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-lxml-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.src",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-lxml-debugsource-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.aarch64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-lxml-debugsource-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.ppc64le",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-lxml-debugsource-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.s390x",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-lxml-debugsource-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.x86_64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-ply-0:3.11-10.module+el8.4.0+9822+20bf1249.src",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-psutil-0:5.8.0-4.module+el8.4.0+9822+20bf1249.src",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-psutil-debugsource-0:5.8.0-4.module+el8.4.0+9822+20bf1249.aarch64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-psutil-debugsource-0:5.8.0-4.module+el8.4.0+9822+20bf1249.ppc64le",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-psutil-debugsource-0:5.8.0-4.module+el8.4.0+9822+20bf1249.s390x",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-psutil-debugsource-0:5.8.0-4.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-psycopg2-0:2.8.6-2.module+el8.4.0+9822+20bf1249.src",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-psycopg2-debugsource-0:2.8.6-2.module+el8.4.0+9822+20bf1249.aarch64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-psycopg2-debugsource-0:2.8.6-2.module+el8.4.0+9822+20bf1249.ppc64le",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-psycopg2-debugsource-0:2.8.6-2.module+el8.4.0+9822+20bf1249.s390x",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-psycopg2-debugsource-0:2.8.6-2.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-pycparser-0:2.20-3.module+el8.4.0+9822+20bf1249.src",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-pysocks-0:1.7.1-4.module+el8.4.0+9822+20bf1249.src",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-requests-0:2.25.0-2.module+el8.4.0+9822+20bf1249.src",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-toml-0:0.10.1-5.module+el8.4.0+9822+20bf1249.src",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-urllib3-0:1.25.10-4.module+el8.5.0+11712+ea2d2be1.src",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python-wheel-1:0.35.1-4.module+el8.5.0+12204+54860423.src",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.aarch64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.ppc64le",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.s390x",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.src",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-PyMySQL-0:0.10.1-2.module+el8.4.0+9822+20bf1249.noarch",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-cffi-0:1.14.3-2.module+el8.4.0+9822+20bf1249.aarch64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-cffi-0:1.14.3-2.module+el8.4.0+9822+20bf1249.ppc64le",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-cffi-0:1.14.3-2.module+el8.4.0+9822+20bf1249.s390x",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-cffi-0:1.14.3-2.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-cffi-debuginfo-0:1.14.3-2.module+el8.4.0+9822+20bf1249.aarch64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-cffi-debuginfo-0:1.14.3-2.module+el8.4.0+9822+20bf1249.ppc64le",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-cffi-debuginfo-0:1.14.3-2.module+el8.4.0+9822+20bf1249.s390x",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-cffi-debuginfo-0:1.14.3-2.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-chardet-0:3.0.4-19.module+el8.4.0+9822+20bf1249.noarch",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-cryptography-0:3.3.1-2.module+el8.4.0+9822+20bf1249.aarch64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-cryptography-0:3.3.1-2.module+el8.4.0+9822+20bf1249.ppc64le",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-cryptography-0:3.3.1-2.module+el8.4.0+9822+20bf1249.s390x",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-cryptography-0:3.3.1-2.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-cryptography-debuginfo-0:3.3.1-2.module+el8.4.0+9822+20bf1249.aarch64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-cryptography-debuginfo-0:3.3.1-2.module+el8.4.0+9822+20bf1249.ppc64le",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-cryptography-debuginfo-0:3.3.1-2.module+el8.4.0+9822+20bf1249.s390x",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-cryptography-debuginfo-0:3.3.1-2.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-debuginfo-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.aarch64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-debuginfo-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.ppc64le",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-debuginfo-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.s390x",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-debuginfo-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-debugsource-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.aarch64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-debugsource-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.ppc64le",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-debugsource-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.s390x",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-debugsource-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-devel-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.aarch64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-devel-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.ppc64le",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-devel-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.s390x",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-devel-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-idle-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.aarch64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-idle-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.ppc64le",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-idle-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.s390x",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-idle-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-idna-0:2.10-3.module+el8.4.0+9822+20bf1249.noarch",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-libs-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.aarch64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-libs-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.ppc64le",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-libs-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.s390x",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-libs-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-lxml-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.aarch64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-lxml-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.ppc64le",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-lxml-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.s390x",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-lxml-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.x86_64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-lxml-debuginfo-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.aarch64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-lxml-debuginfo-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.ppc64le",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-lxml-debuginfo-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.s390x",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-lxml-debuginfo-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.x86_64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-mod_wsgi-0:4.7.1-4.module+el8.4.0+9822+20bf1249.aarch64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-mod_wsgi-0:4.7.1-4.module+el8.4.0+9822+20bf1249.ppc64le",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-mod_wsgi-0:4.7.1-4.module+el8.4.0+9822+20bf1249.s390x",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-mod_wsgi-0:4.7.1-4.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-numpy-0:1.19.4-3.module+el8.5.0+12204+54860423.aarch64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-numpy-0:1.19.4-3.module+el8.5.0+12204+54860423.ppc64le",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-numpy-0:1.19.4-3.module+el8.5.0+12204+54860423.s390x",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-numpy-0:1.19.4-3.module+el8.5.0+12204+54860423.x86_64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-numpy-debuginfo-0:1.19.4-3.module+el8.5.0+12204+54860423.aarch64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-numpy-debuginfo-0:1.19.4-3.module+el8.5.0+12204+54860423.ppc64le",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-numpy-debuginfo-0:1.19.4-3.module+el8.5.0+12204+54860423.s390x",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-numpy-debuginfo-0:1.19.4-3.module+el8.5.0+12204+54860423.x86_64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-numpy-doc-0:1.19.4-3.module+el8.5.0+12204+54860423.noarch",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-numpy-f2py-0:1.19.4-3.module+el8.5.0+12204+54860423.aarch64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-numpy-f2py-0:1.19.4-3.module+el8.5.0+12204+54860423.ppc64le",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-numpy-f2py-0:1.19.4-3.module+el8.5.0+12204+54860423.s390x",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-numpy-f2py-0:1.19.4-3.module+el8.5.0+12204+54860423.x86_64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-pip-0:20.2.4-7.module+el8.6.0+13003+6bb2c488.noarch",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-pip-wheel-0:20.2.4-7.module+el8.6.0+13003+6bb2c488.noarch",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-ply-0:3.11-10.module+el8.4.0+9822+20bf1249.noarch",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-psutil-0:5.8.0-4.module+el8.4.0+9822+20bf1249.aarch64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-psutil-0:5.8.0-4.module+el8.4.0+9822+20bf1249.ppc64le",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-psutil-0:5.8.0-4.module+el8.4.0+9822+20bf1249.s390x",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-psutil-0:5.8.0-4.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-psutil-debuginfo-0:5.8.0-4.module+el8.4.0+9822+20bf1249.aarch64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-psutil-debuginfo-0:5.8.0-4.module+el8.4.0+9822+20bf1249.ppc64le",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-psutil-debuginfo-0:5.8.0-4.module+el8.4.0+9822+20bf1249.s390x",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-psutil-debuginfo-0:5.8.0-4.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-psycopg2-0:2.8.6-2.module+el8.4.0+9822+20bf1249.aarch64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-psycopg2-0:2.8.6-2.module+el8.4.0+9822+20bf1249.ppc64le",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-psycopg2-0:2.8.6-2.module+el8.4.0+9822+20bf1249.s390x",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-psycopg2-0:2.8.6-2.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-psycopg2-debuginfo-0:2.8.6-2.module+el8.4.0+9822+20bf1249.aarch64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-psycopg2-debuginfo-0:2.8.6-2.module+el8.4.0+9822+20bf1249.ppc64le",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-psycopg2-debuginfo-0:2.8.6-2.module+el8.4.0+9822+20bf1249.s390x",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-psycopg2-debuginfo-0:2.8.6-2.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-psycopg2-doc-0:2.8.6-2.module+el8.4.0+9822+20bf1249.aarch64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-psycopg2-doc-0:2.8.6-2.module+el8.4.0+9822+20bf1249.ppc64le",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-psycopg2-doc-0:2.8.6-2.module+el8.4.0+9822+20bf1249.s390x",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-psycopg2-doc-0:2.8.6-2.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-psycopg2-tests-0:2.8.6-2.module+el8.4.0+9822+20bf1249.aarch64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-psycopg2-tests-0:2.8.6-2.module+el8.4.0+9822+20bf1249.ppc64le",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-psycopg2-tests-0:2.8.6-2.module+el8.4.0+9822+20bf1249.s390x",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-psycopg2-tests-0:2.8.6-2.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-pycparser-0:2.20-3.module+el8.4.0+9822+20bf1249.noarch",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-pysocks-0:1.7.1-4.module+el8.4.0+9822+20bf1249.noarch",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-pyyaml-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.aarch64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-pyyaml-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.ppc64le",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-pyyaml-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.s390x",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-pyyaml-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.x86_64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-pyyaml-debuginfo-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.aarch64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-pyyaml-debuginfo-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.ppc64le",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-pyyaml-debuginfo-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.s390x",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-pyyaml-debuginfo-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.x86_64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-requests-0:2.25.0-2.module+el8.4.0+9822+20bf1249.noarch",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-rpm-macros-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.noarch",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-scipy-0:1.5.4-3.module+el8.4.0+9822+20bf1249.aarch64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-scipy-0:1.5.4-3.module+el8.4.0+9822+20bf1249.ppc64le",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-scipy-0:1.5.4-3.module+el8.4.0+9822+20bf1249.s390x",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-scipy-0:1.5.4-3.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-scipy-debuginfo-0:1.5.4-3.module+el8.4.0+9822+20bf1249.aarch64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-scipy-debuginfo-0:1.5.4-3.module+el8.4.0+9822+20bf1249.ppc64le",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-scipy-debuginfo-0:1.5.4-3.module+el8.4.0+9822+20bf1249.s390x",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-scipy-debuginfo-0:1.5.4-3.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-setuptools-0:50.3.2-6.module+el8.6.0+22162+859a69ec.noarch",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-setuptools-wheel-0:50.3.2-6.module+el8.6.0+22162+859a69ec.noarch",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-six-0:1.15.0-3.module+el8.4.0+9822+20bf1249.noarch",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-test-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.aarch64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-test-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.ppc64le",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-test-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.s390x",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-test-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-tkinter-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.aarch64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-tkinter-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.ppc64le",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-tkinter-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.s390x",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-tkinter-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-toml-0:0.10.1-5.module+el8.4.0+9822+20bf1249.noarch",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-urllib3-0:1.25.10-4.module+el8.5.0+11712+ea2d2be1.noarch",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-wheel-1:0.35.1-4.module+el8.5.0+12204+54860423.noarch",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python39-wheel-wheel-1:0.35.1-4.module+el8.5.0+12204+54860423.noarch",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python3x-pip-0:20.2.4-7.module+el8.6.0+13003+6bb2c488.src",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python3x-setuptools-0:50.3.2-6.module+el8.6.0+22162+859a69ec.src",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:python3x-six-0:1.15.0-3.module+el8.4.0+9822+20bf1249.src",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:scipy-0:1.5.4-3.module+el8.4.0+9822+20bf1249.src",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:scipy-debugsource-0:1.5.4-3.module+el8.4.0+9822+20bf1249.aarch64",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:scipy-debugsource-0:1.5.4-3.module+el8.4.0+9822+20bf1249.ppc64le",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:scipy-debugsource-0:1.5.4-3.module+el8.4.0+9822+20bf1249.s390x",
+            "AppStream-8.6.0.Z.E4S:python39:3.9:8060020240801142753:6a631399:scipy-debugsource-0:1.5.4-3.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:PyYAML-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.src",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:PyYAML-debugsource-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.x86_64",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:mod_wsgi-0:4.7.1-4.module+el8.4.0+9822+20bf1249.src",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:numpy-0:1.19.4-3.module+el8.5.0+12204+54860423.src",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:numpy-debugsource-0:1.19.4-3.module+el8.5.0+12204+54860423.x86_64",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python-PyMySQL-0:0.10.1-2.module+el8.4.0+9822+20bf1249.src",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python-cffi-0:1.14.3-2.module+el8.4.0+9822+20bf1249.src",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python-cffi-debugsource-0:1.14.3-2.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python-chardet-0:3.0.4-19.module+el8.4.0+9822+20bf1249.src",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python-cryptography-0:3.3.1-2.module+el8.4.0+9822+20bf1249.src",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python-cryptography-debugsource-0:3.3.1-2.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python-idna-0:2.10-3.module+el8.4.0+9822+20bf1249.src",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python-lxml-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.src",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python-lxml-debugsource-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.x86_64",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python-ply-0:3.11-10.module+el8.4.0+9822+20bf1249.src",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python-psutil-0:5.8.0-4.module+el8.4.0+9822+20bf1249.src",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python-psutil-debugsource-0:5.8.0-4.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python-psycopg2-0:2.8.6-2.module+el8.4.0+9822+20bf1249.src",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python-psycopg2-debugsource-0:2.8.6-2.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python-pycparser-0:2.20-3.module+el8.4.0+9822+20bf1249.src",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python-pysocks-0:1.7.1-4.module+el8.4.0+9822+20bf1249.src",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python-requests-0:2.25.0-2.module+el8.4.0+9822+20bf1249.src",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python-toml-0:0.10.1-5.module+el8.4.0+9822+20bf1249.src",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python-urllib3-0:1.25.10-4.module+el8.5.0+11712+ea2d2be1.src",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python-wheel-1:0.35.1-4.module+el8.5.0+12204+54860423.src",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.src",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-PyMySQL-0:0.10.1-2.module+el8.4.0+9822+20bf1249.noarch",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-cffi-0:1.14.3-2.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-cffi-debuginfo-0:1.14.3-2.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-chardet-0:3.0.4-19.module+el8.4.0+9822+20bf1249.noarch",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-cryptography-0:3.3.1-2.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-cryptography-debuginfo-0:3.3.1-2.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-debuginfo-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-debugsource-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-devel-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-idle-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-idna-0:2.10-3.module+el8.4.0+9822+20bf1249.noarch",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-libs-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-lxml-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.x86_64",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-lxml-debuginfo-0:4.6.5-1.module+el8.6.0+13933+9cf0c87c.x86_64",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-mod_wsgi-0:4.7.1-4.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-numpy-0:1.19.4-3.module+el8.5.0+12204+54860423.x86_64",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-numpy-debuginfo-0:1.19.4-3.module+el8.5.0+12204+54860423.x86_64",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-numpy-doc-0:1.19.4-3.module+el8.5.0+12204+54860423.noarch",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-numpy-f2py-0:1.19.4-3.module+el8.5.0+12204+54860423.x86_64",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-pip-0:20.2.4-7.module+el8.6.0+13003+6bb2c488.noarch",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-pip-wheel-0:20.2.4-7.module+el8.6.0+13003+6bb2c488.noarch",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-ply-0:3.11-10.module+el8.4.0+9822+20bf1249.noarch",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-psutil-0:5.8.0-4.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-psutil-debuginfo-0:5.8.0-4.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-psycopg2-0:2.8.6-2.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-psycopg2-debuginfo-0:2.8.6-2.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-psycopg2-doc-0:2.8.6-2.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-psycopg2-tests-0:2.8.6-2.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-pycparser-0:2.20-3.module+el8.4.0+9822+20bf1249.noarch",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-pysocks-0:1.7.1-4.module+el8.4.0+9822+20bf1249.noarch",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-pyyaml-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.x86_64",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-pyyaml-debuginfo-0:5.4.1-1.module+el8.5.0+10613+59a13ec4.x86_64",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-requests-0:2.25.0-2.module+el8.4.0+9822+20bf1249.noarch",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-rpm-macros-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.noarch",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-scipy-0:1.5.4-3.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-scipy-debuginfo-0:1.5.4-3.module+el8.4.0+9822+20bf1249.x86_64",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-setuptools-0:50.3.2-6.module+el8.6.0+22162+859a69ec.noarch",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-setuptools-wheel-0:50.3.2-6.module+el8.6.0+22162+859a69ec.noarch",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-six-0:1.15.0-3.module+el8.4.0+9822+20bf1249.noarch",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-test-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-tkinter-0:3.9.7-2.module+el8.6.0+20026+579726f4.2.x86_64",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-toml-0:0.10.1-5.module+el8.4.0+9822+20bf1249.noarch",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-urllib3-0:1.25.10-4.module+el8.5.0+11712+ea2d2be1.noarch",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-wheel-1:0.35.1-4.module+el8.5.0+12204+54860423.noarch",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python39-wheel-wheel-1:0.35.1-4.module+el8.5.0+12204+54860423.noarch",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python3x-pip-0:20.2.4-7.module+el8.6.0+13003+6bb2c488.src",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python3x-setuptools-0:50.3.2-6.module+el8.6.0+22162+859a69ec.src",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:python3x-six-0:1.15.0-3.module+el8.4.0+9822+20bf1249.src",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:scipy-0:1.5.4-3.module+el8.4.0+9822+20bf1249.src",
+            "AppStream-8.6.0.Z.TUS:python39:3.9:8060020240801142753:6a631399:scipy-debugsource-0:1.5.4-3.module+el8.4.0+9822+20bf1249.x86_64"
+          ]
+        }
+      ],
+      "threats": [
+        {
+          "category": "impact",
+          "details": "Important"
+        }
+      ],
+      "title": "pypa/setuptools: Remote code execution via download functions in the package_index module in pypa/setuptools"
+    }
+  ]
+}


### PR DESCRIPTION
Sometimes RPMs are packed in a module. It's a little harder to detect the actual modules themselves on a running system, but we can still check their RPMs. This change allows skipping modules, but keeps their RPM children.