### PR TITLE
Clarify sentence about "last_affected" and "fixed" in docs.

### DIFF
--- a/docs/schema.md
+++ b/docs/schema.md
@@ -1058,7 +1058,7 @@ Only **a single type** (either `introduced`, `fixed`, `last_affected`,
 `limit`) is allowed in each event object. For instance,
 `{"introduced": "1.0.0", "fixed": "1.0.2"}` is **invalid**.
 
-An events array can have entries containing either "last_affected" or "fixed" events, 
+Entries in the `events` array may be "last_affected" or "fixed" events, 
 but not both. It's **strongly recommended** to use `fixed` instead of
 `last_affected` where possible, as it precisely identifies the version which
 contains the fix. `last_affected` should be thought of as the hard ceiling


### PR DESCRIPTION
From the docs:

> Entries in the events array can contain either "last_affected" or "fixed" events, but not both.

This line could be referring to either of these events arrays:

``` json
{
  "events": [
    {"introduced": "0.0.0"},
    {"last_affected": "1.0.0", "fixed": "1.0.1"}
  ]
}
```

``` json
{
  "events": [
    {"introduced": "0.0.0"},
    {"last_affected": "1.0.0"},
    {"fixed": "1.0.1"}
  ]
}
```

The first one is invalid because it has an Object that contains two entries, but that is covered by this line from the docs:

> Only a single type (either introduced, fixed, last_affected, limit) is allowed in each event object.

And according to this comment I think the **latter** invalid case is the one that is being referred to: https://github.com/ossf/osv-schema/issues/146#issuecomment-1495436723

So I suggest changing the wording to be more specific:

> An events array can have entries containing either "last_affected" or "fixed" events, but not both.

