### PR TITLE
fix: add missing `GIT` reference constant

### DIFF
--- a/bindings/go/osvschema/constants.go
+++ b/bindings/go/osvschema/constants.go
@@ -64,6 +64,7 @@ const (
 	ReferenceReport     ReferenceType = "REPORT"
 	ReferenceFix        ReferenceType = "FIX"
 	ReferenceIntroduced ReferenceType = "INTRODUCED"
+	ReferenceGit        ReferenceType = "GIT"
 	ReferencePackage    ReferenceType = "PACKAGE"
 	ReferenceEvidence   ReferenceType = "EVIDENCE"
 	ReferenceWeb        ReferenceType = "WEB"


### PR DESCRIPTION
This is defined in the schema but we don't have a constant for it