### PR TITLE
refactor: remove unneeded check

### DIFF
--- a/tools/osv-linter/internal/linter.go
+++ b/tools/osv-linter/internal/linter.go
@@ -211,12 +211,10 @@ func LintCommand(cCtx *cli.Context) error {
 		}
 		fmt.Println(string(jsonData))
 	} else {
-		if len(perFileFindings) > 0 {
-			for filename, findings := range perFileFindings {
-				fmt.Printf("%s:\n", filename)
-				for _, finding := range findings {
-					fmt.Printf("\t * %s\n", finding.Error())
-				}
+		for filename, findings := range perFileFindings {
+			fmt.Printf("%s:\n", filename)
+			for _, finding := range findings {
+				fmt.Printf("\t * %s\n", finding.Error())
 			}
 		}
 	}


### PR DESCRIPTION
The loop will do nothing if the map is empty, so there's no need to check its length first