### PR TITLE
ci: ensure filenames don't have undesired characters

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -24,9 +24,9 @@ jobs:
         with:
           persist-credentials: false
       - run: |
-          find . -mindepth 1 ! -regex '.*/[#@A-Za-z0-9._-]*' \
-            | xargs -I '{}' bash -c \
-              "echo '{}' && echo '::error file={}::This filename contains undesired characters' && false"
+          find . -mindepth 1 ! -regex '.*/[#@A-Za-z0-9._-]*' -print0 \
+            | xargs -0 -I{} bash -c \
+              'printf "::error file=%q::This filename contains undesired characters\n" "$1" && false' _ {}
   tests_osv-go:
     permissions:
       contents: read # to fetch code (actions/checkout)


### PR DESCRIPTION
This should ensure that files are valid across OSs - I've gone with an inclusive pattern which purposely does not have some characters that are technically legal but that I don't think there's a good reason to use them in a filename.