### PR TITLE
fix: output string representation of err in linter, not Go syntax

### DIFF
--- a/tools/osv-linter/internal/checks/packages.go
+++ b/tools/osv-linter/internal/checks/packages.go
@@ -166,7 +166,7 @@ func PackagePurlValid(json *gjson.Result, config *Config) (findings []CheckError
 			purlWithVersion := purl.String() + "@version"
 			_, err = packageurl.FromString(purlWithVersion)
 			if err != nil {
-				findings = append(findings, CheckError{Message: fmt.Sprintf("Invalid Purl %q: %#v", purl.String(), err)})
+				findings = append(findings, CheckError{Message: fmt.Sprintf("Invalid Purl %q: %v", purl.String(), err)})
 			}
 		}
 


### PR DESCRIPTION
The linter was outputting the Go syntax representation of the err value for the Purl checker rather than the string value: 
`&errors.errorString{s:"namespace is required"}` vs `namespace is required`

This should output it correctly. 