### PR TITLE
fix: add `CRAN` to the list of supported ecosystems

### DIFF
--- a/tools/osv-linter/internal/pkgchecker/ecosystems.go
+++ b/tools/osv-linter/internal/pkgchecker/ecosystems.go
@@ -6,6 +6,7 @@ import (
 
 // Ecosystem support is a work in progress.
 var SupportedEcosystems = []string{
+	"CRAN",
 	"crates.io",
 	"Go",
 	"Hackage",


### PR DESCRIPTION
I missed this in #399