### PR TITLE
Add EEF Database

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Together, these include vulnerabilities from:
 -   crates.io
 -   Debian GNU/Linux
 -   Echo
+-   Erlang Ecosystem Foundation
 -   GitHub Actions
 -   Go
 -   Haskell

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -279,6 +279,17 @@ The defined database prefixes and their "home" databases are:
       </td>
     </tr>
     <tr>
+      <td><code>EEF</code></td>
+      <td><a href="https://cna.erlef.org/osv/all.json">Erlang Ecosystem Foundation CNA Vulnerabilities</a></td>
+      <td>
+        <ul>
+          <li>How to contribute: <a href="https://cna.erlef.org/contact">https://cna.erlef.org/contact</a></li>
+          <li>Source URL: <code>https://github.com/erlef-cna/website/tree/main/_data/osv</code></li>
+          <li>OSV Formatted URL: <code>https://cna.erlef.org/osv/&lt;ID&gt;.json</code></li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
       <td><code>ELA</code></td>
       <td><a href="https://www.freexian.com/lts/extended/">Debian Extended LTS Security Advisories (provided by Freexian)</a></td>
       <td>

--- a/tools/osv-linter/internal/checks/schema_generated.json
+++ b/tools/osv-linter/internal/checks/schema_generated.json
@@ -385,7 +385,7 @@
       "type": "string",
       "title": "Currently supported home database identifier prefixes",
       "description": "These home databases are also documented at https://ossf.github.io/osv-schema/#id-modified-fields",
-      "pattern": "^(ASB-A|PUB-A|ALPINE|ALSA|ALBA|ALEA|BELL|BIT|CGA|CURL|CVE|DEBIAN|DSA|DLA|ELA|DTSA|ECHO|GHSA|GO|GSD|HSEC|JLSEC|KUBE|LBSEC|LSN|MAL|MINI|MGASA|OESA|OSV|openSUSE-SU|PHSA|PSF|PYSEC|RHBA|RHEA|RHSA|RLSA|RXSA|RSEC|RUSTSEC|SUSE-[SRFO]U|UBUNTU|USN|V8)-"
+      "pattern": "^(ASB-A|PUB-A|ALPINE|ALSA|ALBA|ALEA|BELL|BIT|CGA|CURL|CVE|DEBIAN|DSA|DLA|ELA|DTSA|ECHO|EEF|GHSA|GO|GSD|HSEC|JLSEC|KUBE|LBSEC|LSN|MAL|MINI|MGASA|OESA|OSV|openSUSE-SU|PHSA|PSF|PYSEC|RHBA|RHEA|RHSA|RLSA|RXSA|RSEC|RUSTSEC|SUSE-[SRFO]U|UBUNTU|USN|V8)-"
     },
     "severity": {
       "type": [

--- a/validation/schema.json
+++ b/validation/schema.json
@@ -385,7 +385,7 @@
       "type": "string",
       "title": "Currently supported home database identifier prefixes",
       "description": "These home databases are also documented at https://ossf.github.io/osv-schema/#id-modified-fields",
-      "pattern": "^(ASB-A|PUB-A|ALPINE|ALSA|ALBA|ALEA|BELL|BIT|CGA|CURL|CVE|DEBIAN|DSA|DLA|ELA|DTSA|ECHO|GHSA|GO|GSD|HSEC|JLSEC|KUBE|LBSEC|LSN|MAL|MINI|MGASA|OESA|OSV|openSUSE-SU|PHSA|PSF|PYSEC|RHBA|RHEA|RHSA|RLSA|RXSA|RSEC|RUSTSEC|SUSE-[SRFO]U|UBUNTU|USN|V8)-"
+      "pattern": "^(ASB-A|PUB-A|ALPINE|ALSA|ALBA|ALEA|BELL|BIT|CGA|CURL|CVE|DEBIAN|DSA|DLA|ELA|DTSA|ECHO|EEF|GHSA|GO|GSD|HSEC|JLSEC|KUBE|LBSEC|LSN|MAL|MINI|MGASA|OESA|OSV|openSUSE-SU|PHSA|PSF|PYSEC|RHBA|RHEA|RHSA|RLSA|RXSA|RSEC|RUSTSEC|SUSE-[SRFO]U|UBUNTU|USN|V8)-"
     },
     "severity": {
       "type": [


### PR DESCRIPTION
We're providing information in the OSV format for all the Hex.pm vulnerabilities for which our CNA assigns.

Our CNA scope includes all Hex.pm packages, unless covered by the scope of another CNA.

Since we're primarily a CNA ond this effort is to raise compatibility with the information we provide in our CVE entries, We'll be naming them `EEF-<CVE ID>`.

OSV REST Link: https://cna.erlef.org/osv/all.json
OSV Detail URL: `https://cna.erlef.org/osv/<ID>.json`
List of Vulnerabilities: https://cna.erlef.org/cves/
Our stuff on GH: https://github.com/erlef-cna
