### PR TITLE
feat: support wildcard package name '*' in schema and linter

### DIFF
--- a/docs/schema.md
+++ b/docs/schema.md
@@ -887,6 +887,11 @@ strings in the table below. The `name` field is a string identifying the library
 within its ecosystem. The two fields must both be present, because the
 `ecosystem` serves to define the interpretation of the `name`.
 
+Use the wildcard package name `*` to indicate that an advisory affects all
+packages within the specified `ecosystem`. For example, this is useful when an
+ecosystem version reaches end-of-life (EOL) and receives no further security
+support.
+
 The `purl` field is a string following the
  [Package URL specification](https://github.com/package-url/purl-spec) that
 identifies the package, without the `@version` component.

--- a/tools/osv-linter/internal/checks/packages.go
+++ b/tools/osv-linter/internal/checks/packages.go
@@ -44,6 +44,9 @@ func PackageExists(json *gjson.Result, config *Config) (findings []CheckError) {
 			return true // keep iterating (over affected entries)
 		}
 		pkg := value.Get("package.name").String()
+		if pkg == "*" {
+			return true // keep iterating, wildcard package matches everything and doesn't need to exist
+		}
 
 		// Avoid unnecessary network traffic for repeat packages.
 		if _, ok := knownExistent[Package{Ecosystem: ecosystem, Name: pkg}]; ok {
@@ -92,6 +95,9 @@ func PackageVersionsExist(json *gjson.Result, config *Config) (findings []CheckE
 			return true // keep iterating (over affected entries)
 		}
 		pkg := value.Get("package.name").String()
+		if pkg == "*" {
+			return true // keep iterating, wildcard package matches everything and doesn't need to exist
+		}
 		versionsToCheck := []string{}
 		// Examine versions in ranges.
 		maybeRanges := value.Get("ranges")

--- a/tools/osv-linter/internal/checks/packages_test.go
+++ b/tools/osv-linter/internal/checks/packages_test.go
@@ -27,6 +27,14 @@ func TestPackageExists(t *testing.T) {
 			},
 			wantFindings: []CheckError{{Code: "", Message: "package \"123bla\" not found in \"PyPI\""}},
 		},
+		{
+			name: "Wildcard package name in PyPI",
+			args: args{
+				json:   LoadTestData("../../testdata/wildcard-package.json"),
+				config: &Config{},
+			},
+			wantFindings: nil,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -62,6 +70,14 @@ func TestPackageVersionsExists(t *testing.T) {
 				json:   LoadTestData("../../testdata/GHSA-9v2f-6vcg-3hgv.json"),
 				config: &Config{Ecosystems: []string{"npm"}},
 			},
+		},
+		{
+			name: "Wildcard package versions check",
+			args: args{
+				json:   LoadTestData("../../testdata/wildcard-package.json"),
+				config: &Config{},
+			},
+			wantFindings: nil,
 		},
 	}
 	for _, tt := range tests {

--- a/tools/osv-linter/testdata/wildcard-package.json
+++ b/tools/osv-linter/testdata/wildcard-package.json
@@ -1,0 +1,19 @@
+{
+  "modified": "2026-06-10T00:00:00Z",
+  "published": "2026-06-10T00:00:00Z",
+  "schema_version": "1.5.0",
+  "id": "CVE-2026-99999",
+  "summary": "Ecosystem wildcard test",
+  "details": "This is a test case for a wildcard package name.",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "PyPI",
+        "name": "*"
+      },
+      "versions": [
+        "1.0.0"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This PR introduces support for a special wildcard package name `*` to the OSV schema and the `osv-linter` validation tool.
## Changes
- Update the schema.md to document the wildcard package name `*` which allows an advisory to affect all packages within a specified ecosystem (e.g. to denote EOL).
- Also updated the linter and jsonschema

This fixes #519 by providing a mechanism to represent End-of-Life (EOL) for an entire ecosystem without having to list every individual package. By using a wildcard package name `*`, data providers can publish a single advisory for the EOL ecosystem version (e.g. `Ubuntu:18.04`). Any query for a package within that ecosystem will then match this advisory, alerting users that the ecosystem itself is no longer supported, so the results might not be complete / up to date.

Definitely looking for feedback on this approach!
