### PR TITLE
tools: Update redhat csaf2osv conversion to support upstream field + tests

### DIFF
--- a/tools/redhat/redhat_osv/osv.py
+++ b/tools/redhat/redhat_osv/osv.py
@@ -8,7 +8,7 @@ from jsonschema import validate
 from redhat_osv.csaf import Remediation, CSAF
 
 # Update this if verified against a later version
-SCHEMA_VERSION = "1.6.7"
+SCHEMA_VERSION = "1.7.0"
 # This assumes the datetime being formatted is in UTC
 DATE_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
 # Go package advisory reference prefix
@@ -130,6 +130,7 @@ class OSV:
         # This attribute is declared after id to make the resulting JSON human-readable. It can only
         # be populated after reading the csaf vulnerabilities and references sections.
         self.related: list[str] = []
+        self.upstream: list[str] = []
 
         if published:
             self.published = published
@@ -159,7 +160,7 @@ class OSV:
         unique_packages: dict[str: tuple[str: str]] = {}
 
         for vulnerability in csaf_data.vulnerabilities:
-            self.related.append(vulnerability.cve_id)
+            self.upstream.append(vulnerability.cve_id)
             for remediation in vulnerability.remediations:
                 # Safety check for when we start processing non-rpm content
                 if not remediation.purl.startswith("pkg:rpm/"):

--- a/tools/redhat/testdata/OSV/RHSA-2024_4546.json
+++ b/tools/redhat/testdata/OSV/RHSA-2024_4546.json
@@ -1,9 +1,11 @@
 {
-  "schema_version": "1.6.7",
+  "schema_version": "1.7.0",
   "id": "RHSA-2024:4546",
   "related": [
-    "CVE-2023-45288",
     "GO-2024-2687"
+  ],
+  "upstream": [
+    "CVE-2023-45288"
   ],
   "published": "2024-09-02T14:30:00Z",
   "modified": "2024-09-02T14:30:00Z",

--- a/tools/redhat/testdata/OSV/RHSA-2024_6220.json
+++ b/tools/redhat/testdata/OSV/RHSA-2024_6220.json
@@ -1,7 +1,8 @@
 {
-  "schema_version": "1.6.7",
+  "schema_version": "1.7.0",
   "id": "RHSA-2024:6220",
-  "related": [
+  "related": [],
+  "upstream": [
     "CVE-2024-6345"
   ],
   "published": "2024-09-02T14:30:00Z",


### PR DESCRIPTION
CVE upstream has moved from `related` to `upstream` to support https://github.com/ossf/osv-schema/pull/312 schema change. 

The `GO` vuln alias (for the CVE entry) has been left in related, so as not to affect the computation on the OSV.dev hierarchy display side. 

Tests updated to the latest schema version as well. 