### PR TITLE
add small clarification to affected versions

### DIFF
--- a/docs/schema.md
+++ b/docs/schema.md
@@ -951,7 +951,10 @@ These `events` objects represent a "timeline" of status changes for the affected
 package.
 
 The values of `introduced`, `fixed`, `last_affected` and `limit` are version strings
-as defined by the `affected[].ranges[].type` field.
+as defined by the `affected[].ranges[].type` field. Note that these version
+strings are not guaranteed to exactly match versions of the package found in the
+upstream package repository. For example, they may be normalized, or have build
+metadata stripped.
 
 #### Special values
 


### PR DESCRIPTION
Recently, in OSV.dev (https://github.com/google/osv.dev/issues/4143) someone pointed out that the 'fixed' version of some of our records do not map directly to an upstream package version.

Update the schema to clarify that this may be the case.