### PR TITLE
Add Homebrew ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Together, these include vulnerabilities from:
 - Go
 - Haskell
 - Hex
+- Homebrew
 - Julia
 - Linux kernel
 - Mageia

--- a/bindings/go/osvconstants/constants.go
+++ b/bindings/go/osvconstants/constants.go
@@ -28,6 +28,7 @@ const (
 	EcosystemGo                         Ecosystem = "Go"
 	EcosystemHackage                    Ecosystem = "Hackage"
 	EcosystemHex                        Ecosystem = "Hex"
+	EcosystemHomebrew                   Ecosystem = "Homebrew"
 	EcosystemJulia                      Ecosystem = "Julia"
 	EcosystemKubernetes                 Ecosystem = "Kubernetes"
 	EcosystemLinux                      Ecosystem = "Linux"

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -230,6 +230,17 @@ The defined database prefixes and their "home" databases are:
       </td>
     </tr>
     <tr>
+      <td><code>BREW</code></td>
+      <td><a href="https://brew.sh/">Homebrew Advisory Database</a></td>
+      <td>
+        <ul>
+          <li>How to contribute: TBD</li>
+          <li>Source URL: <code>TBD</code></li>
+          <li>OSV Formatted URL: <code>TBD</code></li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
       <td><code>CGA</code></td>
       <td><a href="https://packages.cgr.dev/chainguard/osv/all.json">Chainguard Security Notices</a></td>
       <td>
@@ -964,6 +975,7 @@ The defined ecosystems are:
 | `Go` | The Go ecosystem; the `name` field is a Go module path. |
 | `Hackage` | The Haskell package ecosystem. The `name` field is a Haskell package name as published on Hackage. |
 | `Hex` | The package manager for the Erlang ecosystem; the `name` is a Hex package name. |
+| `Homebrew` | The Homebrew package manager for macOS and Linux; the `name` is the formula name (e.g. `openssl@3`). Casks are not currently in scope. Without a `:<tap>` suffix the formula is assumed to come from the default `homebrew/core` tap. A version is the formula version as reported by `brew info` with an `_N` suffix when the formula revision is nonzero (e.g. `1.81.6_6`), matching the version component of a `pkg:brew` purl. |
 | `Julia` | The Julia Programming Language ecosystem; the `name` is a registered package in the General registry. |
 | `Kubernetes` | The Kubernetes ecosystem; `name` is the Go module name associated with the relevant Kubernetes component (e.g. `k8s.io/apiserver`) |
 | `Linux` | The Linux kernel. The only supported `name` is `Kernel`. |

--- a/ecosystems.json
+++ b/ecosystems.json
@@ -21,6 +21,7 @@
   "Go": "The Go ecosystem; the `name` field is a Go module path.",
   "Hackage": "The Haskell package ecosystem. The `name` field is a Haskell package name as published on Hackage.",
   "Hex": "The package manager for the Erlang ecosystem; the `name` is a Hex package name.",
+  "Homebrew": "The Homebrew package manager for macOS and Linux; the `name` is the formula name (e.g. `openssl@3`). Casks are not currently in scope. Without a `:<tap>` suffix the formula is assumed to come from the default `homebrew/core` tap. A version is the formula version as reported by `brew info` with an `_N` suffix when the formula revision is nonzero (e.g. `1.81.6_6`), matching the version component of a `pkg:brew` purl.",
   "Julia": "The Julia Programming Language ecosystem; the `name` is a registered package in the General registry.",
   "Kubernetes": "The Kubernetes ecosystem; `name` is the Go module name associated with the relevant Kubernetes component (e.g. `k8s.io/apiserver`)",
   "Linux": "The Linux kernel. The only supported `name` is `Kernel`.",

--- a/tools/osv-linter/internal/checks/schema_generated.json
+++ b/tools/osv-linter/internal/checks/schema_generated.json
@@ -419,6 +419,7 @@
         "Go",
         "Hackage",
         "Hex",
+        "Homebrew",
         "Julia",
         "Kubernetes",
         "Linux",
@@ -456,13 +457,13 @@
       "type": "string",
       "title": "Currently supported ecosystems",
       "description": "These ecosystems are also documented at https://ossf.github.io/osv-schema/#affectedpackage-field",
-      "pattern": "^(AlmaLinux|Alpaquita|Alpine|Android|Azure Linux|BellSoft Hardened Containers|Bioconductor|Bitnami|Chainguard|CleanStart|ConanCenter|CRAN|crates\\.io|Debian|Docker Hardened Images|Echo|FreeBSD|GHC|GitHub Actions|Go|Hackage|Hex|Julia|Kubernetes|Linux|Mageia|Maven|MinimOS|npm|NuGet|opam|openEuler|openSUSE|OSS-Fuzz|Packagist|Photon OS|Pub|PyPI|Red Hat|Rocky Linux|Root|RubyGems|SUSE|SwiftURL|TuxCare|Ubuntu|vcpkg|VSCode|Wolfi|GIT)(:.+)?$"
+      "pattern": "^(AlmaLinux|Alpaquita|Alpine|Android|Azure Linux|BellSoft Hardened Containers|Bioconductor|Bitnami|Chainguard|CleanStart|ConanCenter|CRAN|crates\\.io|Debian|Docker Hardened Images|Echo|FreeBSD|GHC|GitHub Actions|Go|Hackage|Hex|Homebrew|Julia|Kubernetes|Linux|Mageia|Maven|MinimOS|npm|NuGet|opam|openEuler|openSUSE|OSS-Fuzz|Packagist|Photon OS|Pub|PyPI|Red Hat|Rocky Linux|Root|RubyGems|SUSE|SwiftURL|TuxCare|Ubuntu|vcpkg|VSCode|Wolfi|GIT)(:.+)?$"
     },
     "prefix": {
       "type": "string",
       "title": "Currently supported home database identifier prefixes",
       "description": "These home databases are also documented at https://ossf.github.io/osv-schema/#id-modified-fields",
-      "pattern": "^(x_|(ASB-A|PUB-A|ALPINE|ALSA|ALBA|ALEA|AZL|BELL|BIT|CGA|CLEANSTART|CLSA|CURL|CVE|DEBIAN|DHI|DRUPAL|DSA|DLA|ELA|DTSA|ECHO|EEF|FreeBSD|GHSA|GO|GSD|HSEC|JLSEC|KUBE|LBSEC|LSN|MAL|MINI|MGASA|OESA|OSEC|OSV|openSUSE-SU|PHSA|PSF|PYSEC|RHBA|RHEA|RHSA|RLSA|RXSA|RSEC|ROOT|RUSTSEC|SUSE-[SRFO]U|UBUNTU|USN|V8|VCPKG)-)"
+      "pattern": "^(x_|(ASB-A|PUB-A|ALPINE|ALSA|ALBA|ALEA|AZL|BELL|BIT|BREW|CGA|CLEANSTART|CLSA|CURL|CVE|DEBIAN|DHI|DRUPAL|DSA|DLA|ELA|DTSA|ECHO|EEF|FreeBSD|GHSA|GO|GSD|HSEC|JLSEC|KUBE|LBSEC|LSN|MAL|MINI|MGASA|OESA|OSEC|OSV|openSUSE-SU|PHSA|PSF|PYSEC|RHBA|RHEA|RHSA|RLSA|RXSA|RSEC|ROOT|RUSTSEC|SUSE-[SRFO]U|UBUNTU|USN|V8|VCPKG)-)"
     },
     "severity": {
       "type": [

--- a/validation/schema.json
+++ b/validation/schema.json
@@ -419,6 +419,7 @@
         "Go",
         "Hackage",
         "Hex",
+        "Homebrew",
         "Julia",
         "Kubernetes",
         "Linux",
@@ -456,13 +457,13 @@
       "type": "string",
       "title": "Currently supported ecosystems",
       "description": "These ecosystems are also documented at https://ossf.github.io/osv-schema/#affectedpackage-field",
-      "pattern": "^(AlmaLinux|Alpaquita|Alpine|Android|Azure Linux|BellSoft Hardened Containers|Bioconductor|Bitnami|Chainguard|CleanStart|ConanCenter|CRAN|crates\\.io|Debian|Docker Hardened Images|Echo|FreeBSD|GHC|GitHub Actions|Go|Hackage|Hex|Julia|Kubernetes|Linux|Mageia|Maven|MinimOS|npm|NuGet|opam|openEuler|openSUSE|OSS-Fuzz|Packagist|Photon OS|Pub|PyPI|Red Hat|Rocky Linux|Root|RubyGems|SUSE|SwiftURL|TuxCare|Ubuntu|vcpkg|VSCode|Wolfi|GIT)(:.+)?$"
+      "pattern": "^(AlmaLinux|Alpaquita|Alpine|Android|Azure Linux|BellSoft Hardened Containers|Bioconductor|Bitnami|Chainguard|CleanStart|ConanCenter|CRAN|crates\\.io|Debian|Docker Hardened Images|Echo|FreeBSD|GHC|GitHub Actions|Go|Hackage|Hex|Homebrew|Julia|Kubernetes|Linux|Mageia|Maven|MinimOS|npm|NuGet|opam|openEuler|openSUSE|OSS-Fuzz|Packagist|Photon OS|Pub|PyPI|Red Hat|Rocky Linux|Root|RubyGems|SUSE|SwiftURL|TuxCare|Ubuntu|vcpkg|VSCode|Wolfi|GIT)(:.+)?$"
     },
     "prefix": {
       "type": "string",
       "title": "Currently supported home database identifier prefixes",
       "description": "These home databases are also documented at https://ossf.github.io/osv-schema/#id-modified-fields",
-      "pattern": "^(x_|(ASB-A|PUB-A|ALPINE|ALSA|ALBA|ALEA|AZL|BELL|BIT|CGA|CLEANSTART|CLSA|CURL|CVE|DEBIAN|DHI|DRUPAL|DSA|DLA|ELA|DTSA|ECHO|EEF|FreeBSD|GHSA|GO|GSD|HSEC|JLSEC|KUBE|LBSEC|LSN|MAL|MINI|MGASA|OESA|OSEC|OSV|openSUSE-SU|PHSA|PSF|PYSEC|RHBA|RHEA|RHSA|RLSA|RXSA|RSEC|ROOT|RUSTSEC|SUSE-[SRFO]U|UBUNTU|USN|V8|VCPKG)-)"
+      "pattern": "^(x_|(ASB-A|PUB-A|ALPINE|ALSA|ALBA|ALEA|AZL|BELL|BIT|BREW|CGA|CLEANSTART|CLSA|CURL|CVE|DEBIAN|DHI|DRUPAL|DSA|DLA|ELA|DTSA|ECHO|EEF|FreeBSD|GHSA|GO|GSD|HSEC|JLSEC|KUBE|LBSEC|LSN|MAL|MINI|MGASA|OESA|OSEC|OSV|openSUSE-SU|PHSA|PSF|PYSEC|RHBA|RHEA|RHSA|RLSA|RXSA|RSEC|ROOT|RUSTSEC|SUSE-[SRFO]U|UBUNTU|USN|V8|VCPKG)-)"
     },
     "severity": {
       "type": [


### PR DESCRIPTION
Adds `Homebrew` as an OSV ecosystem and registers the `BREW` advisory prefix.

The corresponding purl type (`pkg:brew`) is defined in [package-url/purl-spec#796](https://github.com/package-url/purl-spec/pull/796), merged 2026-07-09. This declares the ecosystem in `ecosystems.json` and regenerates the derived files with `scripts/update-ecosystems-lists.py`. The `name` is the formula name from the default `homebrew/core` tap; a version is the formula version with an `_N` revision suffix when nonzero, matching Homebrew's `PkgVersion` and the version component of a `pkg:brew` purl.

Home database URLs are TBD pending publication of the Homebrew advisory database (generated via `brew vulns --osv-export` in [Homebrew/homebrew-brew-vulns](https://github.com/Homebrew/homebrew-brew-vulns)), matching how vcpkg and Azure Linux landed.

Context: [Homebrew/discussions#6869](https://github.com/orgs/Homebrew/discussions/6869).