### PR TITLE
docs: clarify guidance on multiple ecosystems and GIT entries

### DIFF
--- a/docs/schema.md
+++ b/docs/schema.md
@@ -1005,6 +1005,23 @@ It is permitted for a database name (the DB prefix in the `id` field) and an
 ecosystem name to be the same, provided they have the same owner who can make
 decisions about the meaning of the `ecosystem_specific` field (see below).
 
+### Depicting multiple ecosystems in the same record
+
+An OSV record can describe a vulnerability affecting multiple ecosystems. This is done by including multiple objects in the `affected` array, each specifying a different `package.ecosystem`.
+
+#### Separating Git and Strict Ecosystems
+
+When providing vulnerability information for both a strict packaging ecosystem (such as `npm`, `PyPI`, or `Go`) and Git-level details (such as commit hashes), it is recommended to use separate entries in the `affected` array.
+
+- **Strict Ecosystem Entry**: This entry should use the specific ecosystem name (e.g., `"ecosystem": "npm"`). It should list affected versions in the `versions` field or use `ECOSYSTEM` or `SEMVER` range types in the `ranges` field.
+- **Git Entry**: This entry should use **no** `package` field. It should use the `GIT` range type in the `ranges` field to specify affected commit ranges.
+
+This separation ensures that tools relying on strict version parsing for a specific ecosystem do not get confused by Git commit hashes, and vice versa.
+
+#### Version Enumeration for Git Entries
+
+For entries using `GIT` "ecosystem", the `versions` field is typically populated with enumerated versions (tags) derived from the Git repository specified in `ranges[].repo`. OSV infrastructure (such as https://osv.dev) can automatically perform this enumeration during ingestion, populating the `versions` array with relevant tags that fall within the specified commit ranges. If in the same affected field as a strict ecosystem, versions from both the Git repository and the strict ecosystem will appear in the `versions` array.
+
 ### affected[].severity field
 
 The `severity` field is an optional element [defined here](#severity-field).

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -1036,14 +1036,9 @@ The `affected` object's `versions` field is a JSON array of strings. Each string
 is a single affected version in whatever version syntax is used by the given
 package ecosystem.
 
-When there is no well-defined packaging ecosystem specified (for
-example, general C/C++ libraries), GIT commit ranges are typically the best way
-to define vulnerable version ranges. In this case, versions specified in this
-array cannot be relied upon to conform to any particular syntax (e.g. they
-could be the upstream Git version tags derived from these GIT commit ranges,
-which is what [OSV.dev](https://osv.dev/) populates this field with). In this
-situation, the GIT commit ranges in [`affected[].ranges`](#affectedranges-field)
-should be used to match vulnerabilities by Git commit hashes.
+When using the `GIT` pseudo-ecosystem (either because there is no well-defined packaging ecosystem, or to provide supplementary Git-level details), versions specified in this array typically represent Git tags and cannot be relied upon to conform to any particular package manager's syntax. In this situation, the GIT commit ranges in [`affected[].ranges`](#affectedranges-field) should be used to match vulnerabilities by Git commit hashes.
+
+If you are providing both strict ecosystem versions and Git-level details, it is recommended to separate them into different entries. See [Separating Git and Strict Ecosystems](#separating-git-and-strict-ecosystems) for more details.
 
 ### affected[].ranges[] field
 


### PR DESCRIPTION
This PR updates the schema documentation to provide clear guidelines on how to structure `affected` fields when a vulnerability applies to both a strict/"real" ecosystem (like `Go` or `npm`) and generic Git repositories.

- Explains how to depict multiple ecosystems in the same record.
- Recommends using distinct entries in the `affected` array for `GIT` and strict ecosystems to ensure tooling compatibility.
- Clarifies that `GIT` records get their `versions` enumerated from the attached repository tags, and how OSV infrastructure automates this.

Mixing Git commit hashes and semantic versions in the same `affected` entry can cause mixed enumerated versions in the versions array, that can confuse both publishers and consumers. This documentation guides publishers to separate them for better compatibility.
