### PR TITLE
fix(bindings): restore special casing for `SEMVER` range type

### DIFF
--- a/bindings/go/osvschema/constants.go
+++ b/bindings/go/osvschema/constants.go
@@ -67,7 +67,7 @@ type RangeType string
 const (
 	RangeEcosystem RangeType = "ECOSYSTEM"
 	RangeGit       RangeType = "GIT"
-	RangeSemver    RangeType = "SEMVER"
+	RangeSemVer    RangeType = "SEMVER"
 )
 
 type ReferenceType string

--- a/scripts/generate-go-constants.py
+++ b/scripts/generate-go-constants.py
@@ -49,6 +49,9 @@ def convert_enum_value_to_go_name(type_name: str, value: str) -> str:
         # Fallback for other severity types like "Ubuntu".
         return to_pascal_case(value)
 
+    if type_name == 'RangeType' and value == 'SEMVER':
+      return 'SemVer'
+
     # For all other enum types, convert the value to PascalCase.
     # e.g., "REMEDIATION_DEVELOPER" -> "RemediationDeveloper"
     return to_pascal_case(value)


### PR DESCRIPTION
This restores the original casing of the constant which #419 changed by mistake