### PR TITLE
test: ensure that schema has been (re)generated

### DIFF
--- a/tools/osv-linter/internal/checks/schema_test.go
+++ b/tools/osv-linter/internal/checks/schema_test.go
@@ -1,0 +1,28 @@
+package checks_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestSchemaHasBeenGenerated(t *testing.T) {
+	t.Parallel()
+
+	var err error
+
+	want, err := os.ReadFile("../../../../validation/schema.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := os.ReadFile("schema_generated.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("Schema needs to be regenerated (-want +got):\n%s", diff)
+	}
+}


### PR DESCRIPTION
This should help ensure the two files are kept in sync - while this doesn't feel the best, it seemed slightly better than e.g. having a job that does a `diff` since we already run tests in a dedicated job