### PR TITLE
fix(jsonschema): add upstream field to schema definition

### DIFF
--- a/validation/schema.json
+++ b/validation/schema.json
@@ -35,6 +35,12 @@
         "type": "string"
       }
     },
+    "upstream": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
     "summary": {
       "type": "string"
     },


### PR DESCRIPTION
This commit adds the `upstream` field to the schema definition. It was omitted from #312