### PR TITLE
refactor: ecosystem checks based on ecosystems generated in constants

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,7 @@ To add a new ecosystem, follow these steps:
 3.  **`README.md`**: Add the new ecosystem to the list of data exporters in the README.
 
 4.  **Run update script**: Finally, run `python3 ./scripts/update-ecosystems-lists.py`. This script will automatically update the following files based on your changes to `ecosystems.json`:
-    *   `bindings/go/osvschema/constants.go`
+    *   `bindings/go/osvconstants/constants.go`
     *   The main ecosystem table in `docs/schema.md`
     *   The ecosystem enum in `validation/schema.json`
     *   Make a copy of the `validation/schema.json` for the linter in `tools/osv-linter/internal/checks/schema_generated.json`

--- a/tools/osv-linter/internal/checks/checks.go
+++ b/tools/osv-linter/internal/checks/checks.go
@@ -39,7 +39,7 @@ type CheckDef struct {
 
 // Config defines the configuration for a check.
 type Config struct {
-	Verbose    bool
+	Verbose      bool
 	Ecosystems   []string
 	JSON         bool
 	NewEcosystem bool

--- a/tools/osv-linter/internal/checks/packages_test.go
+++ b/tools/osv-linter/internal/checks/packages_test.go
@@ -7,6 +7,11 @@ import (
 	"github.com/tidwall/gjson"
 )
 
+func parseJSON(s string) *gjson.Result {
+	res := gjson.Parse(s)
+	return &res
+}
+
 func TestPackageExists(t *testing.T) {
 	t.Parallel()
 
@@ -34,6 +39,57 @@ func TestPackageExists(t *testing.T) {
 				config: &Config{},
 			},
 			wantFindings: nil,
+		},
+		{
+			name: "Schema ecosystem without registry check (WordPress)",
+			args: args{
+				json: parseJSON(`{
+					"affected": [
+						{
+							"package": {
+								"name": "my-plugin",
+								"ecosystem": "WordPress:Plugin"
+							}
+						}
+					]
+				}`),
+				config: &Config{},
+			},
+			wantFindings: nil,
+		},
+		{
+			name: "Schema ecosystem without registry check (Homebrew)",
+			args: args{
+				json: parseJSON(`{
+					"affected": [
+						{
+							"package": {
+								"name": "openssl@3",
+								"ecosystem": "Homebrew"
+							}
+						}
+					]
+				}`),
+				config: &Config{},
+			},
+			wantFindings: nil,
+		},
+		{
+			name: "Unknown ecosystem produces finding",
+			args: args{
+				json: parseJSON(`{
+					"affected": [
+						{
+							"package": {
+								"name": "my-pkg",
+								"ecosystem": "UnknownEco"
+							}
+						}
+					]
+				}`),
+				config: &Config{},
+			},
+			wantFindings: []CheckError{{Code: "", Message: "package \"my-pkg\" not found in \"UnknownEco\""}},
 		},
 	}
 	for _, tt := range tests {
@@ -79,11 +135,63 @@ func TestPackageVersionsExists(t *testing.T) {
 			},
 			wantFindings: nil,
 		},
+		{
+			name: "Schema ecosystem without registry check (WordPress)",
+			args: args{
+				json: parseJSON(`{
+					"affected": [
+						{
+							"package": {
+								"name": "my-plugin",
+								"ecosystem": "WordPress:Plugin"
+							},
+							"versions": ["1.0.0", "1.1.0"]
+						}
+					]
+				}`),
+				config: &Config{},
+			},
+			wantFindings: nil,
+		},
+		{
+			name: "Schema ecosystem without registry check (Homebrew)",
+			args: args{
+				json: parseJSON(`{
+					"affected": [
+						{
+							"package": {
+								"name": "openssl@3",
+								"ecosystem": "Homebrew"
+							},
+							"versions": ["3.0.0"]
+						}
+					]
+				}`),
+				config: &Config{},
+			},
+			wantFindings: nil,
+		},
+		{
+			name: "Unknown ecosystem produces finding",
+			args: args{
+				json: parseJSON(`{
+					"affected": [
+						{
+							"package": {
+								"name": "my-pkg",
+								"ecosystem": "UnknownEco"
+							},
+							"versions": ["1.0.0"]
+						}
+					]
+				}`),
+				config: &Config{},
+			},
+			wantFindings: []CheckError{{Code: "", Message: "unsupported ecosystem: UnknownEco"}},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
 			if gotFindings := PackageVersionsExist(tt.args.json, tt.args.config); !reflect.DeepEqual(gotFindings, tt.wantFindings) {
 				t.Errorf("PackageVersionsExist() = %v, want %v", gotFindings, tt.wantFindings)
 			}

--- a/tools/osv-linter/internal/checks/schema.go
+++ b/tools/osv-linter/internal/checks/schema.go
@@ -3,8 +3,10 @@ package checks
 import (
 	_ "embed"
 	"fmt"
+	"slices"
 	"strings"
 
+	"github.com/ossf/osv-schema/linter/internal/pkgchecker"
 	"github.com/tidwall/gjson"
 	"github.com/xeipuuv/gojsonschema"
 )
@@ -14,6 +16,30 @@ import (
 
 //go:embed schema_generated.json
 var LoadedSchema []byte
+
+func init() {
+	pkgchecker.IsSchemaEcosystem = IsSchemaEcosystem
+}
+
+// SchemaEcosystems returns the list of all ecosystems defined in the loaded JSON schema.
+func SchemaEcosystems() []string {
+	var ecosystems []string
+	res := gjson.GetBytes(LoadedSchema, "$defs.ecosystemName.enum")
+	if res.Exists() && res.IsArray() {
+		for _, item := range res.Array() {
+			ecosystems = append(ecosystems, item.String())
+		}
+	}
+	return ecosystems
+}
+
+// IsSchemaEcosystem reports whether ecosystem is defined in the loaded schema or is "GIT".
+func IsSchemaEcosystem(ecosystem string) bool {
+	if ecosystem == "GIT" {
+		return true
+	}
+	return slices.Contains(SchemaEcosystems(), ecosystem)
+}
 
 var CheckInvalidSchema = &CheckDef{
 	Code:        "SCH:001",

--- a/tools/osv-linter/internal/checks/schema_test.go
+++ b/tools/osv-linter/internal/checks/schema_test.go
@@ -1,10 +1,13 @@
 package checks_test
 
 import (
+	"encoding/json"
 	"os"
+	"slices"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/ossf/osv-schema/linter/internal/checks"
 )
 
 func TestSchemaHasBeenGenerated(t *testing.T) {
@@ -24,5 +27,29 @@ func TestSchemaHasBeenGenerated(t *testing.T) {
 
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("Schema needs to be regenerated (-want +got):\n%s", diff)
+	}
+}
+
+func TestSchemaEcosystems_MatchesEcosystemsJSON(t *testing.T) {
+	t.Parallel()
+
+	data, err := os.ReadFile("../../../../ecosystems.json")
+	if err != nil {
+		t.Fatalf("failed to read ecosystems.json: %v", err)
+	}
+
+	var ecosystemsMap map[string]string
+	if err := json.Unmarshal(data, &ecosystemsMap); err != nil {
+		t.Fatalf("failed to unmarshal ecosystems.json: %v", err)
+	}
+
+	ecosystems := checks.SchemaEcosystems()
+	for eco := range ecosystemsMap {
+		if !slices.Contains(ecosystems, eco) {
+			t.Errorf("ecosystem %q from ecosystems.json is missing from SchemaEcosystems()", eco)
+		}
+	}
+	if len(ecosystems) != len(ecosystemsMap) {
+		t.Errorf("SchemaEcosystems() length (%d) != ecosystems.json length (%d)", len(ecosystems), len(ecosystemsMap))
 	}
 }

--- a/tools/osv-linter/internal/pkgchecker/ecosystems.go
+++ b/tools/osv-linter/internal/pkgchecker/ecosystems.go
@@ -21,6 +21,10 @@ var SupportedEcosystems = []string{
 	"RubyGems",
 }
 
+// IsSchemaEcosystem reports whether the ecosystem is valid according to the schema.
+// Set by checks package at initialization.
+var IsSchemaEcosystem func(ecosystem string) bool
+
 // EcosystemBaseURLs maps ecosystems to their base API URLs.
 var EcosystemBaseURLs = map[string]string{
 	"CRAN":      "https://crandb.r-pkg.org/",
@@ -41,78 +45,38 @@ var EcosystemBaseURLs = map[string]string{
 // Dispatcher for ecosystem-specific package existence checking.
 func ExistsInEcosystem(pkg string, ecosystem string, suffix string) bool {
 	switch ecosystem {
-	case "AlmaLinux":
-		return true
-	case "Alpine":
-		return true
-	case "Android":
-		return true
-	case "Bitnami":
-		return true
-	case "Chainguard":
-		return true
 	case "CRAN":
 		return existsInCran(pkg)
 	case "crates.io":
 		return existsInCrates(pkg)
-	case "Debian":
-		return true
-	case "Echo":
-		return true
-	case "GIT":
-		return true
-	case "GitHub Actions":
-		return true
 	case "Go":
 		return existsInGo(pkg)
-	case "GSD":
-		return true
 	case "Hackage":
 		return existsInHackage(pkg)
 	case "Hex":
 		return existsInHex(pkg)
 	case "Julia":
 		return existsInJulia(pkg)
-	case "Kubernetes":
-		return true
-	case "Linux":
-		return true
 	case "Maven":
 		return existsInMaven(pkg)
-	case "MinimOS":
-		return true
 	case "npm":
 		return existsInNpm(pkg)
 	case "NuGet":
 		return existsInNuget(pkg)
-	case "openSUSE":
-		return true
-	case "OSS-Fuzz":
-		return true
 	case "Packagist":
 		return existsInPackagist(pkg, suffix)
 	case "Pub":
 		return existsInPub(pkg)
 	case "PyPI":
 		return existsInPyPI(pkg)
-	case "Red Hat":
-		return true
-	case "Rocky Linux":
-		return true
 	case "RubyGems":
 		return existsInRubyGems(pkg)
-	case "SUSE":
-		return true
-	case "SwiftURL":
-		return true
-	case "Ubuntu":
-		return true
-	case "UVI":
-		return true
-	case "Wolfi":
-		return true
+	default:
+		if IsSchemaEcosystem != nil && IsSchemaEcosystem(ecosystem) {
+			return true
+		}
+		return false
 	}
-	return false
 }
 
 // MissingVersionsError describes when specific versions of a package could not be found.
@@ -139,74 +103,34 @@ func (e MissingVersionsError) Error() string {
 // Dispatcher for ecosystem-specific package version existence checking.
 func VersionsExistInEcosystem(pkg string, versions []string, ecosystem string, suffix string) error {
 	switch ecosystem {
-	case "AlmaLinux":
-		return nil
-	case "Alpine":
-		return nil
-	case "Android":
-		return nil
-	case "Bitnami":
-		return nil
-	case "Chainguard":
-		return nil
 	case "CRAN":
 		return versionsExistInCran(pkg, versions)
 	case "crates.io":
 		return versionsExistInCrates(pkg, versions)
-	case "Debian":
-		return nil
-	case "Echo":
-		return nil
-	case "GIT":
-		return nil
-	case "GitHub Actions":
-		return nil
 	case "Go":
 		return versionsExistInGo(pkg, versions)
-	case "GSD":
-		return nil
 	case "Hackage":
 		return versionsExistInHackage(pkg, versions)
-	case "Julia":
-		return versionsExistInJulia(pkg, versions)
 	case "Hex":
 		return versionsExistInHex(pkg, versions)
-	case "Linux":
-		return nil
-	case "Maven":
-		return nil
-	case "MinimOS":
-		return nil
+	case "Julia":
+		return versionsExistInJulia(pkg, versions)
 	case "npm":
 		return versionsExistInNpm(pkg, versions)
 	case "NuGet":
 		return versionsExistInNuGet(pkg, versions)
-	case "openSUSE":
-		return nil
-	case "OSS-Fuzz":
-		return nil
 	case "Packagist":
 		return versionsExistInPackagist(pkg, versions, suffix)
 	case "Pub":
 		return versionsExistInPub(pkg, versions)
 	case "PyPI":
 		return versionsExistInPyPI(pkg, versions)
-	case "Red Hat":
-		return nil
-	case "Rocky Linux":
-		return nil
 	case "RubyGems":
 		return versionsExistInRubyGems(pkg, versions)
-	case "SUSE":
-		return nil
-	case "SwiftURL":
-		return nil
-	case "Ubuntu":
-		return nil
-	case "UVI":
-		return nil
-	case "Wolfi":
-		return nil
+	default:
+		if IsSchemaEcosystem != nil && IsSchemaEcosystem(ecosystem) {
+			return nil
+		}
+		return fmt.Errorf("unsupported ecosystem: %s", ecosystem)
 	}
-	return fmt.Errorf("unsupported ecosystem: %s", ecosystem)
 }

--- a/tools/osv-linter/internal/pkgchecker/ecosystems_test.go
+++ b/tools/osv-linter/internal/pkgchecker/ecosystems_test.go
@@ -1,6 +1,18 @@
 package pkgchecker
 
-import "testing"
+import (
+	"slices"
+	"testing"
+)
+
+func init() {
+	schemaEcos := []string{
+		"AlmaLinux", "Alpine", "Debian", "Homebrew", "Maven", "WordPress", "GIT",
+	}
+	IsSchemaEcosystem = func(ecosystem string) bool {
+		return slices.Contains(schemaEcos, ecosystem)
+	}
+}
 
 func Test_versionsExistInCran(t *testing.T) {
 	t.Parallel()
@@ -913,6 +925,134 @@ func Test_versionsExistInRubyGems(t *testing.T) {
 
 			if err := versionsExistInRubyGems(tt.args.pkg, tt.args.versions); (err != nil) != tt.wantErr {
 				t.Errorf("versionsExistInRubyGems() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestExistsInEcosystem(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		pkg       string
+		ecosystem string
+		suffix    string
+		want      bool
+	}{
+		{
+			name:      "GIT ecosystem always returns true",
+			pkg:       "foo",
+			ecosystem: "GIT",
+			want:      true,
+		},
+		{
+			name:      "WordPress ecosystem without registry check returns true",
+			pkg:       "my-plugin",
+			ecosystem: "WordPress",
+			suffix:    "Plugin",
+			want:      true,
+		},
+		{
+			name:      "Homebrew ecosystem without registry check returns true",
+			pkg:       "openssl@3",
+			ecosystem: "Homebrew",
+			want:      true,
+		},
+		{
+			name:      "Debian ecosystem without registry check returns true",
+			pkg:       "glibc",
+			ecosystem: "Debian",
+			want:      true,
+		},
+		{
+			name:      "AlmaLinux ecosystem without registry check returns true",
+			pkg:       "kernel",
+			ecosystem: "AlmaLinux",
+			want:      true,
+		},
+		{
+			name:      "unknown ecosystem returns false",
+			pkg:       "anything",
+			ecosystem: "UnknownEco",
+			want:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := ExistsInEcosystem(tt.pkg, tt.ecosystem, tt.suffix); got != tt.want {
+				t.Errorf("ExistsInEcosystem(%q, %q, %q) = %v, want %v", tt.pkg, tt.ecosystem, tt.suffix, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestVersionsExistInEcosystem(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		pkg       string
+		versions  []string
+		ecosystem string
+		suffix    string
+		wantErr   bool
+	}{
+		{
+			name:      "GIT ecosystem returns nil",
+			pkg:       "foo",
+			versions:  []string{"abc1234"},
+			ecosystem: "GIT",
+			wantErr:   false,
+		},
+		{
+			name:      "WordPress ecosystem returns nil",
+			pkg:       "my-plugin",
+			versions:  []string{"1.0.0"},
+			ecosystem: "WordPress",
+			suffix:    "Plugin",
+			wantErr:   false,
+		},
+		{
+			name:      "Homebrew ecosystem returns nil",
+			pkg:       "openssl@3",
+			versions:  []string{"3.0.0"},
+			ecosystem: "Homebrew",
+			wantErr:   false,
+		},
+		{
+			name:      "Maven ecosystem returns nil",
+			pkg:       "org.apache:commons",
+			versions:  []string{"1.0.0"},
+			ecosystem: "Maven",
+			wantErr:   false,
+		},
+		{
+			name:      "Debian ecosystem returns nil",
+			pkg:       "glibc",
+			versions:  []string{"2.31"},
+			ecosystem: "Debian",
+			wantErr:   false,
+		},
+		{
+			name:      "unknown ecosystem returns error",
+			pkg:       "anything",
+			versions:  []string{"1.0.0"},
+			ecosystem: "UnknownEco",
+			wantErr:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := VersionsExistInEcosystem(tt.pkg, tt.versions, tt.ecosystem, tt.suffix)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("VersionsExistInEcosystem() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
 	}


### PR DESCRIPTION
Refactors ecosystem validation in osv-linter to dynamically check against the generated schema (`schema_generated.json`) instead of maintaining a hardcoded list of switch cases in `pkgchecker/ecosystems.go`.

