### PR TITLE
feat: restructure README.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 go.work
 go.work.sum
+.vscode/settings.json

--- a/README.md
+++ b/README.md
@@ -1,8 +1,34 @@
-# Open Source Vulnerability Schema
+# Open Source Vulnerability (OSV) Schema
 
-The Open Source Vulnerability (OSV) schema provides a human and machine readable data format to describe vulnerabilities in a way that precisely maps to open source package versions or commit hashes.
+[Rendered Specification](https://ossf.github.io/osv-schema/)
 
-This format is currently exported by:
+## Overview
+
+The OSV schema provides a human and machine-readable format to describe vulnerabilities that map precisely to open source package versions or commit hashes. It is used by multiple distributions and advisory databases and is the canonical format aggregated by <https://osv.dev>.
+
+## Quick links
+
+- Specification (rendered): <https://ossf.github.io/osv-schema/>
+- JSON Schema: [schema.json](schema.json)
+- Protocol buffer definition: [proto/vulnerability.proto](proto/vulnerability.proto)
+- Tools and converters: [tools/](tools)
+
+## Getting started
+
+Installers and consumers typically use one of the available converters or the rendered spec above. Example data sources that export or convert to OSV include many distro and advisory projects (AlmaLinux, Debian, PyPI advisories, RustSec, etc.). See the `tools/` directory for converters maintained alongside this repo.
+
+## Using the schema
+
+Common tasks:
+
+- Validate a file against the JSON schema: `scripts/validate-schema-table.py` and `schema.json`.
+- Convert vendor-specific advisories: see `tools/` subfolders (e.g., `tools/debian`, `tools/ghsa`).
+- Generate Protobuf types: `proto/vulnerability.proto` contains the canonical proto.
+
+## Adoption
+
+There are many home databases publishing OSV-format advisories or maintain converters:
+
 - [AlmaLinux](https://github.com/AlmaLinux/osv-database)
 - [BellSoft Security Advisory](https://github.com/bell-sw/osv-database)
 - [Bitnami Vulnerability Database](https://github.com/bitnami/vulndb)
@@ -33,52 +59,86 @@ This format is currently exported by:
 - [VMWare Photon OS](https://github.com/vmware/photon/wiki/Security-Advisories) (unofficial)
 
 Together, these include vulnerabilities from:
--   AlmaLinux
--   Alpine
--   Alpaquita Linux
--   Android
--   BellSoft Hardened Containers
--   Bitnami
--   Chainguard
--   CleanStart
--   crates.io
--   Debian GNU/Linux
--   Docker
--   Echo
--   Erlang Ecosystem Foundation
--   FreeBSD
--   GitHub Actions
--   Go
--   Haskell
--   Hex
--   Julia
--   Linux kernel
--   Mageia
--   Maven
--   MinimOS
--   npm
--   NuGet
--   openEuler
--   openSUSE
--   OSS-Fuzz
--   Packagist
--   Photon OS
--   Pub
--   PyPI
--   Python
--   R (CRAN and Bioconductor)
--   Red Hat
--   SUSE
--   Rocky Linux
--   RubyGems
--   Ubuntu
 
-These vulnerabilities are aggregated by <https://osv.dev>.
+- AlmaLinux
+- Alpine
+- Alpaquita Linux
+- Android
+- BellSoft Hardened Containers
+- Bitnami
+- Chainguard
+- CleanStart
+- crates.io
+- Debian GNU/Linux
+- Docker
+- Echo
+- Erlang Ecosystem Foundation
+- FreeBSD
+- GitHub Actions
+- Go
+- Haskell
+- Hex
+- Julia
+- Linux kernel
+- Mageia
+- Maven
+- MinimOS
+- npm
+- NuGet
+- openEuler
+- openSUSE
+- OSS-Fuzz
+- Packagist
+- Photon OS
+- Pub
+- PyPI
+- Python
+- R (CRAN and Bioconductor)
+- Red Hat
+- SUSE
+- Rocky Linux
+- RubyGems
+- Ubuntu
 
-Join the discussion in the [OpenSSF Slack](https://slack.openssf.org/) channel [#osv_schema](https://openssf.slack.com/archives/C03K6SZBH2S)
+See the repository history and the `tools/` subdirectories for more examples and testdata.
 
-Reference tooling (e.g. converters) can be found in the [tools/](tools) directory
+## Development
 
-The current version of the specification is rendered [here](https://ossf.github.io/osv-schema/).
+Prerequisites:
 
-The OSV-Schema specification and the tools here are maintained by the [Open Source Security Foundation (OpenSSF)](https://openssf.org/) [Vulnerability Disclosures Working Group (WG)](https://github.com/ossf/wg-vulnerability-disclosures).
+- Python 3 for scripts in `tools/` and `scripts/`.
+- (Optional) Go for components under `bindings/go`.
+
+Common development tasks:
+
+- Run schema validation: `python3 scripts/validate-schema-table.py` (see script for usage).
+- Run converter tests: check subdirectories in `tools/*/` for test instructions.
+
+## Contributing
+
+We welcome contributions. Please follow the repository's contributor guidelines and code of conduct:
+
+- [CONTRIBUTING.md](CONTRIBUTING.md)
+- [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)
+
+If you find a bug or want to request a feature, open an issue in this repository.
+
+## Community and support
+
+Join the OpenSSF Slack channel `#osv_schema` (Slack invite: <https://slack.openssf.org/>) to discuss the schema and tooling.
+
+## Maintainers
+
+This repository is maintained by the OpenSSF Vulnerability Disclosures Working Group. See the repository `CODEOWNERS` for current maintainers.
+
+## License
+
+This project is licensed under the terms in the repository `LICENSE` file.
+
+## Security
+
+To report a security issue, follow the instructions in `SECURITY.md`.
+
+## Acknowledgements
+
+OSV Schema is used and supported by many projects and ecosystems. See the rendered specification and the `tools/` directory for a (non-exhaustive) list of converters and consumers.


### PR DESCRIPTION
This restructures the README.md to be more comprehensive, specifically including bug reporting instructions for the OSPS-DO-02.01 baseline

Signed-off-by: Andrew Pollock <andrew@pollock.id.au>