### PR TITLE
Fix typo in error message.

### DIFF
--- a/tools/osv-linter/internal/checks/record.go
+++ b/tools/osv-linter/internal/checks/record.go
@@ -15,7 +15,7 @@ var CheckRecordHasAffected = &CheckDef{
 func RecordHasAffected(json *gjson.Result, config *Config) (findings []CheckError) {
 	affectedEntries := json.Get("affected")
 	if !affectedEntries.Exists() || affectedEntries.String() == "[]" {
-		findings = append(findings, CheckError{Message: "Invalid Affected: affected filed cannot be null or empty"})
+		findings = append(findings, CheckError{Message: "Invalid Affected: affected field cannot be null or empty"})
 	}
 	return findings
 }

--- a/tools/osv-linter/internal/checks/record_test.go
+++ b/tools/osv-linter/internal/checks/record_test.go
@@ -30,14 +30,14 @@ func TestAffectedField(t *testing.T) {
 			args: args{
 				json: LoadTestData("../../test_data/SUSE-FU-2022:0444-1.json"),
 			},
-			wantFindings: []CheckError{{Message: "Invalid Affected: affected filed cannot be null or empty"}},
+			wantFindings: []CheckError{{Message: "Invalid Affected: affected field cannot be null or empty"}},
 		},
 		{
 			name: "A file without affected field",
 			args: args{
 				json: LoadTestData("../../test_data/RHSA-2022:0216.json"),
 			},
-			wantFindings: []CheckError{{Message: "Invalid Affected: affected filed cannot be null or empty"}},
+			wantFindings: []CheckError{{Message: "Invalid Affected: affected field cannot be null or empty"}},
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
Fix a confusing typo from "affected filed" to "affected field".

