### PR TITLE
feat(osv-linter): add checks for upstream and aliases fields

### DIFF
--- a/tools/osv-linter/README.md
+++ b/tools/osv-linter/README.md
@@ -38,9 +38,9 @@ OPTIONS:
 ```text
 $ go run ./cmd/osv record lint test_data
 test_data/nointroduced-CVE-2023-41045.json:
-         * [R0001]: missing 'introduced' object in event
+         * [RNG:001]: missing 'introduced' object in event
 test_data/nondistinct-CVE-2018-5407.json:
-         * [R0002]: overlapping event: "e818b74be2170fbe957a07b0da4401c2b694b3b8"
+         * [RNG:002]: overlapping event: "e818b74be2170fbe957a07b0da4401c2b694b3b8"
 2024/10/22 00:04:23 found errors
 exit status 1
 ```
@@ -49,12 +49,15 @@ exit status 1
 $ go run ./cmd/osv/ record lint --checks list
 Available checks:
 
-A0001: (affected-data-exists): every record has affected data
-R0001: (introduced-event-exists): every range has an introduced event
-R0002: (range-is-distinct): range spans multiple versions/commits
-P0001: (package-exists): package exists in ecosystem's registry
-P0002: (package-versions-exist): package versions exist in ecosystem's registry
-P0003: (package-purl-valid): package purl validates
+REC:001: (affected-data-exists): every record has affected data
+REC:002: (valid-aliases): aliases field validates
+REC:003: (valid-upstream): upstream field validates
+REC:004: (valid-related): related field validates
+RNG:001: (introduced-event-exists): every range has an introduced event
+RNG:002: (range-is-distinct): range spans multiple versions/commits
+PKG:001: (package-exists): package exists in ecosystem's registry
+PKG:002: (package-versions-exist): package versions exist in ecosystem's registry
+PKG:003: (package-purl-valid): package purl validates
 ```
 
 ```text
@@ -62,17 +65,28 @@ $ go run ./cmd/osv/ record lint --collection list
 Available check collections:
 
 ALL: all checks currently defined
-        A0001: (affected-data-exists): every record has affected data
-        R0001: (introduced-event-exists): every range has an introduced event
-        R0002: (range-is-distinct): range spans multiple versions/commits
-        P0001: (package-exists): package exists in ecosystem's registry
-        P0002: (package-versions-exist): package versions exist in ecosystem's registry
-        P0003: (package-purl-valid): package purl validates
-offline: checks that do not have remote data dependencies
-        A0001: (affected-data-exists): every record has affected data
-        R0001: (introduced-event-exists): every range has an introduced event
-        R0002: (range-is-distinct): range spans multiple versions/commits
-        P0003: (package-purl-valid): package purl validates
+        REC:001: (affected-data-exists): every record has affected data
+        REC:002: (valid-aliases): aliases field validates
+        REC:003: (valid-upstream): upstream field validates
+        REC:004: (valid-related): related field validates
+        RNG:001: (introduced-event-exists): every range has an introduced event
+        RNG:002: (range-is-distinct): range spans multiple versions/commits
+        PKG:001: (package-exists): package exists in ecosystem's registry
+        PKG:002: (package-versions-exist): package versions exist in ecosystem's registry
+        PKG:003: (package-purl-valid): package purl validates
+offline: Checks that do not have remote data dependencies. These can be run without network access.
+        REC:001: (affected-data-exists): every record has affected data
+        REC:002: (valid-aliases): aliases field validates
+        REC:003: (valid-upstream): upstream field validates
+        REC:004: (valid-related): related field validates
+        RNG:001: (introduced-event-exists): every range has an introduced event
+        RNG:002: (range-is-distinct): range spans multiple versions/commits
+        PKG:003: (package-purl-valid): package purl validates
+fatal: Checks considered critical. Failures indicate fundamental issues with the OSV record.
+        REC:001: (affected-data-exists): every record has affected data
+        REC:002: (valid-aliases): aliases field validates
+        REC:003: (valid-upstream): upstream field validates
+        RNG:002: (range-is-distinct): range spans multiple versions/commits
 ```
 
 ## Contributing

--- a/tools/osv-linter/cmd/osv/main.go
+++ b/tools/osv-linter/cmd/osv/main.go
@@ -21,7 +21,7 @@ func main() {
 						Name: "lint",
 						Flags: []cli.Flag{
 							&cli.BoolFlag{
-								Name: "verbose",
+								Name:  "verbose",
 								Usage: "verbose output",
 							},
 							&cli.StringFlag{
@@ -38,6 +38,10 @@ func main() {
 								Name:  "ecosystems",
 								Value: &cli.StringSlice{},
 								Usage: "the ecosystems to constrain package checks to (use 'list' to see)",
+							},
+							&cli.BoolFlag{
+								Name:  "json",
+								Usage: "output results as JSON",
 							},
 						},
 						Aliases: []string{"check"},

--- a/tools/osv-linter/internal/checks/checks.go
+++ b/tools/osv-linter/internal/checks/checks.go
@@ -41,6 +41,7 @@ type CheckDef struct {
 type Config struct {
 	Verbose    bool
 	Ecosystems []string
+	JSON       bool
 }
 
 // Check defines how to run the check.
@@ -91,22 +92,42 @@ var Collections = []CheckCollection{
 		Name:        "ALL",
 		Description: "all checks currently defined",
 		Checks: []*CheckDef{
+			// Record checks
 			CheckRecordHasAffected,
+			CheckRecordHasValidAliases,
+			CheckRecordHasValidUpstream,
+			CheckRecordHasValidRelated,
+			// Range checks
 			CheckRangeHasIntroducedEvent,
 			CheckRangeIsDistinct,
+			// Package checks
 			CheckPackageExists,
 			CheckPackageVersionsExist,
 			CheckPackagePurlValid,
 		},
 	},
 	{
-		Name:        "offline",
-		Description: "checks that do not have remote data dependencies",
+		Name: "offline",
+		Description: "Checks that do not have remote data dependencies. " +
+			"These can be run without network access.",
 		Checks: []*CheckDef{
 			CheckRecordHasAffected,
+			CheckRecordHasValidAliases,
+			CheckRecordHasValidUpstream,
+			CheckRecordHasValidRelated,
 			CheckRangeHasIntroducedEvent,
 			CheckRangeIsDistinct,
 			CheckPackagePurlValid,
+		},
+	},
+	{
+		Name:        "fatal",
+		Description: "Checks considered critical. Failures indicate fundamental issues with the OSV record.",
+		Checks: []*CheckDef{
+			CheckRecordHasAffected,
+			CheckRecordHasValidAliases,
+			CheckRecordHasValidUpstream,
+			CheckRangeIsDistinct,
 		},
 	},
 }

--- a/tools/osv-linter/internal/checks/packages.go
+++ b/tools/osv-linter/internal/checks/packages.go
@@ -11,7 +11,7 @@ import (
 )
 
 var CheckPackageExists = &CheckDef{
-	Code:        "P0001",
+	Code:        "PKG:001",
 	Name:        "package-exists",
 	Description: "package exists in ecosystem's registry",
 	Check:       PackageExists,
@@ -66,7 +66,7 @@ func PackageExists(json *gjson.Result, config *Config) (findings []CheckError) {
 }
 
 var CheckPackageVersionsExist = &CheckDef{
-	Code:        "P0002",
+	Code:        "PKG:002",
 	Name:        "package-versions-exist",
 	Description: "package versions exist in ecosystem's registry",
 	Check:       PackageVersionsExist,
@@ -137,7 +137,7 @@ func PackageVersionsExist(json *gjson.Result, config *Config) (findings []CheckE
 }
 
 var CheckPackagePurlValid = &CheckDef{
-	Code:        "P0003",
+	Code:        "PKG:003",
 	Name:        "package-purl-valid",
 	Description: "package purl validates",
 	Check:       PackagePurlValid,

--- a/tools/osv-linter/internal/checks/ranges.go
+++ b/tools/osv-linter/internal/checks/ranges.go
@@ -8,7 +8,7 @@ import (
 )
 
 var CheckRangeHasIntroducedEvent = &CheckDef{
-	Code:        "R0001",
+	Code:        "RNG:001",
 	Name:        "introduced-event-exists",
 	Description: "every range has an introduced event",
 	Check:       RangeHasIntroducedEvent,
@@ -33,7 +33,7 @@ func RangeHasIntroducedEvent(json *gjson.Result, config *Config) (findings []Che
 }
 
 var CheckRangeIsDistinct = &CheckDef{
-	Code:        "R0002",
+	Code:        "RNG:002",
 	Name:        "range-is-distinct",
 	Description: "range spans multiple versions/commits",
 	Check:       RangeIsDistinct,

--- a/tools/osv-linter/internal/checks/record.go
+++ b/tools/osv-linter/internal/checks/record.go
@@ -5,10 +5,31 @@ import (
 )
 
 var CheckRecordHasAffected = &CheckDef{
-	Code:        "A0001",
+	Code:        "REC:001",
 	Name:        "affected-data-exists",
 	Description: "every record has affected data",
 	Check:       RecordHasAffected,
+}
+
+var CheckRecordHasValidAliases = &CheckDef{
+	Code:        "REC:002",
+	Name:        "valid-aliases",
+	Description: "aliases field validates",
+	Check:       AliasesCheck,
+}
+
+var CheckRecordHasValidUpstream = &CheckDef{
+	Code:        "REC:003",
+	Name:        "valid-upstream",
+	Description: "upstream field validates",
+	Check:       UpstreamCheck,
+}
+
+var CheckRecordHasValidRelated = &CheckDef{
+	Code:        "REC:004",
+	Name:        "valid-related",
+	Description: "related field validates",
+	Check:       RelatedCheck,
 }
 
 // RecordHasAffected checks if the 'affected' field exists in the JSON and is not an empty array.
@@ -18,4 +39,115 @@ func RecordHasAffected(json *gjson.Result, config *Config) (findings []CheckErro
 		findings = append(findings, CheckError{Message: "Invalid Affected: affected field cannot be null or empty"})
 	}
 	return findings
+}
+
+func UpstreamCheck(json *gjson.Result, config *Config) (findings []CheckError) {
+	upstream := json.Get("upstream")
+	bug := json.Get("id")
+	if !upstream.Exists() {
+		return
+	}
+
+	hasDup, unique := hasDuplicate(upstream)
+	if hasDup {
+		findings = append(findings, CheckError{Message: "Invalid Upstream: upstream should not contain duplicate entries"})
+	}
+
+	if _, exists := unique[bug.String()]; exists {
+		findings = append(findings, CheckError{Message: "Invalid Upstream: upstream should not contain itself"})
+	}
+
+	aliases := json.Get("aliases")
+	if !aliases.Exists() {
+		return
+	}
+
+	hasAliases := false
+	if aliases.IsArray() {
+		for _, bug := range aliases.Array() {
+			if _, exists := unique[bug.String()]; exists {
+				hasAliases = true
+			}
+		}
+	}
+
+	if hasAliases {
+		findings = append(findings, CheckError{Message: "Invalid Upstream: upstream should not contain aliases"})
+	}
+
+	related := json.Get("related")
+	if !related.Exists() {
+		return
+	}
+
+	hasRelated := false
+	if related.IsArray() {
+		for _, bug := range related.Array() {
+			if _, exists := unique[bug.String()]; exists {
+				hasRelated = true
+			}
+		}
+	}
+
+	if hasRelated {
+		findings = append(findings, CheckError{Message: "Invalid Upstream: upstream should not contain related IDs"})
+	}
+
+	return findings
+}
+
+func AliasesCheck(json *gjson.Result, config *Config) (findings []CheckError) {
+	aliases := json.Get("aliases")
+	bug := json.Get("id")
+	if !aliases.Exists() {
+		return
+	}
+
+	hasDup, unique := hasDuplicate(aliases)
+	if hasDup {
+		findings = append(findings, CheckError{Message: "Invalid Aliases: aliases should not contain duplicate entries"})
+	}
+
+	if _, exists := unique[bug.String()]; exists {
+		findings = append(findings, CheckError{Message: "Invalid Aliases: aliases should not contain itself"})
+	}
+
+	return findings
+}
+
+func RelatedCheck(json *gjson.Result, config *Config) (findings []CheckError) {
+	related := json.Get("related")
+	bug := json.Get("id")
+	if !related.Exists() {
+		return
+	}
+
+	hasDup, unique := hasDuplicate(related)
+	if hasDup {
+		findings = append(findings, CheckError{Message: "Invalid Related: Related should not contain duplicate entries"})
+	}
+
+	if _, exists := unique[bug.String()]; exists {
+		findings = append(findings, CheckError{Message: "Invalid Related: Related should not contain itself"})
+	}
+
+	return findings
+}
+
+func hasDuplicate(json gjson.Result) (bool, map[string]bool) {
+	var bugIDs []string
+	if json.IsArray() { // Check if it's actually a JSON array
+		for _, bugResult := range json.Array() {
+			bugIDs = append(bugIDs, bugResult.String())
+		}
+	} else {
+		return false, nil
+	}
+
+	seen := make(map[string]bool)
+	for _, bugID := range bugIDs {
+		seen[bugID] = true
+	}
+
+	return len(seen) != len(bugIDs), seen
 }

--- a/tools/osv-linter/internal/checks/record_test.go
+++ b/tools/osv-linter/internal/checks/record_test.go
@@ -49,3 +49,189 @@ func TestAffectedField(t *testing.T) {
 		})
 	}
 }
+
+func TestAliasesCheck(t *testing.T) {
+	tests := []struct {
+		name         string
+		jsonData     string
+		wantFindings []CheckError
+	}{
+		{
+			name:         "Valid aliases",
+			jsonData:     `{"id": "CVE-2023-0001", "aliases": ["GHSA-xxxx-yyyy-zzzz", "CVE-2023-0002"]}`,
+			wantFindings: nil,
+		},
+		{
+			name:         "Aliases field missing",
+			jsonData:     `{"id": "CVE-2023-0001"}`,
+			wantFindings: nil,
+		},
+		{
+			name:         "Empty aliases array",
+			jsonData:     `{"id": "CVE-2023-0001", "aliases": []}`,
+			wantFindings: nil,
+		},
+		{
+			name:     "Duplicate aliases",
+			jsonData: `{"id": "CVE-2023-0001", "aliases": ["GHSA-xxxx-yyyy-zzzz", "GHSA-xxxx-yyyy-zzzz"]}`,
+			wantFindings: []CheckError{
+				{Message: "Invalid Aliases: aliases should not contain duplicate entries"},
+			},
+		},
+		{
+			name:     "Alias contains record ID",
+			jsonData: `{"id": "CVE-2023-0001", "aliases": ["CVE-2023-0001", "GHSA-xxxx-yyyy-zzzz"]}`,
+			wantFindings: []CheckError{
+				{Message: "Invalid Aliases: aliases should not contain itself"},
+			},
+		},
+		{
+			name:     "Duplicate aliases and contains record ID",
+			jsonData: `{"id": "CVE-2023-0001", "aliases": ["CVE-2023-0001", "CVE-2023-0001"]}`,
+			wantFindings: []CheckError{
+				{Message: "Invalid Aliases: aliases should not contain duplicate entries"},
+				{Message: "Invalid Aliases: aliases should not contain itself"},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			jsonResult := gjson.Parse(tt.jsonData)
+			gotFindings := AliasesCheck(&jsonResult, &Config{Verbose: true})
+			if diff := cmp.Diff(tt.wantFindings, gotFindings, cmpopts.EquateErrors()); diff != "" {
+				t.Errorf("AliasesCheck() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestRelatedCheck(t *testing.T) {
+	tests := []struct {
+		name         string
+		jsonData     string
+		wantFindings []CheckError
+	}{
+		{
+			name:         "Valid related IDs",
+			jsonData:     `{"id": "CVE-2023-0001", "related": ["CVE-2023-0002", "CVE-2023-0003"]}`,
+			wantFindings: nil,
+		},
+		{
+			name:         "Related field missing",
+			jsonData:     `{"id": "CVE-2023-0001"}`,
+			wantFindings: nil,
+		},
+		{
+			name:         "Empty related array",
+			jsonData:     `{"id": "CVE-2023-0001", "related": []}`,
+			wantFindings: nil,
+		},
+		{
+			name:     "Duplicate related IDs",
+			jsonData: `{"id": "CVE-2023-0001", "related": ["CVE-2023-0002", "CVE-2023-0002"]}`,
+			wantFindings: []CheckError{
+				{Message: "Invalid Related: Related should not contain duplicate entries"},
+			},
+		},
+		{
+			name:     "Related ID contains record ID",
+			jsonData: `{"id": "CVE-2023-0001", "related": ["CVE-2023-0001", "CVE-2023-0002"]}`,
+			wantFindings: []CheckError{
+				{Message: "Invalid Related: Related should not contain itself"},
+			},
+		},
+		{
+			name:     "Duplicate related IDs and contains record ID",
+			jsonData: `{"id": "CVE-2023-0001", "related": ["CVE-2023-0001", "CVE-2023-0001"]}`,
+			wantFindings: []CheckError{
+				{Message: "Invalid Related: Related should not contain duplicate entries"},
+				{Message: "Invalid Related: Related should not contain itself"},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			jsonResult := gjson.Parse(tt.jsonData)
+			gotFindings := RelatedCheck(&jsonResult, &Config{Verbose: true})
+			if diff := cmp.Diff(tt.wantFindings, gotFindings, cmpopts.EquateErrors()); diff != "" {
+				t.Errorf("RelatedCheck() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestUpstreamCheck(t *testing.T) {
+	tests := []struct {
+		name         string
+		jsonData     string
+		wantFindings []CheckError
+	}{
+		{
+			name:         "Valid upstream",
+			jsonData:     `{"id": "MY-ID-001", "aliases": ["CVE-001"], "related": ["ADV-001"], "upstream": ["UP-001", "UP-002"]}`,
+			wantFindings: nil,
+		},
+		{
+			name:         "Upstream field missing",
+			jsonData:     `{"id": "MY-ID-001"}`,
+			wantFindings: nil,
+		},
+		{
+			name:         "Empty upstream array",
+			jsonData:     `{"id": "MY-ID-001", "upstream": []}`,
+			wantFindings: nil,
+		},
+		{
+			name:     "Duplicate upstream IDs",
+			jsonData: `{"id": "MY-ID-001", "upstream": ["UP-001", "UP-001"]}`,
+			wantFindings: []CheckError{
+				{Message: "Invalid Upstream: upstream should not contain duplicate entries"},
+			},
+		},
+		{
+			name:     "Upstream contains record ID",
+			jsonData: `{"id": "MY-ID-001", "upstream": ["MY-ID-001"]}`,
+			wantFindings: []CheckError{
+				{Message: "Invalid Upstream: upstream should not contain itself"},
+			},
+		},
+		{
+			name:     "Upstream contains an alias",
+			jsonData: `{"id": "MY-ID-001", "aliases": ["CVE-001"], "upstream": ["CVE-001"]}`,
+			wantFindings: []CheckError{
+				{Message: "Invalid Upstream: upstream should not contain aliases"},
+			},
+		},
+		{
+			name:     "Upstream contains a related ID",
+			jsonData: `{"id": "MY-ID-001", "related": ["ADV-001"], "upstream": ["ADV-001"]}`,
+			wantFindings: []CheckError{
+				{Message: "Invalid Upstream: upstream should not contain related IDs"},
+			},
+		},
+		{
+			name:     "Upstream contains duplicate, self, alias, and related",
+			jsonData: `{"id": "MY-ID-001", "aliases": ["CVE-001"], "related": ["ADV-001"], "upstream": ["UP-DUP", "UP-DUP", "MY-ID-001", "CVE-001", "ADV-001"]}`,
+			wantFindings: []CheckError{
+				{Message: "Invalid Upstream: upstream should not contain duplicate entries"},
+				{Message: "Invalid Upstream: upstream should not contain itself"},
+				{Message: "Invalid Upstream: upstream should not contain aliases"},
+				{Message: "Invalid Upstream: upstream should not contain related IDs"},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			jsonResult := gjson.Parse(tt.jsonData)
+			gotFindings := UpstreamCheck(&jsonResult, &Config{Verbose: true})
+			// Sort findings for consistent comparison as order can vary
+			opts := []cmp.Option{
+				cmpopts.EquateErrors(),
+				cmpopts.SortSlices(func(a, b CheckError) bool { return a.Message < b.Message }),
+			}
+			if diff := cmp.Diff(tt.wantFindings, gotFindings, opts...); diff != "" {
+				t.Errorf("UpstreamCheck() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/tools/osv-linter/internal/pkgchecker/ecosystems.go
+++ b/tools/osv-linter/internal/pkgchecker/ecosystems.go
@@ -69,6 +69,8 @@ func ExistsInEcosystem(pkg string, ecosystem string) bool {
 		return true
 	case "Maven":
 		return existsInMaven(pkg)
+	case "MinimOS":
+		return true
 	case "npm":
 		return existsInNpm(pkg)
 	case "NuGet":
@@ -149,6 +151,8 @@ func VersionsExistInEcosystem(pkg string, versions []string, ecosystem string) e
 	case "Linux":
 		return nil
 	case "Maven":
+		return nil
+	case "MinimOS":
 		return nil
 	case "npm":
 		return nil


### PR DESCRIPTION
This PR adds some new validation checks for upstream, aliases, and related fields to help linux distro data validation

It also made several changes to streamline linter integration into the OSV data import pipeline:

- Error Code Refactoring: Error codes have been updated (e.g. from R0001 to RNG:001). This provides better clarity and scalability as we add more checks (e.g. distinguishing Range, Record, or Relation errors). The colon delimiter also simplifies parsing for users.

- fatal Check Collection: A fatal check collection is used to categorize critical validation failures. 

- JSON Output: Added a JSON output format to simplify programmatic parsing of validation results.

- added MinimOS ecosystem