### PR TITLE
Add V8 prefix.

### DIFF
--- a/docs/schema.md
+++ b/docs/schema.md
@@ -455,6 +455,17 @@ The defined database prefixes and their "home" databases are:
       </td>
     </tr>
     <tr>
+      <td><code>V8</code></td>
+      <td><a href="https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/security/updates.md">V8/Chromium Time-Based Policy</a></td>
+      <td>
+        <ul>
+          <li>How to contribute: <a href="https://github.com/google/chromium-policy-vulnfeed/tree/main?tab=readme-ov-file#chromium-policy-vulnfeed">https://github.com/google/chromium-policy-vulnfeed/tree/main?tab=readme-ov-file#chromium-policy-vulnfeed</a></li>
+          <li>Source URL: <code>https://github.com/google/chromium-policy-vulnfeed/blob/main/advisories/V8-advisory.json</code></li>
+          <li>OSV Formatted URL: <code>https://github.com/google/chromium-policy-vulnfeed/blob/main/advisories/V8-advisory.json</code></li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
       <td>Your database here</td>
       <td colspan="2"><a href="https://github.com/ossf/osv-schema/compare">Send us a PR</a></td>
     </tr>

--- a/validation/schema.json
+++ b/validation/schema.json
@@ -379,8 +379,7 @@
       "type": "string",
       "title": "Currently supported home database identifier prefixes",
       "description": "These home databases are also documented at https://ossf.github.io/osv-schema/#id-modified-fields",
-      "pattern": "^(ASB-A|PUB-A|ALSA|ALBA|ALEA|BIT|CGA|CURL|CVE|DSA|DLA|ELA|DTSA|GHSA|GO|GSD|HSEC|KUBE|LBSEC|MAL|MGASA|OSV|openSUSE-SU|PHSA|PSF|PYSEC|RHBA|RHEA|RHSA|RLSA|RXSA|RSEC|RUSTSEC|SUSE-[SRFO]U|UBUNTU|USN)-"
-    },
+      "pattern": "^(ASB-A|PUB-A|ALSA|ALBA|ALEA|BIT|CGA|CURL|CVE|DSA|DLA|ELA|DTSA|GHSA|GO|GSD|HSEC|KUBE|LBSEC|MAL|MGASA|OSV|openSUSE-SU|PHSA|PSF|PYSEC|RHBA|RHEA|RHSA|RLSA|RXSA|RSEC|RUSTSEC|SUSE-[SRFO]U|UBUNTU|USN|V8)-"    },
     "severity": {
       "type": [
         "array",


### PR DESCRIPTION
### Add V8 prefix to OSV-schema.
As per internal discussions, we are adding the "V8" prefix for policy-based synthetic vulnerability feeds to OSV schema.
The Chromium team has a [policy](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/security/updates.md) that states that direct embedders of Chromium packages such as V8 are responsible for using an up-to-date version of V8 packages. The definition of that is that the V8 package is at most one week old.

Since these types of packages do not have their own identifiers and therefore no advisory could be created, enforcement of such policies was not possible. We now created a synthetic advisory generator that takes such time-based policies and converts them into regularily updated advisories that OSV can read:
https://github.com/google/chromium-policy-vulnfeed/blob/main/advisories/V8-advisory.json

Refer to @oliverchang for context.