### PR TITLE
fix(linter): handle ecosystem allowlist correctly

### DIFF
--- a/tools/osv-linter/internal/checks/packages.go
+++ b/tools/osv-linter/internal/checks/packages.go
@@ -41,7 +41,7 @@ func PackageExists(json *gjson.Result, config *Config) (findings []CheckError) {
 		// e.g. "Alpine:v3.5" -> "Alpine"
 		ecosystem := strings.Split(value.Get("package.ecosystem").String(), ":")[0]
 		// Use config.Ecosystems as an allowlist, if it is set.
-		if config.Ecosystems != nil && !slices.Contains(config.Ecosystems, ecosystem) {
+		if len(config.Ecosystems) > 0 && !slices.Contains(config.Ecosystems, ecosystem) {
 			return true // keep iterating (over affected entries)
 		}
 		pkg := value.Get("package.name").String()

--- a/tools/osv-linter/internal/checks/packages_test.go
+++ b/tools/osv-linter/internal/checks/packages_test.go
@@ -1,0 +1,36 @@
+package checks
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/tidwall/gjson"
+)
+
+func TestPackageExists(t *testing.T) {
+	type args struct {
+		json   *gjson.Result
+		config *Config
+	}
+	tests := []struct {
+		name         string
+		args         args
+		wantFindings []CheckError
+	}{
+		{
+			name: "A malicious PyPI package no longer existing",
+			args: args{
+				json:   LoadTestData("../../test_data/MAL-2024-10238.json"),
+				config: &Config{},
+			},
+			wantFindings: []CheckError{{Code: "", Message: "package \"123bla\" not found in \"PyPI\""}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if gotFindings := PackageExists(tt.args.json, tt.args.config); !reflect.DeepEqual(gotFindings, tt.wantFindings) {
+				t.Errorf("PackageExists() = %v, want %v", gotFindings, tt.wantFindings)
+			}
+		})
+	}
+}

--- a/tools/osv-linter/test_data/MAL-2024-10238.json
+++ b/tools/osv-linter/test_data/MAL-2024-10238.json
@@ -1,0 +1,42 @@
+{
+  "modified": "2024-10-27T13:55:45Z",
+  "published": "2024-10-27T13:55:45Z",
+  "schema_version": "1.5.0",
+  "id": "MAL-2024-10238",
+  "summary": "Malicious code in 123bla (PyPI)",
+  "details": "\n---\n_-= Per source details. Do not edit below this line.=-_\n\n## Source: ossf-package-analysis (482493bb0425cda1267f50c860740681a8c0e91958623ed8d949b9db65b2e4a9)\nThe OpenSSF Package Analysis project identified '123bla' @ 0.0.1 (pypi) as malicious.\n\nIt is considered malicious because:\n\n- The package communicates with a domain associated with malicious activity.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "PyPI",
+        "name": "123bla"
+      },
+      "versions": [
+        "0.0.1"
+      ]
+    }
+  ],
+  "credits": [
+    {
+      "name": "OpenSSF: Package Analysis",
+      "type": "FINDER",
+      "contact": [
+        "https://github.com/ossf/package-analysis",
+        "https://openssf.slack.com/channels/package_analysis"
+      ]
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "import_time": "2024-10-27T14:05:09.316165759Z",
+        "modified_time": "2024-10-27T13:55:45Z",
+        "sha256": "482493bb0425cda1267f50c860740681a8c0e91958623ed8d949b9db65b2e4a9",
+        "source": "ossf-package-analysis",
+        "versions": [
+          "0.0.1"
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
This corrects a bug where the ecosystem allowlist was not working correctly when not set, and so ecosystem checks were not being run at all.