### PR TITLE
fix: Remove extra <tr>

### DIFF
--- a/docs/schema.md
+++ b/docs/schema.md
@@ -356,7 +356,6 @@ The defined database prefixes and their "home" databases are:
       </td>
     </tr>
     <tr>
-    <tr>
       <td><code>MINI</code></td>
       <td><a href="https://packages.mini.dev/advisories/osv/all.json">Minimus Security Notices</a></td>
       <td>


### PR DESCRIPTION
There is an extra <tr> breaking table rendering, and also breaking the entire page after the table starts. 

I tried looking for a markdown validator to prevent this, but that seems to be not trivial.

Tested here: https://another-rex.github.io/osv-schema/