### PR TITLE
fix: update npm package existence test

### DIFF
--- a/tools/osv-linter/internal/pkgchecker/package_check_test.go
+++ b/tools/osv-linter/internal/pkgchecker/package_check_test.go
@@ -43,12 +43,12 @@ func Test_existsInNpm(t *testing.T) {
 	}{
 		{
 			name: "existing package",
-			pkg:  "proxyapi-docs",
+			pkg:  "ip",
 			want: true,
 		},
 		{
 			name: "existing package with a special name",
-			pkg:  "@saferpay/components",
+			pkg:  "@posthog/plugin-server",
 			want: true,
 		},
 		{


### PR DESCRIPTION
Some npm packages have been removed from upstream, causing test failures. Replace these packages with others.