### PR TITLE
feat: Added support for a DEBIAN- prefix

### DIFF
--- a/docs/schema.md
+++ b/docs/schema.md
@@ -235,6 +235,17 @@ The defined database prefixes and their "home" databases are:
       </td>
     </tr>
     <tr>
+      <td><code>DEBIAN</code></td>
+      <td><a href="https://security-tracker.debian.org/tracker/">Debian Security Tracker (provided by OSV.dev)</a></td>
+      <td>
+        <ul>
+          <li>How to contribute: TBD</li>
+          <li>Source URL: <code>https://security-tracker.debian.org/tracker/&lt;ID&gt;</code></li>
+          <li>OSV Formatted URL: <code>https://api.osv.dev/v1/vulns/&lt;ID&gt;</code></li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
       <td><code>DSA</code>/<code>DLA</code>/<code>DTSA</code></td>
       <td><a href="https://www.debian.org/security/">Debian Security Advisory Database (provided by OSV.dev)</a></td>
       <td>

--- a/tools/osv-linter/internal/checks/schema_generated.json
+++ b/tools/osv-linter/internal/checks/schema_generated.json
@@ -384,7 +384,7 @@
       "type": "string",
       "title": "Currently supported home database identifier prefixes",
       "description": "These home databases are also documented at https://ossf.github.io/osv-schema/#id-modified-fields",
-      "pattern": "^(ASB-A|PUB-A|ALSA|ALBA|ALEA|BELL|BIT|CGA|CURL|CVE|DSA|DLA|ELA|DTSA|GHSA|GO|GSD|HSEC|KUBE|LBSEC|LSN|MAL|MINI|MGASA|OESA|OSV|openSUSE-SU|PHSA|PSF|PYSEC|RHBA|RHEA|RHSA|RLSA|RXSA|RSEC|RUSTSEC|SUSE-[SRFO]U|UBUNTU|USN|V8)-"
+      "pattern": "^(ASB-A|PUB-A|ALSA|ALBA|ALEA|BELL|BIT|CGA|CURL|CVE|DEBIAN|DSA|DLA|ELA|DTSA|GHSA|GO|GSD|HSEC|KUBE|LBSEC|LSN|MAL|MINI|MGASA|OESA|OSV|openSUSE-SU|PHSA|PSF|PYSEC|RHBA|RHEA|RHSA|RLSA|RXSA|RSEC|RUSTSEC|SUSE-[SRFO]U|UBUNTU|USN|V8)-"
     },
     "severity": {
       "type": [

--- a/validation/schema.json
+++ b/validation/schema.json
@@ -384,7 +384,7 @@
       "type": "string",
       "title": "Currently supported home database identifier prefixes",
       "description": "These home databases are also documented at https://ossf.github.io/osv-schema/#id-modified-fields",
-      "pattern": "^(ASB-A|PUB-A|ALSA|ALBA|ALEA|BELL|BIT|CGA|CURL|CVE|DSA|DLA|ELA|DTSA|GHSA|GO|GSD|HSEC|KUBE|LBSEC|LSN|MAL|MINI|MGASA|OESA|OSV|openSUSE-SU|PHSA|PSF|PYSEC|RHBA|RHEA|RHSA|RLSA|RXSA|RSEC|RUSTSEC|SUSE-[SRFO]U|UBUNTU|USN|V8)-"
+      "pattern": "^(ASB-A|PUB-A|ALSA|ALBA|ALEA|BELL|BIT|CGA|CURL|CVE|DEBIAN|DSA|DLA|ELA|DTSA|GHSA|GO|GSD|HSEC|KUBE|LBSEC|LSN|MAL|MINI|MGASA|OESA|OSV|openSUSE-SU|PHSA|PSF|PYSEC|RHBA|RHEA|RHSA|RLSA|RXSA|RSEC|RUSTSEC|SUSE-[SRFO]U|UBUNTU|USN|V8)-"
     },
     "severity": {
       "type": [


### PR DESCRIPTION
OSV.dev is looking to decouple Debian and Alpine CVE Trackers from its main CVE-record. 

This PR adds the DEBIAN- prefix for use for CVEs tracked by Debian's security tracker to the schema.