### PR TITLE
swich CSAF type from csaf_vex to csaf_security_advisory

### DIFF
--- a/tools/redhat/redhat_osv/csaf.py
+++ b/tools/redhat/redhat_osv/csaf.py
@@ -163,9 +163,9 @@ class CSAF:
         }
 
         # Only support csaf_vex 2.0
-        if self.csaf != {"type": "csaf_vex", "csaf_version": "2.0"}:
+        if self.csaf != {"type": "csaf_security_advisory", "csaf_version": "2.0"}:
             raise ValueError(
-                f"Can only handle csaf_vex 2.0 documents. Got: {self.csaf}")
+                f"Can only handle csaf_security_advisory 2.0 documents. Got: {self.csaf}")
 
         self.cpes, self.purls = build_product_maps(csaf_data["product_tree"])
 

--- a/tools/redhat/testdata/CSAF/rhsa-2003_315.json
+++ b/tools/redhat/testdata/CSAF/rhsa-2003_315.json
@@ -4,7 +4,7 @@
       "namespace": "https://access.redhat.com/security/updates/classification/",
       "text": "Low"
     },
-    "category": "csaf_vex",
+    "category": "csaf_security_advisory",
     "csaf_version": "2.0",
     "distribution": {
       "text": "Copyright © Red Hat, Inc. All rights reserved.",

--- a/tools/redhat/testdata/CSAF/rhsa-2015_0008.json
+++ b/tools/redhat/testdata/CSAF/rhsa-2015_0008.json
@@ -4,7 +4,7 @@
       "namespace": "https://access.redhat.com/security/updates/classification/",
       "text": "Low"
     },
-    "category": "csaf_vex",
+    "category": "csaf_security_advisory",
     "csaf_version": "2.0",
     "distribution": {
       "text": "Copyright © Red Hat, Inc. All rights reserved.",

--- a/tools/redhat/testdata/CSAF/rhsa-2024_4546.json
+++ b/tools/redhat/testdata/CSAF/rhsa-2024_4546.json
@@ -4,7 +4,7 @@
       "namespace": "https://access.redhat.com/security/updates/classification/",
       "text": "Important"
     },
-    "category": "csaf_vex",
+    "category": "csaf_security_advisory",
     "csaf_version": "2.0",
     "distribution": {
       "text": "Copyright © Red Hat, Inc. All rights reserved.",

--- a/tools/redhat/testdata/CSAF/rhsa-2024_6220.json
+++ b/tools/redhat/testdata/CSAF/rhsa-2024_6220.json
@@ -4,7 +4,7 @@
       "namespace": "https://access.redhat.com/security/updates/classification/",
       "text": "Important"
     },
-    "category": "csaf_vex",
+    "category": "csaf_security_advisory",
     "csaf_version": "2.0",
     "distribution": {
       "text": "Copyright © Red Hat, Inc. All rights reserved.",


### PR DESCRIPTION
Red Hat changed the document.category on 31st Oct. Therefore any records since then have not been processed. 

See https://access.redhat.com/articles/5554431