### PR TITLE
ci(workflow): pin actions to their commit hashes

### DIFF
--- a/.github/workflows/validate-schema.yml
+++ b/.github/workflows/validate-schema.yml
@@ -19,16 +19,16 @@ jobs:
       contents: read
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Check for changes to OSV Schema
         id: check-for-changed-osv-schema
-        uses: tj-actions/changed-files@v45
+        uses: tj-actions/changed-files@2f7c5bfce28377bc069a65ba478de0a74aa0ca32 # v46.0.1
         with:
           files: |
             validation/schema.json
       - name: Validate OSV Schema
         if: steps.check-for-changed-osv-schema.outputs.any_changed == 'true'
-        uses: dsanders11/json-schema-validate-action@v1.2.0
+        uses: dsanders11/json-schema-validate-action@ec60131eddf6f51ed0c737fdcd28616ae1a0e564 # v1.2.0
         with:
           # https://github.com/marketplace/actions/json-schema-validate#validating-schema
           schema: json-schema


### PR DESCRIPTION
This pins the actions to their equivalent commit hashes to avoid disappointment like that seen for `tj-actions/changed-files` (that we managed to avoid being impacted by)
Signed-off-by: Andrew Pollock <apollock@google.com>