### PR TITLE
Update JSON schema to reflect top-level/package severities mutual exclusivity

### DIFF
--- a/validation/schema.json
+++ b/validation/schema.json
@@ -295,6 +295,26 @@
     "id",
     "modified"
   ],
+  "allOf": [
+    {
+      "if": {
+        "required": ["severity"]
+      },
+      "then": {
+        "properties": {
+          "affected": {
+            "items": {
+              "properties": {
+                "severity": {
+                  "type": "null"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  ],
   "$defs": {
     "ecosystemName": {
       "type": "string",

--- a/validation/schema.json
+++ b/validation/schema.json
@@ -298,7 +298,9 @@
   "allOf": [
     {
       "if": {
-        "required": ["severity"]
+        "required": [
+          "severity"
+        ]
       },
       "then": {
         "properties": {


### PR DESCRIPTION
`affected[].severity` mentions:

 'If any package level severity fields are set,
 the top level severity must not be set.'

This change updates the JSON schema under validation to reflect this.

Changes have been tested with both tools mentioned under validation/README.md