### PR TITLE
Add Kubernetes ecosystem

### DIFF
--- a/bindings/go/osvschema/constants.go
+++ b/bindings/go/osvschema/constants.go
@@ -18,6 +18,7 @@ const (
 	EcosystemGo            Ecosystem = "Go"
 	EcosystemHackage       Ecosystem = "Hackage"
 	EcosystemHex           Ecosystem = "Hex"
+	EcosystemKubernetes    Ecosystem = "Kubernetes"
 	EcosystemLinux         Ecosystem = "Linux"
 	EcosystemMageia        Ecosystem = "Mageia"
 	EcosystemMaven         Ecosystem = "Maven"

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -8,7 +8,7 @@ aside:
 show_edit_on_github: true
 ---
 
-**Version 1.6.7 (Sep 16, 2024)**
+**Version 1.6.8 (Dec 4, 2024)**
 
 Original authors:
 - Oliver Chang (ochang@google.com)
@@ -285,6 +285,17 @@ The defined database prefixes and their "home" databases are:
           <li>How to contribute: <a href="https://github.com/haskell/security-advisories/blob/main/CONTRIBUTING.md">https://github.com/haskell/security-advisories/blob/main/CONTRIBUTING.md</a></li>
           <li>Source URL: <code>TBD</code></li>
           <li>OSV Formatted URL: <code>https://raw.githubusercontent.com/haskell/security-advisories/main/advisories/&lt;ID&gt;.json</code></li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
+      <td><code>KUBE</code></td>
+      <td><a href="https://github.com/kubernetes-sigs/cve-feed-osv">Kubernetes Official CVE Feed</a></td>
+      <td>
+        <ul>
+          <li>How to contribute: <a href="https://github.com/kubernetes-sigs/cve-feed-osv/blob/main/CONTRIBUTING.md">https://github.com/kubernetes-sigs/cve-feed-osv/blob/main/CONTRIBUTING.md</a></li>
+          <li>Source URL: <code>https://kubernetes.io/docs/reference/issues-security/official-cve-feed/index.json</code></li>
+          <li>OSV Formatted URL: <code>https://raw.githubusercontent.com/kubernetes-sigs/cve-feed-osv/blob/main/vulns/&lt;ID&gt;.json</code></li>
         </ul>
       </td>
     </tr>
@@ -706,6 +717,7 @@ The defined ecosystems are:
 | `Go` | The Go ecosystem; the `name` field is a Go module path. |
 | `Hackage` | The Haskell package ecosystem. The `name` field is a Haskell package name as published on Hackage. |
 | `Hex` | The package manager for the Erlang ecosystem; the `name` is a Hex package name. |
+| `Kubernetes` | The Kubernetes ecosystem; the `name` field is a Kubernetes component name. |
 | `Linux` | The Linux kernel. The only supported `name` is `Kernel`. |
 | `Mageia` | The Mageia Linux package ecosystem; the `name` is the name of the source package. The ecosystem string must have a `:<RELEASE-NUMBER>` suffix to scope the package to a particular Mageia release. Eg `Mageia:9`. |
 | `Maven` | The Maven Java package ecosystem. The `name` field is a Maven package name in the format `groupId:artifactId`. The ecosystem string might optionally have a `:<REMOTE-REPO-URL>` suffix to denote the remote repository URL that best represents the source of truth for this package, without a trailing slash (e.g. `Maven:https://maven.google.com`). If this is omitted, this is assumed to be the Maven Central repository (`https://repo.maven.apache.org/maven2`). |

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -717,7 +717,7 @@ The defined ecosystems are:
 | `Go` | The Go ecosystem; the `name` field is a Go module path. |
 | `Hackage` | The Haskell package ecosystem. The `name` field is a Haskell package name as published on Hackage. |
 | `Hex` | The package manager for the Erlang ecosystem; the `name` is a Hex package name. |
-| `Kubernetes` | The Kubernetes ecosystem; If the component is a Go module, then the `name` filed is the Go module name. |
+| `Kubernetes` | The Kubernetes ecosystem; `name` is the Go module name associated with the relevant Kubernetes component (e.g. `k8s.io/apiserver`) |
 | `Linux` | The Linux kernel. The only supported `name` is `Kernel`. |
 | `Mageia` | The Mageia Linux package ecosystem; the `name` is the name of the source package. The ecosystem string must have a `:<RELEASE-NUMBER>` suffix to scope the package to a particular Mageia release. Eg `Mageia:9`. |
 | `Maven` | The Maven Java package ecosystem. The `name` field is a Maven package name in the format `groupId:artifactId`. The ecosystem string might optionally have a `:<REMOTE-REPO-URL>` suffix to denote the remote repository URL that best represents the source of truth for this package, without a trailing slash (e.g. `Maven:https://maven.google.com`). If this is omitted, this is assumed to be the Maven Central repository (`https://repo.maven.apache.org/maven2`). |

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -717,7 +717,7 @@ The defined ecosystems are:
 | `Go` | The Go ecosystem; the `name` field is a Go module path. |
 | `Hackage` | The Haskell package ecosystem. The `name` field is a Haskell package name as published on Hackage. |
 | `Hex` | The package manager for the Erlang ecosystem; the `name` is a Hex package name. |
-| `Kubernetes` | The Kubernetes ecosystem; the `name` field is a Kubernetes component name. |
+| `Kubernetes` | The Kubernetes ecosystem; If the component is a Go module, then the `name` filed is the Go module name. |
 | `Linux` | The Linux kernel. The only supported `name` is `Kernel`. |
 | `Mageia` | The Mageia Linux package ecosystem; the `name` is the name of the source package. The ecosystem string must have a `:<RELEASE-NUMBER>` suffix to scope the package to a particular Mageia release. Eg `Mageia:9`. |
 | `Maven` | The Maven Java package ecosystem. The `name` field is a Maven package name in the format `groupId:artifactId`. The ecosystem string might optionally have a `:<REMOTE-REPO-URL>` suffix to denote the remote repository URL that best represents the source of truth for this package, without a trailing slash (e.g. `Maven:https://maven.google.com`). If this is omitted, this is assumed to be the Maven Central repository (`https://repo.maven.apache.org/maven2`). |

--- a/ecosystems.json
+++ b/ecosystems.json
@@ -14,6 +14,7 @@
   "Go": "The Go ecosystem; the `name` field is a Go module path.",
   "Hackage": "The Haskell package ecosystem. The `name` field is a Haskell package name as published on Hackage.",
   "Hex": "The package manager for the Erlang ecosystem; the `name` is a Hex package name.",
+  "Kubernetes": "The Kubernetes ecosystem; `name` is the Go module name associated with the relevant Kubernetes component (e.g. `k8s.io/apiserver`)",
   "Linux": "The Linux kernel. The only supported `name` is `Kernel`.",
   "Mageia": "The Mageia Linux package ecosystem; the `name` is the name of the source package. The ecosystem string must have a `:<RELEASE-NUMBER>` suffix to scope the package to a particular Mageia release. Eg `Mageia:9`.",
   "Maven": "The Maven Java package ecosystem. The `name` field is a Maven package name in the format `groupId:artifactId`. The ecosystem string might optionally have a `:<REMOTE-REPO-URL>` suffix to denote the remote repository URL that best represents the source of truth for this package, without a trailing slash (e.g. `Maven:https://maven.google.com`). If this is omitted, this is assumed to be the Maven Central repository (`https://repo.maven.apache.org/maven2`).",

--- a/tools/osv-linter/internal/pkgchecker/ecosystems.go
+++ b/tools/osv-linter/internal/pkgchecker/ecosystems.go
@@ -55,6 +55,8 @@ func ExistsInEcosystem(pkg string, ecosystem string) bool {
 		return true
 	case "Hex":
 		return true
+	case "Kubernetes":
+		return true
 	case "Linux":
 		return true
 	case "Maven":

--- a/validation/schema.json
+++ b/validation/schema.json
@@ -316,6 +316,7 @@
         "Go",
         "Hackage",
         "Hex",
+        "Kubernetes",
         "Linux",
         "Mageia",
         "Maven",
@@ -350,7 +351,7 @@
       "type": "string",
       "title": "Currently supported home database identifier prefixes",
       "description": "These home databases are also documented at https://ossf.github.io/osv-schema/#id-modified-fields",
-      "pattern": "^(ASB-A|PUB-A|ALSA|ALBA|ALEA|BIT|CGA|CURL|CVE|DSA|DLA|ELA|DTSA|GHSA|GO|GSD|HSEC|LBSEC|MAL|OSV|openSUSE-SU|PHSA|PSF|PYSEC|RHBA|RHEA|RHSA|RLSA|RXSA|RSEC|RUSTSEC|SUSE-[SRFO]U|UBUNTU|USN)-"
+      "pattern": "^(ASB-A|PUB-A|ALSA|ALBA|ALEA|BIT|CGA|CURL|CVE|DSA|DLA|ELA|DTSA|GHSA|GO|GSD|HSEC|KUBE|LBSEC|MAL|OSV|openSUSE-SU|PHSA|PSF|PYSEC|RHBA|RHEA|RHSA|RLSA|RXSA|RSEC|RUSTSEC|SUSE-[SRFO]U|UBUNTU|USN)-"
     },
     "severity": {
       "type": [

--- a/validation/schema.json
+++ b/validation/schema.json
@@ -345,7 +345,7 @@
       "type": "string",
       "title": "Currently supported ecosystems",
       "description": "These ecosystems are also documented at https://ossf.github.io/osv-schema/#affectedpackage-field",
-      "pattern": "^(AlmaLinux|Alpine|Android|Bioconductor|Bitnami|Chainguard|ConanCenter|CRAN|crates\\.io|Debian|GHC|GitHub Actions|Go|Hackage|Hex|Linux|Mageia|Maven|npm|NuGet|openSUSE|OSS-Fuzz|Packagist|Photon OS|Pub|PyPI|Red Hat|Rocky Linux|RubyGems|SUSE|SwiftURL|Ubuntu|Wolfi|GIT)(:.+)?$"
+      "pattern": "^(AlmaLinux|Alpine|Android|Bioconductor|Bitnami|Chainguard|ConanCenter|CRAN|crates\\.io|Debian|GHC|GitHub Actions|Go|Hackage|Hex|Kubernetes|Linux|Mageia|Maven|npm|NuGet|openSUSE|OSS-Fuzz|Packagist|Photon OS|Pub|PyPI|Red Hat|Rocky Linux|RubyGems|SUSE|SwiftURL|Ubuntu|Wolfi|GIT)(:.+)?$"
     },
     "prefix": {
       "type": "string",


### PR DESCRIPTION
Adding `Kubernetes` ecosystem according to the discussion [here](https://github.com/kubernetes-sigs/cve-feed-osv/issues/9).

This PR does not specify how to handle Kubernetes distributions by cloud vendors like EKS and GKE. We can talk about it here if needed, or merge it once and discuss it separately.