### PR TITLE
ci: ensure go files are formatted with `gofmt`

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -37,6 +37,7 @@ jobs:
           check-latest: true
 
       - run: go test ./...
+      - run: gofmt -s -d */**.go
   tests_osv-linter:
     permissions:
       contents: read # to fetch code (actions/checkout)
@@ -57,6 +58,7 @@ jobs:
           check-latest: true
 
       - run: go test ./...
+      - run: gofmt -s -d */**.go
 
   ecosystem_lists:
     permissions:


### PR DESCRIPTION
I've just added this at the end of the test jobs since everything is so quick I don't think its worth having dedicated jobs for these