### PR TITLE
fix(proto): Fix typos in comments in vulnerability.proto

### DIFF
--- a/proto/vulnerability.proto
+++ b/proto/vulnerability.proto
@@ -24,7 +24,7 @@ option go_package = "github.com/ossf/osv-schema/bindings/go/osvschema";
 // Commit reference.
 //
 // In some rare cases, this may refer to a small range of commits rather than an
-// exact commit (to accomodate for automated systems). In such cases, the
+// exact commit (to accommodate for automated systems). In such cases, the
 // semantics are as follows:
 //
 // - If this is referring to a commit which introduces a vulnerability, then
@@ -208,7 +208,7 @@ message Vulnerability {
   // Required. Affected commit ranges and versions.
   repeated Affected affected = 17;
   // Optional. URLs to more information/advisories (including the
-  // scheme e.g "https://").
+  // scheme e.g. "https://").
   repeated Reference references = 16;
   // Optional. JSON object holding additional information about the
   // vulnerability as defined by the database for which the record applies.


### PR DESCRIPTION
This PR fixes two minor typos in the comments within `proto/vulnerability.proto` file so that they won't get complains when being imported to internal.