### PR TITLE
feat(osv-linter): add REC:005 id character-set check

### DIFF
--- a/tools/osv-linter/internal/checks/checks.go
+++ b/tools/osv-linter/internal/checks/checks.go
@@ -104,6 +104,7 @@ var Collections = []CheckCollection{
 			CheckRecordHasValidAliases,
 			CheckRecordHasValidUpstream,
 			CheckRecordHasValidRelated,
+			CheckRecordHasValidID,
 			// Range checks
 			CheckRangeHasIntroducedEvent,
 			CheckRangeIsDistinct,
@@ -123,6 +124,7 @@ var Collections = []CheckCollection{
 			CheckRecordHasValidAliases,
 			CheckRecordHasValidUpstream,
 			CheckRecordHasValidRelated,
+			CheckRecordHasValidID,
 			CheckRangeHasIntroducedEvent,
 			CheckRangeIsDistinct,
 			CheckPackagePurlValid,

--- a/tools/osv-linter/internal/checks/record.go
+++ b/tools/osv-linter/internal/checks/record.go
@@ -1,8 +1,16 @@
 package checks
 
 import (
+	"fmt"
+	"regexp"
+
 	"github.com/tidwall/gjson"
 )
+
+// validIDPattern is the set of characters permitted in an OSV record id.
+// Restricting ids to this ASCII subset avoids the need for URL encoding and
+// prevents shell-scripting errors caused by spaces or other punctuation.
+var validIDPattern = regexp.MustCompile(`^[a-zA-Z0-9:_.-]+$`)
 
 var CheckRecordHasAffected = &CheckDef{
 	Code:        "REC:001",
@@ -30,6 +38,13 @@ var CheckRecordHasValidRelated = &CheckDef{
 	Name:        "valid-related",
 	Description: "related field validates",
 	Check:       RelatedCheck,
+}
+
+var CheckRecordHasValidID = &CheckDef{
+	Code:        "REC:005",
+	Name:        "record-id-valid",
+	Description: "id field uses only permitted characters",
+	Check:       IDCheck,
 }
 
 // RecordHasAffected checks if the 'affected' field exists in the JSON and is not an empty array.
@@ -119,6 +134,21 @@ func RelatedCheck(json *gjson.Result, config *Config) (findings []CheckError) {
 
 	if _, exists := unique[bug.String()]; exists {
 		findings = append(findings, CheckError{Message: "Invalid Related: Related should not contain itself"})
+	}
+
+	return findings
+}
+
+// IDCheck verifies that the 'id' field only contains characters from the
+// permitted set (^[a-zA-Z0-9:_.-]+$).
+func IDCheck(json *gjson.Result, config *Config) (findings []CheckError) {
+	id := json.Get("id")
+	if !id.Exists() {
+		return
+	}
+
+	if !validIDPattern.MatchString(id.String()) {
+		findings = append(findings, CheckError{Message: fmt.Sprintf("Invalid ID: id %q contains characters outside the permitted set [a-zA-Z0-9:_.-]", id.String())})
 	}
 
 	return findings

--- a/tools/osv-linter/internal/checks/record_test.go
+++ b/tools/osv-linter/internal/checks/record_test.go
@@ -166,6 +166,55 @@ func TestRelatedCheck(t *testing.T) {
 	}
 }
 
+func TestIDCheck(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		jsonData     string
+		wantFindings []CheckError
+	}{
+		{
+			name:         "Valid CVE ID",
+			jsonData:     `{"id": "CVE-2023-0001"}`,
+			wantFindings: nil,
+		},
+		{
+			name:         "Valid ID with permitted punctuation",
+			jsonData:     `{"id": "GO:stdlib-1.2.3_beta"}`,
+			wantFindings: nil,
+		},
+		{
+			name:         "ID field missing",
+			jsonData:     `{"aliases": ["CVE-2023-0001"]}`,
+			wantFindings: nil,
+		},
+		{
+			name:     "ID contains a space",
+			jsonData: `{"id": "CVE 2023 0001"}`,
+			wantFindings: []CheckError{
+				{Message: `Invalid ID: id "CVE 2023 0001" contains characters outside the permitted set [a-zA-Z0-9:_.-]`},
+			},
+		},
+		{
+			name:     "ID contains a slash",
+			jsonData: `{"id": "OSV/2023/0001"}`,
+			wantFindings: []CheckError{
+				{Message: `Invalid ID: id "OSV/2023/0001" contains characters outside the permitted set [a-zA-Z0-9:_.-]`},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			jsonResult := gjson.Parse(tt.jsonData)
+			gotFindings := IDCheck(&jsonResult, &Config{Verbose: true})
+			if diff := cmp.Diff(tt.wantFindings, gotFindings, cmpopts.EquateErrors()); diff != "" {
+				t.Errorf("IDCheck() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
 func TestUpstreamCheck(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

This adds a new osv-linter record check, `REC:005` (`record-id-valid`), that validates the OSV `id` field against the character set proposed in #547: `^[a-zA-Z0-9:_.-]+$`. An `id` containing any character outside that ASCII subset (for example a space or a `/`) now produces a finding.

The rationale follows the issue: constraining ids to this subset avoids the need for URL encoding and prevents shell-scripting errors caused by spaces or other punctuation in downstream tooling.

## Scope

#547 is a two-part proposal. I deliberately scoped this PR to only the first, mechanical part (the character-set constraint), because it is objectively checkable with a regex. I did not implement the second part (the "semantic neutrality / opaque IDs" guideline that new ids should be semantically meaningless), since that is a human-judgement guideline rather than something a linter can reliably enforce, and it reads more like documentation guidance than a deterministic check.

## Implementation

The check mirrors the existing `REC:00x` checks exactly:

- a package-level `validIDPattern` compiled regex in `internal/checks/record.go`
- a `CheckRecordHasValidID` `CheckDef` (code `REC:005`, name `record-id-valid`)
- an `IDCheck` function that reads `id` via gjson and emits a `CheckError` on a non-conforming value (records without an `id` are left to the schema check and are not flagged here)
- registration in the `ALL` and `offline` collections (it has no remote data dependency, so it is an offline check; I left it out of `fatal`, consistent with `REC:004` also not being in that curated subset)

It uses only the standard library (`regexp`, `fmt`); no new dependency is added.

## Testing

`TestIDCheck` is added to `record_test.go` following the existing table-test style: valid ids pass (a normal `CVE-` id and one exercising the permitted `: . - _` punctuation), a missing `id` is a no-op, and ids containing a space or a slash fail with the expected message.

- `go test ./internal/checks/...` passes (full module `go test ./...` also green)
- `go vet ./internal/checks/...` is clean
- the new files are `gofmt` clean
- `go run ./cmd/osv record check --checks list` shows `REC:005: (record-id-valid): id field uses only permitted characters`

## Note

I opened this as a focused first step on #547. As far as I can tell no maintainer has weighed in on the issue yet, so I am happy to adjust the naming, the message wording, which collections it belongs to, or whether the character set should match here exactly, based on your preference. Happy to also pick up the semantic-neutrality half separately if you decide it should live as a (likely documentation-only) guideline.

Addresses #547.
