### PR TITLE
feat: update linter to Go v1.24.4

### DIFF
--- a/tools/osv-linter/go.mod
+++ b/tools/osv-linter/go.mod
@@ -1,6 +1,6 @@
 module github.com/ossf/osv-schema/linter
 
-go 1.22.6
+go 1.24.4
 
 require (
 	github.com/aquasecurity/go-pep440-version v0.0.0-20210121094942-22b2f8951d46


### PR DESCRIPTION
This enables the use of packages from `osv-scalibr` which requires at least Go v1.24