### PR TITLE
fix(linter): address linter issues on withdrawn records and range version and purl

### DIFF
--- a/tools/osv-linter/internal/checks/packages.go
+++ b/tools/osv-linter/internal/checks/packages.go
@@ -162,7 +162,12 @@ func PackagePurlValid(json *gjson.Result, config *Config) (findings []CheckError
 
 		_, err := packageurl.FromString(purl.String())
 		if err != nil {
-			findings = append(findings, CheckError{Message: fmt.Sprintf("Invalid Purl %q: %#v", purl.String(), err)})
+			// Add a version placeholder, as some ecosystem requires one.
+			purlWithVersion := purl.String() + "@version"
+			_, err = packageurl.FromString(purlWithVersion)
+			if err != nil {
+				findings = append(findings, CheckError{Message: fmt.Sprintf("Invalid Purl %q: %#v", purl.String(), err)})
+			}
 		}
 
 		return true // keep iterating (over affected entries)

--- a/tools/osv-linter/internal/checks/ranges.go
+++ b/tools/osv-linter/internal/checks/ranges.go
@@ -71,12 +71,9 @@ func RangeIsDistinct(json *gjson.Result, config *Config) (findings []CheckError)
 				if result.Exists() {
 					startEvents = append(startEvents, result.String())
 				}
-				// Collect all the fixed/last_affected values.
+				// Collect all the fixed
+				// last_affected can be the same version as introduced
 				result = value.Get("fixed")
-				if result.Exists() {
-					endEvents = append(endEvents, result.String())
-				}
-				result = value.Get("last_affected")
 				if result.Exists() {
 					endEvents = append(endEvents, result.String())
 				}

--- a/tools/osv-linter/internal/checks/record.go
+++ b/tools/osv-linter/internal/checks/record.go
@@ -34,6 +34,12 @@ var CheckRecordHasValidRelated = &CheckDef{
 
 // RecordHasAffected checks if the 'affected' field exists in the JSON and is not an empty array.
 func RecordHasAffected(json *gjson.Result, config *Config) (findings []CheckError) {
+	// Withdrawn records are fine to not contain affected field
+	isWithdrawn := json.Get("withdrawn")
+	if isWithdrawn.Exists() {
+		return
+	}
+
 	affectedEntries := json.Get("affected")
 	if !affectedEntries.Exists() || affectedEntries.String() == "[]" {
 		findings = append(findings, CheckError{Message: "Invalid Affected: affected field cannot be null or empty"})


### PR DESCRIPTION
Fixes linter issues by:
- Skipping affected field checks for withdrawn records.
- Allowing records to have matching last_affected and introduced versions.
- Adding a mock version to ecosystem PURL strings when required