### PR TITLE
feat: update `osv-scalibr`

### DIFF
--- a/tools/osv-linter/go.mod
+++ b/tools/osv-linter/go.mod
@@ -4,7 +4,7 @@ go 1.24.4
 
 require (
 	github.com/google/go-cmp v0.7.0
-	github.com/google/osv-scalibr v0.3.1
+	github.com/google/osv-scalibr v0.3.2-0.20250819020439-57339a98e548
 	github.com/package-url/packageurl-go v0.1.3
 	github.com/sethvargo/go-retry v0.2.4
 	github.com/tidwall/gjson v1.18.0

--- a/tools/osv-linter/go.sum
+++ b/tools/osv-linter/go.sum
@@ -5,8 +5,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
-github.com/google/osv-scalibr v0.3.1 h1:bXSaKfhlh7Q4ysLLjfFRJ1HONFsLyYvPOXD9v94yi0M=
-github.com/google/osv-scalibr v0.3.1/go.mod h1:dUF/iQx3OboIV/z1N1S2Bji1esSvAj/sWlLzQ7BXhmo=
+github.com/google/osv-scalibr v0.3.2-0.20250819020439-57339a98e548 h1:DMmZAIYot3LPcsfIeY3DOGoZNiV4Msn/cDxl5fmXHVw=
+github.com/google/osv-scalibr v0.3.2-0.20250819020439-57339a98e548/go.mod h1:D+mQbd5Gkzpf98X6OXuh2JzvlD0U4U3rmf1DaviOUho=
 github.com/package-url/packageurl-go v0.1.3 h1:4juMED3hHiz0set3Vq3KeQ75KD1avthoXLtmE3I0PLs=
 github.com/package-url/packageurl-go v0.1.3/go.mod h1:nKAWB8E6uk1MHqiS/lQb9pYBGH2+mdJ2PJc2s50dQY0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=


### PR DESCRIPTION
Notably this brings in https://github.com/google/osv-scalibr/pull/1168 and https://github.com/google/osv-scalibr/pull/1159 which unblocks https://github.com/ossf/osv-schema/pull/399 and https://github.com/ossf/osv-schema/pull/389 respectively