### PR TITLE
feat: add dedicated header for ecosystems table

### DIFF
--- a/docs/schema.md
+++ b/docs/schema.md
@@ -681,6 +681,8 @@ versions and different potential vulnerabilities:
 {"ecosystem": "PyPI", "name": "zlib"}
 ```
 
+#### Defined ecosystems
+
 <!-- Please keep this list alphabetically sorted -->
 The defined ecosystems are:
 


### PR DESCRIPTION
The table is pretty important but currently you can't actually link directly to it, so this adds a header for that